### PR TITLE
fix: concurrent eval test

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -956,6 +956,9 @@ func TestConcurrentEvals(t *testing.T) {
 				hello1 = true
 			case "hello world2":
 				hello2 = true
+			case "hello world1hello world2", "hello world2hello world1":
+				hello1 = true
+				hello2 = true
 			default:
 				c <- fmt.Errorf("unexpected output: %v", l)
 				return


### PR DESCRIPTION
When testing concurrent eval, more valid output combinations
are possible, specially intermixed lines.

This would fix wrong CI builds such as
https://travis-ci.com/github/traefik/yaegi/jobs/391714212