### PR TITLE
fix: correct assign from function call

### DIFF
--- a/_test/file_access.go
+++ b/_test/file_access.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+func main() {
+	file, err := ioutil.TempFile("", "yeagibench")
+	if err != nil {
+		panic(err)
+	}
+
+	n, err := file.Write([]byte("hello world"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("n:", n)
+
+	err = file.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	b, err := ioutil.ReadFile(file.Name())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("b:", string(b))
+
+	err = os.Remove(file.Name())
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Output:
+// n: 11
+// b: hello world

--- a/_test/ret6.go
+++ b/_test/ret6.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+type Foo struct{}
+
+func foo() *Foo { return nil }
+
+func main() {
+	f := foo()
+	fmt.Println(f)
+}
+
+// Output:
+// <nil>

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -142,7 +142,7 @@ func TestEvalNil(t *testing.T) {
 				`)
 			},
 			src: "Hello()",
-			res: "<invalid reflect.Value>",
+			res: "<nil>",
 		},
 	})
 }

--- a/interp/type.go
+++ b/interp/type.go
@@ -423,7 +423,7 @@ func (t *Type) zero() (v reflect.Value, err error) {
 	case AliasT:
 		v, err = t.val.zero()
 
-	case ArrayT, StructT:
+	case ArrayT, PtrT, StructT:
 		v = reflect.New(t.TypeOf()).Elem()
 
 	case ValueT:


### PR DESCRIPTION
The following changes should fix real and potential  problems
regarding how variables are set from function return values.

In assign from call expressions, Values in caller frame are now
directly assigned from function calls (call(), binCall() or builtins).
The assignement is performed with reflect Set methods or variants,
instead of "=" operator, to enforce runtime type checks.
No assignment is performed if target variable is "_".

The assignX() and assignX2() builtins are now removed in favor of
above method.

The representation of nil for pointer on struct has been fixed.

The identification of channel is fixed in for-range channel expression.

Improve relevant unit tests.

Fix #153