### PR TITLE
Fix: handle recursive type definition

### DIFF
--- a/_test/struct22.go
+++ b/_test/struct22.go
@@ -1,0 +1,15 @@
+package main
+
+type S struct {
+	Child *S
+	Name  string
+}
+
+func main() {
+	s := &S{Name: "root"}
+	s.Child = &S{Name: "child"}
+	println(s.Child.Name)
+}
+
+// Output:
+// child

--- a/_test/struct23.go
+++ b/_test/struct23.go
@@ -1,0 +1,15 @@
+package main
+
+type S struct {
+	Child []*S
+	Name  string
+}
+
+func main() {
+	s := &S{Name: "root"}
+	s.Child = append(s.Child, &S{Name: "child"})
+	println(s.Child[0].Name)
+}
+
+// Output:
+// child

--- a/interp/example_eval_test.go
+++ b/interp/example_eval_test.go
@@ -1,0 +1,38 @@
+package interp_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/containous/yaegi/interp"
+)
+
+// Generic example
+func Example_eval() {
+	// Create a new interpreter context
+	i := interp.New(interp.Options{})
+
+	// Run some code: define a new function
+	_, err := i.Eval("func f(i int) int { return 2 * i }")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Access the interpreted f function with Eval
+	v, err := i.Eval("f")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Returned v is a reflect.Value, so we can use its interface
+	f, ok := v.Interface().(func(int) int)
+	if !ok {
+		log.Fatal("type assertion failed")
+	}
+
+	// Use interpreted f as it was pre-compiled
+	fmt.Println(f(2))
+
+	// Output:
+	// 4
+}

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -44,16 +44,17 @@ func (k sKind) String() string {
 // A symbol represents an interpreter object such as type, constant, var, func,
 // label, builtin or binary object. Symbols are defined within a scope.
 type symbol struct {
-	kind    sKind
-	typ     *itype        // Type of value
-	node    *node         // Node value if index is negative
-	from    []*node       // list of nodes jumping to node if kind is label, or nil
-	recv    *receiver     // receiver node value, if sym refers to a method
-	index   int           // index of value in frame or -1
-	rval    reflect.Value // default value (used for constants)
-	path    string        // package path if typ.cat is SrcPkgT or BinPkgT
-	builtin bltnGenerator // Builtin function or nil
-	global  bool          // true if symbol is defined in global space
+	kind      sKind
+	typ       *itype        // Type of value
+	node      *node         // Node value if index is negative
+	from      []*node       // list of nodes jumping to node if kind is label, or nil
+	recv      *receiver     // receiver node value, if sym refers to a method
+	index     int           // index of value in frame or -1
+	rval      reflect.Value // default value (used for constants)
+	path      string        // package path if typ.cat is SrcPkgT or BinPkgT
+	builtin   bltnGenerator // Builtin function or nil
+	global    bool          // true if symbol is defined in global space
+	recursive bool          // true if symbol is a recursive type definition
 	// TODO: implement constant checking
 	//constant bool             // true if symbol value is constant
 }

--- a/interp/value.go
+++ b/interp/value.go
@@ -107,6 +107,17 @@ func genValue(n *node) func(*frame) reflect.Value {
 	}
 }
 
+func genValueInterfacePtr(n *node) func(*frame) reflect.Value {
+	value := genValue(n)
+	it := reflect.TypeOf((*interface{})(nil)).Elem()
+
+	return func(f *frame) reflect.Value {
+		v := reflect.New(it).Elem()
+		v.Set(value(f))
+		return v.Addr()
+	}
+}
+
 func genValueInterface(n *node) func(*frame) reflect.Value {
 	value := genValue(n)
 


### PR DESCRIPTION
It is not possible to use reflect.StructOf to generate a recursive
struct, where a field type is the same as the struct. In this case
we define the field type as an interface{}, and detect / replace
related assignement and access functions.

Fix #238