### PR TITLE
interp: fix implicit type for bin composite lit case

### DIFF
--- a/_test/binstruct_slice0.go
+++ b/_test/binstruct_slice0.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"image"
+)
+
+func main() {
+	v := []image.Point{
+		{X: 3, Y: 2},
+	}
+	fmt.Println(v)
+}
+
+// Output:
+// [(3,2)]

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1129,7 +1129,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 			sym, level, found := sc.lookup(n.ident)
 			if !found {
 				// retry with the filename, in case ident is a package name.
-				// TODO(mpl): maybe we improve lookup itself so it can deal with that.
 				sym, level, found = sc.lookup(filepath.Join(n.ident, baseName))
 				if !found {
 					err = n.cfgErrorf("undefined: %s", n.ident)
@@ -2388,8 +2387,13 @@ func compositeGenerator(n *node, typ *itype) (gen bltnGenerator) {
 	case valueT:
 		switch k := n.typ.rtype.Kind(); k {
 		case reflect.Struct:
-			gen = compositeBinStruct
+			if n.nleft == 1 {
+				gen = compositeBinStruct
+			} else {
+				gen = compositeBinStructNotype
+			}
 		case reflect.Map:
+			// TODO(mpl): maybe needs a NoType VS Type too
 			gen = compositeBinMap
 		default:
 			log.Panic(n.cfgErrorf("compositeGenerator not implemented for type kind: %s", k))

--- a/interp/run.go
+++ b/interp/run.go
@@ -2010,12 +2010,15 @@ func compositeBinMap(n *node) {
 	}
 }
 
-// compositeBinStruct creates and populates a struct object from a binary type.
-func compositeBinStruct(n *node) {
+// doCompositeBinStruct creates and populates a struct object from a binary type.
+func doCompositeBinStruct(n *node, hasType bool) {
 	next := getExec(n.tnext)
 	value := valueGenerator(n, n.findex)
 	typ := n.typ.rtype
-	child := n.child[1:]
+	child := n.child
+	if hasType {
+		child = n.child[1:]
+	}
 	values := make([]func(*frame) reflect.Value, len(child))
 	fieldIndex := make([][]int, len(child))
 	for i, c := range child {
@@ -2050,6 +2053,9 @@ func compositeBinStruct(n *node) {
 		return next
 	}
 }
+
+func compositeBinStruct(n *node)       { doCompositeBinStruct(n, true) }
+func compositeBinStructNotype(n *node) { doCompositeBinStruct(n, false) }
 
 func destType(n *node) *itype {
 	switch n.anc.kind {


### PR DESCRIPTION
When the type is implicit, the first element in the list of children is
not the type of the composite literal, but it is one of the actual
children, so it should not be discarded.

Fixes #862