### PR TITLE
 interp: use correct GOPATH from go/build.Default

### DIFF
--- a/interp/src.go
+++ b/interp/src.go
@@ -1,6 +1,7 @@
 package interp
 
 import (
+	"go/build"
 	"io/ioutil"
 	"log"
 	"os"
@@ -53,7 +54,7 @@ func pkgDir(path string) string {
 	if _, err := os.Stat(dir); err == nil {
 		return dir
 	}
-	dir = os.Getenv("HOME") + "/go/src/" + path
+	dir = filepath.Join(build.Default.GOPATH, "src", path)
 	if _, err := os.Stat(dir); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
 This CL uses go/build.Default.GOPATH to infer the correct value for
 $GOPATH at build time.

 Previously, pkgDir would fail if somebody were to build and test
 containous/gi from a different GOPATH location (e.g. GOPATH=/build/go)