### PR TITLE
feat: handle recover builtin

### DIFF
--- a/_test/recover0.go
+++ b/_test/recover0.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+func main() {
+	println("hello")
+	defer func() {
+		r := recover()
+		fmt.Println("recover:", r)
+	}()
+	println("world")
+}
+
+// Output:
+// hello
+// world
+// recover: <nil>

--- a/_test/recover1.go
+++ b/_test/recover1.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+func main() {
+	println("hello")
+	defer func() {
+		r := recover()
+		fmt.Println("recover:", r)
+	}()
+	panic("test panic")
+	println("world")
+}
+
+// Output:
+// hello
+// recover: test panic

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -422,6 +422,8 @@ func (interp *Interpreter) Cfg(root *Node) ([]*Node, error) {
 					}
 					n.child[1].val = n.typ
 					n.child[1].kind = BasicLit
+				case "recover":
+					n.typ = scope.getType("interface{}")
 				}
 			} else if n.child[0].isType(scope) {
 				// Type conversion expression
@@ -1184,6 +1186,15 @@ func genValue(n *Node) func(*Frame) reflect.Value {
 			return func(f *Frame) reflect.Value { return v }
 		}
 		return valueGenerator(n, n.findex)
+	}
+}
+
+func genValueAddr(n *Node) func(*Frame) *reflect.Value {
+	return func(f *Frame) *reflect.Value {
+		for level := n.level; level > 0; level-- {
+			f = f.anc
+		}
+		return &f.data[n.findex]
 	}
 }
 

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3226,6 +3226,56 @@ func main() {
 	// 3
 }
 
+func Example_recover0() {
+	src := `
+package main
+
+import "fmt"
+
+func main() {
+	println("hello")
+	defer func() {
+		r := recover()
+		fmt.Println("recover:", r)
+	}()
+	println("world")
+}
+`
+	i := New(Opt{Entry: "main"})
+	i.Use(stdlib.Value, stdlib.Type)
+	i.Eval(src)
+
+	// Output:
+	// hello
+	// world
+	// recover: <nil>
+}
+
+func Example_recover1() {
+	src := `
+package main
+
+import "fmt"
+
+func main() {
+	println("hello")
+	defer func() {
+		r := recover()
+		fmt.Println("recover:", r)
+	}()
+	panic("test panic")
+	println("world")
+}
+`
+	i := New(Opt{Entry: "main"})
+	i.Use(stdlib.Value, stdlib.Type)
+	i.Eval(src)
+
+	// Output:
+	// hello
+	// recover: test panic
+}
+
 func Example_ret1() {
 	src := `
 package main


### PR DESCRIPTION
The recovered state is stored in `Frame`, and captured in `runCfg()`.
`assign()` has been modified to set handle `interface{}` type (not
possible with `reflect`.

Fix #10