### PR TITLE
fix: correct access to parameter type for variadic binary methods

### DIFF
--- a/_test/m2/m2_test.go
+++ b/_test/m2/m2_test.go
@@ -1,0 +1,7 @@
+package m2
+
+import "testing"
+
+func TestM2(t *testing.T) {
+	t.Errorf("got %s, want %s", "AAA", "BBB")
+}

--- a/_test/variadic10.go
+++ b/_test/variadic10.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+func main() {
+	logger := log.New(os.Stdout, "test ", log.Lmsgprefix)
+	logger.Printf("args: %v %v", 1, "truc")
+}
+
+// Output:
+// test args: 1 truc

--- a/_test/variadic10.go
+++ b/_test/variadic10.go
@@ -8,7 +8,9 @@ import (
 func main() {
 	logger := log.New(os.Stdout, "test ", log.Lmsgprefix)
 	logger.Printf("args: %v %v", 1, "truc")
+	logger.Printf("args: %v %v %v", 1, "truc", 2)
 }
 
 // Output:
 // test args: 1 truc
+// test args: 1 truc 2

--- a/interp/run.go
+++ b/interp/run.go
@@ -1069,8 +1069,7 @@ func callBin(n *node) {
 	// A method signature obtained from reflect.Type includes receiver as 1st arg, except for interface types.
 	rcvrOffset := 0
 	if recv := n.child[0].recv; recv != nil && !isInterface(recv.node.typ) {
-		numIn, numChild := funcType.NumIn(), len(child)
-		if variadic > 0 && numIn > variadic || numIn > numChild {
+		if variadic > 0 || funcType.NumIn() > len(child) {
 			rcvrOffset = 1
 		}
 	}

--- a/interp/run.go
+++ b/interp/run.go
@@ -1070,7 +1070,7 @@ func callBin(n *node) {
 	rcvrOffset := 0
 	if recv := n.child[0].recv; recv != nil && !isInterface(recv.node.typ) {
 		numIn, numChild := funcType.NumIn(), len(child)
-		if variadic > 0 && numIn >= numChild || numIn > numChild {
+		if variadic > 0 && numIn > variadic || numIn > numChild {
 			rcvrOffset = 1
 		}
 	}


### PR DESCRIPTION
The computation of receiver offset for variadic methods was incorrect.
The logic to apply or not the receiver offset for variadic was incorrect
too. Receiver offset must not be added for variadic arguments beyond
the minimum number of arguments.

Fixes #858