### PR TITLE
fix: handle method on interface type objects

### DIFF
--- a/interp/ast.go
+++ b/interp/ast.go
@@ -209,6 +209,7 @@ const (
 	Lor
 	Lower
 	LowerEqual
+	Method
 	Mul
 	MulAssign
 	Negate
@@ -263,6 +264,7 @@ var actions = [...]string{
 	Land:         "&&",
 	Lor:          "||",
 	Lower:        "<",
+	Method:       "Method",
 	Mul:          "*",
 	MulAssign:    "*=",
 	Negate:       "-",

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -956,7 +956,9 @@ func (interp *Interpreter) Cfg(root *Node) ([]*Node, error) {
 				n.val = ti
 				switch n.typ.cat {
 				case InterfaceT:
+					n.typ = n.typ.fieldSeq(ti)
 					n.gen = getMethodByName
+					n.action = Method
 				case PtrT:
 					n.typ = n.typ.fieldSeq(ti)
 					n.gen = getPtrIndexSeq

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -250,6 +250,38 @@ func TestEvalUnary(t *testing.T) {
 	})
 }
 
+func TestEvalMethod(t *testing.T) {
+	i := interp.New(interp.Opt{})
+	eval(t, i, `
+		type Root struct {
+			Name string
+		}
+
+		type One struct {
+			Root
+		}
+
+		type Hi interface {
+			Hello() string
+		}
+
+		func (r *Root) Hello() string { return "Hello " + r.Name }
+
+		var r = Root{"R"}
+		var o = One{r}
+		var root interface{} = &Root{Name: "test1"}
+		var one interface{} = &One{Root{Name: "test2"}}
+	`)
+	runTests(t, i, []testCase{
+		{src: "r.Hello()", res: "Hello R"},
+		{src: "(&r).Hello()", res: "Hello R"},
+		{src: "o.Hello()", res: "Hello R"},
+		{src: "(&o).Hello()", res: "Hello R"},
+		{src: "root.(Hi).Hello()", res: "Hello test1"},
+		{src: "one.(Hi).Hello()", res: "Hello test2"},
+	})
+}
+
 func runTests(t *testing.T, i *interp.Interpreter, tests []testCase) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
Define a new Method action to detect method calls on interface
types. In this case the receiver is resolved from a dynamic
type rather than a static one.

Handle method calls where receiver is a pointer.

In typeAssert, always return an interface value with the concrete
type, to fix method lookup on interface objects.

Add relevant tests.

Fix #92