### PR TITLE
fix: correct handling of struct init from sparse composite

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -556,17 +556,10 @@ func (interp *Interpreter) Cfg(root *Node) ([]*Node, error) {
 			case MapT:
 				n.gen = mapLit
 			case StructT:
-				n.action, n.gen = CompositeLit, compositeLit
-				child := n.child
-				if child[0].isType(scope) {
-					child = n.child[1:]
-				}
-				// Handle object assign from sparse key / values
-				if len(child) > 0 && child[0].kind == KeyValueExpr {
+				if n.lastChild().kind == KeyValueExpr {
 					n.gen = compositeSparse
-					for _, c := range child {
-						c.findex = n.typ.fieldIndex(c.child[0].ident)
-					}
+				} else {
+					n.gen = compositeLit
 				}
 			}
 
@@ -1111,10 +1104,10 @@ func (n *Node) cfgError(format string, a ...interface{}) CfgError {
 	return CfgError(fmt.Errorf("%s: "+format, a...))
 }
 
-func genRun(n *Node) error {
+func genRun(node *Node) error {
 	var err CfgError
 
-	n.Walk(func(n *Node) bool {
+	node.Walk(func(n *Node) bool {
 		if err != nil {
 			return false
 		}

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -98,6 +98,26 @@ func TestEvalNil2(t *testing.T) {
 	}
 }
 
+func TestEvalComposite0(t *testing.T) {
+	i := interp.New(interp.Opt{})
+	evalCheck(t, i, `
+type T struct {
+	a, b, c, d, e, f, g, h, i, j, k, l, m, n string
+	o map[string]int
+	p []string
+}
+
+var a = T{
+	o: map[string]int{"truc": 1, "machin": 2},
+	p: []string{"hello", "world"},
+}
+`)
+	v := evalCheck(t, i, `a.p[1]`)
+	if v.Interface().(string) != "world" {
+		t.Fatalf("expected world, got %v", v)
+	}
+}
+
 func evalCheck(t *testing.T, i *interp.Interpreter, src string) reflect.Value {
 	res, err := i.Eval(src)
 	if err != nil {

--- a/interp/run.go
+++ b/interp/run.go
@@ -1017,8 +1017,9 @@ func compositeSparse(n *Node) {
 	values := make(map[int]func(*Frame) reflect.Value)
 	a, _ := n.typ.zero()
 	for _, c := range child {
-		convertLiteralValue(c.child[1], n.typ.field[c.findex].typ.TypeOf())
-		values[c.findex] = genValue(c.child[1])
+		field := n.typ.fieldIndex(c.child[0].ident)
+		convertLiteralValue(c.child[1], n.typ.field[field].typ.TypeOf())
+		values[field] = genValue(c.child[1])
 	}
 
 	n.exec = func(f *Frame) Builtin {


### PR DESCRIPTION
The field index computed from the key value expression in sparse
composite literal was stored in `node.findex`, corrupting the memory
allocation. It is now stored in a local variable for immediate use.

fix #97