### PR TITLE
test: refactor eval tests

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -170,7 +170,7 @@ func f() string {
 
 	v := eval(t, i, `f()`)
 	if v.Interface().(string) != "test" {
-		t.Fatalf("expected test, got %v", v)
+		t.Fatalf("got %v, want test", v)
 	}
 }
 
@@ -190,7 +190,7 @@ var a = T{
 `)
 	v := eval(t, i, `a.p[1]`)
 	if v.Interface().(string) != "world" {
-		t.Fatalf("expected world, got %v", v)
+		t.Fatalf("got %v, want word", v)
 	}
 }
 
@@ -211,7 +211,7 @@ func Foo() {
 	http.DefaultClient = &http.Client{}
 	eval(t, i, `Foo()`)
 	if http.DefaultClient.Timeout != 2*time.Second {
-		t.Fatalf("expected 2s, got %v", http.DefaultClient.Timeout)
+		t.Fatalf("got %v, want 2s", http.DefaultClient.Timeout)
 	}
 }
 

--- a/interp/interp_export_test.go
+++ b/interp/interp_export_test.go
@@ -35,7 +35,7 @@ func Hi(h Helloer) {
 // the interfaces and methods  definitions)
 //
 type Wrap struct {
-	DoHello func() // implements Hello()
+	DoHello func() // related to the Hello() method.
 	// Other interface method wrappers...
 }
 
@@ -43,7 +43,7 @@ func (w Wrap) Hello() { w.DoHello() }
 
 func TestInterface(t *testing.T) {
 	i := interp.New(interp.Opt{})
-	// export the Wrap type to the interpeter under virtual "wrap" package
+	// export the Wrap type to the interpreter under virtual "wrap" package
 	i.Use(nil, interp.LibTypeMap{
 		"wrap": {
 			"Wrap": reflect.TypeOf((*Wrap)(nil)).Elem(),


### PR DESCRIPTION
`evalCheck` is renamed in `eva`l.

Add `testCase` struct to describe test cases. A `pre` function can be invoked prior to run the eval script which generate the result.

A `runTests` function executes all tests in a `testCase` array.  Parallel sub-tests execution  is disabled, as simultaneous compile operations in the same interpreter context is not yet safe.

Many simple tests can now be described in one-liners.
