### PR TITLE
interp: support implicit-type slice of pointers of struct composite literal

### DIFF
--- a/_test/binstruct_ptr_map0.go
+++ b/_test/binstruct_ptr_map0.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"image"
+)
+
+func main() {
+	v := map[string]*image.Point{
+		"foo": {X: 3, Y: 2},
+		"bar": {X: 4, Y: 5},
+	}
+	fmt.Println(v["foo"], v["bar"])
+}
+
+// Output:
+// (3,2) (4,5)

--- a/_test/binstruct_ptr_slice0.go
+++ b/_test/binstruct_ptr_slice0.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"image"
+)
+
+func main() {
+	v := []*image.Point{
+		{X: 3, Y: 2},
+		{X: 4, Y: 5},
+	}
+	fmt.Println(v)
+}
+
+// Output:
+// [(3,2) (4,5)]

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -975,6 +975,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					vtyp := &itype{cat: valueT, rtype: rtype.Elem()}
 					err = check.mapLitExpr(child, ktyp, vtyp)
 				}
+				// TODO(mpl): how come we don't have anything to do for reflect.Ptr here?
 			}
 			if err != nil {
 				break
@@ -982,7 +983,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 
 			n.findex = sc.add(n.typ)
 			// TODO: Check that composite literal expr matches corresponding type
-			n.gen = compositeGenerator(n, n.typ)
+			n.gen = compositeGenerator(n, n.typ, nil)
 
 		case fallthroughtStmt:
 			if n.anc.kind != caseBody {
@@ -2359,10 +2360,10 @@ func gotoLabel(s *symbol) {
 	}
 }
 
-func compositeGenerator(n *node, typ *itype) (gen bltnGenerator) {
+func compositeGenerator(n *node, typ *itype, rtyp reflect.Type) (gen bltnGenerator) {
 	switch typ.cat {
 	case aliasT, ptrT:
-		gen = compositeGenerator(n, n.typ.val)
+		gen = compositeGenerator(n, n.typ.val, rtyp)
 	case arrayT:
 		gen = arrayLit
 	case mapT:
@@ -2385,7 +2386,10 @@ func compositeGenerator(n *node, typ *itype) (gen bltnGenerator) {
 			}
 		}
 	case valueT:
-		switch k := n.typ.rtype.Kind(); k {
+		if rtyp == nil {
+			rtyp = n.typ.rtype
+		}
+		switch k := rtyp.Kind(); k {
 		case reflect.Struct:
 			if n.nleft == 1 {
 				gen = compositeBinStruct
@@ -2393,8 +2397,10 @@ func compositeGenerator(n *node, typ *itype) (gen bltnGenerator) {
 				gen = compositeBinStructNotype
 			}
 		case reflect.Map:
-			// TODO(mpl): maybe needs a NoType VS Type too
+			// TODO(mpl): maybe needs a NoType version too
 			gen = compositeBinMap
+		case reflect.Ptr:
+			gen = compositeGenerator(n, typ, n.typ.val.rtype)
 		default:
 			log.Panic(n.cfgErrorf("compositeGenerator not implemented for type kind: %s", k))
 		}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -975,7 +975,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					vtyp := &itype{cat: valueT, rtype: rtype.Elem()}
 					err = check.mapLitExpr(child, ktyp, vtyp)
 				}
-				// TODO(mpl): how come we don't have anything to do for reflect.Ptr here?
 			}
 			if err != nil {
 				break

--- a/interp/run.go
+++ b/interp/run.go
@@ -2015,6 +2015,9 @@ func doCompositeBinStruct(n *node, hasType bool) {
 	next := getExec(n.tnext)
 	value := valueGenerator(n, n.findex)
 	typ := n.typ.rtype
+	if n.typ.cat == ptrT || n.typ.cat == aliasT {
+		typ = n.typ.val.rtype
+	}
 	child := n.child
 	if hasType {
 		child = n.child[1:]
@@ -2049,7 +2052,13 @@ func doCompositeBinStruct(n *node, hasType bool) {
 		for i, v := range values {
 			s.FieldByIndex(fieldIndex[i]).Set(v(f))
 		}
-		value(f).Set(s)
+		d := value(f)
+		switch {
+		case d.Type().Kind() == reflect.Ptr:
+			d.Set(s.Addr())
+		default:
+			d.Set(s)
+		}
 		return next
 	}
 }


### PR DESCRIPTION
Also fix same case for implicit-type maps of etc.

Fixes #883
