### PR TITLE
fix: yaegi os.Args should contain the script name

### DIFF
--- a/cmd/yaegi/run.go
+++ b/cmd/yaegi/run.go
@@ -70,7 +70,7 @@ func run(arg []string) error {
 
 	// Skip first os arg to set command line as expected by interpreted main
 	path := args[0]
-	os.Args = arg[1:]
+	os.Args = arg
 	flag.CommandLine = flag.NewFlagSet(path, flag.ExitOnError)
 
 	if isFile(path) {


### PR DESCRIPTION
`flag.Parse()` fails with a panic when run using `yaegi run` as there are an unexpected number of args. It expects the first arg to be the application name. In the case of yaegi it makes sense that this is the script name. 

Fixes #868