### PR TITLE
fix: index expression on binary map

### DIFF
--- a/_test/map17.go
+++ b/_test/map17.go
@@ -1,0 +1,20 @@
+package main
+
+import "net/http"
+
+type T struct {
+	header string
+}
+
+func (b *T) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if b.header != "" {
+		req.Header[b.header] = []string{"hello"}
+	}
+}
+
+func main() {
+	println("ok")
+}
+
+// Output:
+// ok

--- a/interp/run.go
+++ b/interp/run.go
@@ -917,7 +917,7 @@ func getIndexArray(n *Node) {
 func getIndexMap(n *Node) {
 	value0 := genValue(n.child[0]) // map
 	tnext := getExec(n.tnext)
-	z := reflect.New(n.child[0].typ.val.TypeOf()).Elem()
+	z := reflect.New(n.child[0].typ.TypeOf().Elem()).Elem()
 
 	if n.child[1].rval.IsValid() { // constant map index
 		mi := n.child[1].rval


### PR DESCRIPTION
Compute element type from expression compatible with binary map.

Fix #222