### PR TITLE
interp: refactor doComposite cases

### DIFF
--- a/_test/composite12.go
+++ b/_test/composite12.go
@@ -1,0 +1,19 @@
+package main
+
+type A struct {
+	C D
+}
+
+type D struct {
+	E string
+}
+
+func main() {
+	a := A{}
+	a.C = D{"bb"}
+
+	println(a.C.E)
+}
+
+// Output:
+// bb

--- a/_test/composite13.go
+++ b/_test/composite13.go
@@ -1,0 +1,19 @@
+package main
+
+type A struct {
+	C D
+}
+
+type D struct {
+	E string
+}
+
+func main() {
+	a := A{}
+	a.C = D{E: "bb"}
+
+	println(a.C.E)
+}
+
+// Output:
+// bb

--- a/_test/composite8bis.go
+++ b/_test/composite8bis.go
@@ -1,0 +1,16 @@
+package main
+
+type T struct{ I int }
+
+func main() {
+	t := []*T{}
+	s := []int{1, 2}
+	for _, e := range s {
+		x := &T{I: e}
+		t = append(t, x)
+	}
+	println(t[0].I, t[1].I)
+}
+
+// Output:
+// 1 2

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -543,6 +543,12 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 						// which require and additional operation to set the value
 						break
 					}
+					if dest.action == aGetIndex {
+						// optimization does not work when assigning to a struct field. Maybe we're not
+						// setting the right frame index or something, and we would end up not writing at
+						// the right place. So disabling it for now.
+						break
+					}
 					// Skip the assign operation entirely, the source frame index is set
 					// to destination index, avoiding extra memory alloc and duplication.
 					n.gen = nop
@@ -2368,9 +2374,9 @@ func compositeGenerator(n *node, typ *itype) (gen bltnGenerator) {
 			gen = compositeLitNotype
 		case n.lastChild().kind == keyValueExpr:
 			if n.nleft == 1 {
-				gen = compositeSparse
+				gen = compositeLitKeyed
 			} else {
-				gen = compositeSparseNotype
+				gen = compositeLitKeyedNotype
 			}
 		default:
 			if n.nleft == 1 {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -60,7 +60,7 @@ type receiver struct {
 
 // frame contains values for the current execution level (a function context).
 type frame struct {
-	// id is an atomic counter used for cancellation, only access
+	// id is an atomic counter used for cancellation, only accessed
 	// via newFrame/runid/setrunid/clone.
 	// Located at start of struct to ensure proper aligment.
 	id uint64


### PR DESCRIPTION
Also, there is an optimisation that used to take place when the RHS of
an assignment is a struct literal. That optimisation avoids some
allocation by "instructing" that whatever we want to write for the frame
of the RHS gets directly written to the frame of the LHS.
But it just so happens that we're doing this incorrectly when the LHS is
a struct field (or probably for any other kind of getIndex AST
action). Therefore this PR also disables the optimisation when the LHS
is a getIndex.

Fixes #851
Fixes #854
