### PR TITLE
feat: better error handling in type parsing

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -209,7 +209,7 @@ func (i *Interpreter) Eval(src string) (reflect.Value, error) {
 			initNodes = append(initNodes, sym.node)
 		}
 	} else {
-		root.types = frameTypes(root, i.fsize+1)
+		root.types, _ = frameTypes(root, i.fsize+1)
 		setExec(root.start)
 	}
 
@@ -219,7 +219,9 @@ func (i *Interpreter) Eval(src string) (reflect.Value, error) {
 
 	// Execute CFG
 	if !i.NoRun {
-		genRun(root)
+		if err = genRun(root); err != nil {
+			return res, err
+		}
 		i.fsize++
 		i.resizeFrame()
 		i.run(root, nil)

--- a/interp/run.go
+++ b/interp/run.go
@@ -664,7 +664,7 @@ func getFunc(n *Node) {
 	i := n.findex
 	next := getExec(n.tnext)
 	if len(n.types) == 0 {
-		n.types = frameTypes(n, n.flen)
+		n.types, _ = frameTypes(n, n.flen)
 	}
 
 	n.exec = func(f *Frame) Builtin {
@@ -982,7 +982,7 @@ func arrayLit(n *Node) {
 	value := valueGenerator(n, n.findex)
 	next := getExec(n.tnext)
 	child := n.child[1:]
-	a := n.typ.zero()
+	a, _ := n.typ.zero()
 	values := make([]func(*Frame) reflect.Value, len(child))
 	for i, c := range child {
 		convertLiteralValue(c, n.typ.val.TypeOf())
@@ -1039,7 +1039,7 @@ func compositeLit(n *Node) {
 	value := valueGenerator(n, n.findex)
 	next := getExec(n.tnext)
 	child := n.child[1:]
-	a := n.typ.zero()
+	a, _ := n.typ.zero()
 	values := make([]func(*Frame) reflect.Value, len(child))
 	for i, c := range child {
 		convertLiteralValue(c, n.typ.field[i].typ.TypeOf())
@@ -1061,7 +1061,7 @@ func compositeSparse(n *Node) {
 	next := getExec(n.tnext)
 	child := n.child[1:]
 	values := make(map[int]func(*Frame) reflect.Value)
-	a := n.typ.zero()
+	a, _ := n.typ.zero()
 	for _, c := range child {
 		convertLiteralValue(c.child[1], n.typ.field[c.findex].typ.TypeOf())
 		values[c.findex] = genValue(c.child[1])

--- a/interp/src.go
+++ b/interp/src.go
@@ -34,13 +34,12 @@ func (i *Interpreter) importSrcFile(path string) error {
 		}
 
 		name = filepath.Join(dir, name)
-		buf, err := ioutil.ReadFile(name)
-		if err != nil {
+		var buf []byte
+		if buf, err = ioutil.ReadFile(name); err != nil {
 			return err
 		}
 
-		_, root, err = i.ast(string(buf), name)
-		if err != nil {
+		if _, root, err = i.ast(string(buf), name); err != nil {
 			return err
 		}
 		rootNodes = append(rootNodes, root)
@@ -56,8 +55,8 @@ func (i *Interpreter) importSrcFile(path string) error {
 
 	// Generate control flow graphs
 	for _, root := range rootNodes {
-		nodes, err := i.Cfg(root)
-		if err != nil {
+		var nodes []*Node
+		if nodes, err = i.Cfg(root); err != nil {
 			return err
 		}
 		initNodes = append(initNodes, nodes...)
@@ -69,7 +68,9 @@ func (i *Interpreter) importSrcFile(path string) error {
 
 	// Once all package sources have been parsed, execute entry points then init functions
 	for _, n := range rootNodes {
-		genRun(n)
+		if err = genRun(n); err != nil {
+			return err
+		}
 		i.fsize++
 		i.resizeFrame()
 		i.run(n, nil)


### PR DESCRIPTION
When parsing types, instead of panic, set proper error and diagnostic
with
source location. Propagate errors correctly.

Fix #17