### PR TITLE
fix: improve use of explicit nil

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -163,7 +163,7 @@ func initUniverse() *Scope {
 		"iota":  &Symbol{kind: Const, typ: &Type{cat: IntT}},
 
 		// predefined Go zero value
-		"nil": &Symbol{typ: &Type{cat: UnsetT}},
+		"nil": &Symbol{typ: &Type{cat: NilT}},
 
 		// predefined Go builtins
 		"append":  &Symbol{kind: Bltn, builtin: _append},

--- a/interp/run.go
+++ b/interp/run.go
@@ -1116,8 +1116,8 @@ func _case(n *Node) {
 				typ := types[0]
 				n.exec = func(f *Frame) Builtin {
 					if v := value(f); !v.IsValid() {
-						// match zero value against interface{}
-						if typ.cat == UnsetT {
+						// match zero value against nil
+						if typ.cat == NilT {
 							return tnext
 						}
 						return fnext

--- a/interp/type.go
+++ b/interp/type.go
@@ -10,7 +10,7 @@ type Cat uint
 
 // Types for go language
 const (
-	UnsetT Cat = iota
+	NilT Cat = iota
 	AliasT
 	ArrayT
 	BinT
@@ -48,7 +48,7 @@ const (
 )
 
 var cats = [...]string{
-	UnsetT:      "UnsetT",
+	NilT:        "NilT",
 	AliasT:      "AliasT",
 	ArrayT:      "ArrayT",
 	BinT:        "BinT",
@@ -346,7 +346,7 @@ func init() {
 	zeroValues[ByteT] = reflect.ValueOf(byte(0))
 	zeroValues[Complex64T] = reflect.ValueOf(complex64(0))
 	zeroValues[Complex128T] = reflect.ValueOf(complex128(0))
-	zeroValues[ErrorT] = reflect.ValueOf(error(nil))
+	zeroValues[ErrorT] = reflect.ValueOf(new(error)).Elem()
 	zeroValues[Float32T] = reflect.ValueOf(float32(0))
 	zeroValues[Float64T] = reflect.ValueOf(float64(0))
 	zeroValues[IntT] = reflect.ValueOf(int(0))
@@ -509,8 +509,7 @@ func (t *Type) TypeOf() reflect.Type {
 		return reflect.ChanOf(reflect.BothDir, t.val.TypeOf())
 
 	case ErrorT:
-		var e = new(error)
-		return reflect.TypeOf(e).Elem()
+		return reflect.TypeOf(new(error)).Elem()
 
 	case FuncT:
 		in := make([]reflect.Type, len(t.arg))


### PR DESCRIPTION
Type category `UnsetT` is renamed in `NilT`.
Catch invalid use of untyped nil in `:=` expression.
Convert nil to output parameter type when used in `return` expression.
Fix representation of zero value of `error`.
Improve and add relevant unit tests.

Fix #81