### PR TITLE
feature: set default GOPATH for command line and allow self interpreting

### DIFF
--- a/cmd/yaegi/yaegi.go
+++ b/cmd/yaegi/yaegi.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"go/build"
 	"io/ioutil"
 	"log"
 	"os"
@@ -24,13 +25,15 @@ func main() {
 	args := flag.Args()
 	log.SetFlags(log.Lshortfile)
 
-	i := interp.New(interp.Options{})
+	i := interp.New(interp.Options{GoPath: build.Default.GOPATH})
 	i.Use(stdlib.Symbols)
 	i.Use(interp.Symbols)
 
 	if len(args) > 0 {
 		// Skip first os arg to set command line as expected by interpreted main
 		os.Args = os.Args[1:]
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 		b, err := ioutil.ReadFile(args[0])
 		if err != nil {
 			log.Fatal("Could not read file: ", args[0])

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -5,6 +5,12 @@ import "reflect"
 // Symbols variable stores the map of stdlib symbols per package
 var Symbols = map[string]map[string]reflect.Value{}
 
+func init() {
+	Symbols["github.com/containous/yaegi/stdlib"] = map[string]reflect.Value{
+		"Symbols": reflect.ValueOf(Symbols),
+	}
+}
+
 // Provide access to go standard library (http://golang.org/pkg/)
 
 //go:generate ../cmd/goexports/goexports archive/tar archive/zip

--- a/stdlib/syscall/syscall.go
+++ b/stdlib/syscall/syscall.go
@@ -5,4 +5,10 @@ import "reflect"
 // Symbols stores the map of syscall package symbols
 var Symbols = map[string]map[string]reflect.Value{}
 
+func init() {
+	Symbols["github.com/containous/yaegi/stdlib/syscall"] = map[string]reflect.Value{
+		"Symbols": reflect.ValueOf(Symbols),
+	}
+}
+
 //go:generate ../../cmd/goexports/goexports syscall

--- a/stdlib/unsafe/unsafe.go
+++ b/stdlib/unsafe/unsafe.go
@@ -5,4 +5,10 @@ import "reflect"
 // Symbols stores the map of unsafe package symbols
 var Symbols = map[string]map[string]reflect.Value{}
 
+func init() {
+	Symbols["github.com/containous/yaegi/stdlib/unsafe"] = map[string]reflect.Value{
+		"Symbols": reflect.ValueOf(Symbols),
+	}
+}
+
 //go:generate ../../cmd/goexports/goexports unsafe


### PR DESCRIPTION
To be on par with `go run`, the default GOPATH is applied to yaegi
command line (note that interp default behaviour is unchanged).

Flag state is explicitely initialized prior to start the REPL, to
allow recursion.

Make sure that stdlib symbols define themselves to allow recursion.

It is now possible to perform the following:

```console
$ go build cmd/yaegi/yaegi.go
$ ./yaegi cmd/yaegi/yaegi.go cmd/yaegi/yaegi.go cmd/yaegi/yaegi.go
>
```