### PR TITLE
fix: handle forward type declarations, preserving early methods

### DIFF
--- a/_test/type12.go
+++ b/_test/type12.go
@@ -1,18 +1,27 @@
 package main
 
-import "fmt"
-
-type Hello struct {
-	Goodbye GoodbyeProvider
+type T1 struct {
+	T2 *T2
 }
+
+func (t *T1) Get() string {
+	return t.T2.V().Name
+}
+
+type T2 struct {
+	Name string
+}
+
+func (t *T2) V() *T2 {
+	if t == nil {
+		return defaultT2
+	}
+	return t
+}
+
+var defaultT2 = &T2{"no name"}
 
 func main() {
-	a := &Hello{}
-
-	fmt.Println(a)
+	t := &T1{}
+	println(t.Get())
 }
-
-type GoodbyeProvider func(message string) string
-
-// Output:
-// &{<nil>}


### PR DESCRIPTION
Also removed duplicate type12 with type9, and check now for early
methods.

Fix #189