### PR TITLE
Fix: detect invalid use of builtin during compilation

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -650,7 +650,6 @@ func (interp *Interpreter) Cfg(root *Node) ([]*Node, error) {
 
 		case GoStmt:
 			wireChild(n)
-			// TODO: should error if call expression refers to a builtin
 
 		case Ident:
 			if isKey(n) {
@@ -696,6 +695,10 @@ func (interp *Interpreter) Cfg(root *Node) ([]*Node, error) {
 							n.fsize = n.typ.rtype.NumOut()
 						}
 						n.rval = sym.val.(reflect.Value)
+					case sym.kind == Bltn:
+						if n.anc.kind != CallExpr {
+							err = n.cfgError("use of builtin %s not in function call", n.ident)
+						}
 					}
 				}
 				if n.sym != nil {

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -33,7 +33,6 @@ func TestInterpConsistency(t *testing.T) {
 			file.Name() == "cli1.go" || // FIXME global vars
 			file.Name() == "interface0.go" || // TODO not implemented yet
 			file.Name() == "heap.go" || // TODO not implemented yet
-			file.Name() == "bltn.go" || // TODO not implemented yet
 			file.Name() == "chan6.go" || // FIXME related to channel #7
 			file.Name() == "select1.go" || // FIXME related to channel #7
 			file.Name() == "ret1.go" || // TODO not implemented yet #22


### PR DESCRIPTION
Fix #49