### PR TITLE
interp: apply integer division when appropriate

### DIFF
--- a/_test/const17.go
+++ b/_test/const17.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+var t [7/3]int
+
+func main() {
+	t[0] = 3/2
+	t[1] = 5/2
+	fmt.Println(t)
+}
+
+// Output:
+// [1 2]

--- a/cmd/yaegi/yaegi.go
+++ b/cmd/yaegi/yaegi.go
@@ -72,6 +72,9 @@ Options:
 	  include unsafe symbols.
 
 Debugging support (may be removed at any time):
+  YAEGI_PROMPT=1
+    Force enable the printing of the REPL prompt and the result of last instruction,
+    even if stdin is not a terminal.
   YAEGI_AST_DOT=1
     Generate and display graphviz dot of AST with dotty(1)
   YAEGI_CFG_DOT=1

--- a/internal/cmd/genop/genop.go
+++ b/internal/cmd/genop/genop.go
@@ -197,8 +197,10 @@ func {{$name}}Const(n *node) {
 		v := constant.Shift(vConstantValue(v0), token.{{tokenFromName $name}}, uint(vUint(v1)))
 		n.rval.Set(reflect.ValueOf(v))
 		{{- else if (eq $op.Name "/")}}
-		// TODO(mpl): exclude uints?
 		var operator token.Token
+		// When the result of the operation is expected to be an int (because both
+		// operands are ints), we want to force the type of the whole expression to be an
+		// int (and not a float), which is achieved by using the QUO_ASSIGN operator.
 		if n.typ.untyped && isInt(n.typ.rtype) {
 			operator = token.QUO_ASSIGN
 		} else {

--- a/internal/cmd/genop/genop.go
+++ b/internal/cmd/genop/genop.go
@@ -196,6 +196,16 @@ func {{$name}}Const(n *node) {
 		{{- if $op.Shift}}
 		v := constant.Shift(vConstantValue(v0), token.{{tokenFromName $name}}, uint(vUint(v1)))
 		n.rval.Set(reflect.ValueOf(v))
+		{{- else if (eq $op.Name "/")}}
+		// TODO(mpl): exclude uints?
+		var operator token.Token
+		if n.typ.untyped && isInt(n.typ.rtype) {
+			operator = token.QUO_ASSIGN
+		} else {
+			operator = token.QUO
+		}
+		v := constant.BinaryOp(vConstantValue(v0), operator, vConstantValue(v1))
+		n.rval.Set(reflect.ValueOf(v))
 		{{- else}}
 		v := constant.BinaryOp(vConstantValue(v0), token.{{tokenFromName $name}}, vConstantValue(v1))
 		n.rval.Set(reflect.ValueOf(v))

--- a/interp/op.go
+++ b/interp/op.go
@@ -701,7 +701,14 @@ func quoConst(n *node) {
 	n.rval = reflect.New(t).Elem()
 	switch {
 	case isConst:
-		v := constant.BinaryOp(vConstantValue(v0), token.QUO, vConstantValue(v1))
+		// TODO(mpl): exclude uints?
+		var operator token.Token
+		if n.typ.untyped && isInt(n.typ.rtype) {
+			operator = token.QUO_ASSIGN
+		} else {
+			operator = token.QUO
+		}
+		v := constant.BinaryOp(vConstantValue(v0), operator, vConstantValue(v1))
 		n.rval.Set(reflect.ValueOf(v))
 	case isComplex(t):
 		n.rval.SetComplex(vComplex(v0) / vComplex(v1))

--- a/interp/op.go
+++ b/interp/op.go
@@ -701,8 +701,10 @@ func quoConst(n *node) {
 	n.rval = reflect.New(t).Elem()
 	switch {
 	case isConst:
-		// TODO(mpl): exclude uints?
 		var operator token.Token
+		// When the result of the operation is expected to be an int (because both
+		// operands are ints), we want to force the type of the whole expression to be an
+		// int (and not a float), which is achieved by using the QUO_ASSIGN operator.
 		if n.typ.untyped && isInt(n.typ.rtype) {
 			operator = token.QUO_ASSIGN
 		} else {

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -1040,24 +1040,10 @@ func (check typecheck) convertUntyped(n *node, typ *itype) error {
 		return convErr
 	}
 
-	isFloatToIntDivision := false
 	if err := check.representable(n, rtyp); err != nil {
-		if !isInt(rtyp) || n.action != aQuo {
-			return err
-		}
-		// retry in the case of a division, and pretend we want a float. Because if we
-		// can represent a float, then it follows that we can represent the integer
-		// part of that float as an int.
-		if err := check.representable(n, reflect.TypeOf(1.0)); err != nil {
-			return err
-		}
-		isFloatToIntDivision = true
+		return err
 	}
-	if isFloatToIntDivision {
-		n.rval, err = check.convertConstFloatToInt(n.rval)
-	} else {
-		n.rval, err = check.convertConst(n.rval, rtyp)
-	}
+	n.rval, err = check.convertConst(n.rval, rtyp)
 	if err != nil {
 		if errors.Is(err, errCantConvert) {
 			return convErr
@@ -1097,22 +1083,6 @@ func (check typecheck) representable(n *node, t reflect.Type) error {
 		return n.cfgErrorf("cannot convert %s to %s", c.ExactString(), t.Kind().String())
 	}
 	return nil
-}
-
-func (check typecheck) convertConstFloatToInt(v reflect.Value) (reflect.Value, error) {
-	if !v.IsValid() {
-		return v, errors.New("invalid float reflect value")
-	}
-	c, ok := v.Interface().(constant.Value)
-	if !ok {
-		return v, errors.New("unexpected non-constant value")
-	}
-
-	if constant.ToFloat(c).Kind() != constant.Float {
-		return v, errors.New("const value cannot be converted to float")
-	}
-	fl, _ := constant.Float64Val(c)
-	return reflect.ValueOf(int(fl)).Convert(reflect.TypeOf(1.0)), nil
 }
 
 func (check typecheck) convertConst(v reflect.Value, t reflect.Type) (reflect.Value, error) {


### PR DESCRIPTION
When working with an untyped const expression involving a division, if
the default type of the result should be an int (for example because the
default types of all the operands are ints as well), then we should make
sure that the operation that is applied is indeed an integer division,
and that the type of the result is not a float.

This is achieved by using the QUO_ASSIGN operator, instead of the QUO
operator.

This should fix several problems lurking around, and it notably fixes
one of the visible consequences, which is a systematic panic when using
the REPL as a "calculator".

This incidentally also allows us to revert what was done in
5dfc3b86dc7753b035343261339663dd78520412 since it now turns out it was
just a hack to fix one of the symptoms.

Fixes #864