### PR TITLE
fix: no collision when importing multiple packages with same name

### DIFF
--- a/_test/import3.go
+++ b/_test/import3.go
@@ -2,5 +2,7 @@ package main
 
 import "./foo"
 
-//func main() { println(foo.Bar, foo.Boo) }
 func main() { println(foo.Bar, foo.Boo) }
+
+// Output:
+// BARR Boo

--- a/_test/import4.go
+++ b/_test/import4.go
@@ -1,0 +1,8 @@
+package main
+
+import "./p1"
+
+func main() { println("num:", p1.Uint32()) }
+
+// Output:
+// num: 2596996162

--- a/_test/p1/s1.go
+++ b/_test/p1/s1.go
@@ -1,0 +1,5 @@
+package p1
+
+import "crypto/rand"
+
+var Prime = rand.Prime

--- a/_test/p1/s2.go
+++ b/_test/p1/s2.go
@@ -1,0 +1,7 @@
+package p1
+
+import "math/rand"
+
+var Uint32 = rand.Uint32
+
+func init() { rand.Seed(1) }

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -171,6 +171,7 @@ func TestInterpErrorConsistency(t *testing.T) {
 			}
 
 			i := interp.New()
+			i.Name = filePath
 			i.Use(stdlib.Value)
 
 			_, errEval := i.Eval(string(src))
@@ -178,7 +179,7 @@ func TestInterpErrorConsistency(t *testing.T) {
 				t.Fatal("An error is expected but got none.")
 			}
 
-			if errEval.Error() != test.expectedInterp {
+			if !strings.Contains(errEval.Error(), test.expectedInterp) {
 				t.Errorf("got %q, want: %q", errEval.Error(), test.expectedInterp)
 			}
 

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -387,7 +388,7 @@ func assertEval(t *testing.T, i *interp.Interpreter, src, expectedError, expecte
 	res, err := i.Eval(src)
 
 	if expectedError != "" {
-		if err == nil || err.Error() != expectedError {
+		if err == nil || !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("got %v, want %s", err, expectedError)
 		}
 		return

--- a/interp/interp_file_test.go
+++ b/interp/interp_file_test.go
@@ -52,6 +52,7 @@ func runCheck(t *testing.T, p string) {
 	os.Stdout = w
 
 	i := interp.New()
+	i.Name = p
 	i.Use(interp.ExportValue)
 	i.Use(stdlib.Value)
 
@@ -60,7 +61,7 @@ func runCheck(t *testing.T, p string) {
 		if err == nil {
 			t.Fatalf("got nil error, want: %q", wanted)
 		}
-		if res := strings.TrimSpace(err.Error()); res != wanted {
+		if res := strings.TrimSpace(err.Error()); !strings.Contains(res, wanted) {
 			t.Errorf("got %q, want: %q", res, wanted)
 		}
 		return


### PR DESCRIPTION
Recompute import package names in each source file, to allow imported
package names to be scoped per file.

Also, in tests, set the input file name if present.

fix #150