### PR TITLE
fix: replace playground link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ func main() {
 }
 ```
 
-[Go Playground](https://play.golang.org/p/zzvw4VlerLP)
+[Go Playground](https://play.golang.org/p/2n-EpZbMYI9)
 
 ### As a dynamic extension framework
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ func main() {
 }
 ```
 
-[Go Playground](https://play.golang.org/p/6SEAoaO7n0U)
+[Go Playground](https://play.golang.org/p/WvwH4JqrU-p)
 
 ### As a command-line interpreter
 


### PR DESCRIPTION
### Context

Replacing playground link in doc, the previous code imported containous instead of traefik.

### ToDo

- [x] Create new playground code with the right `import`.