### PR TITLE
feature: provide a version sub-command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 env:
   global:
     - GO111MODULE=on
-    - GOFLAGS=-ldflags=-X=main.version=$(git describe --tags)
+    - GOFLAGS="-ldflags=-X=main.version=$(git describe --tags)"
 
 go_import_path: github.com/traefik/yaegi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
 env:
   global:
     - GO111MODULE=on
+    - GOFLAGS=-ldflags=-X=main.version=$(git describe --tags)
 
 go_import_path: github.com/traefik/yaegi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
 env:
   global:
     - GO111MODULE=on
-    - GOFLAGS="-ldflags=-X=main.version=$(git describe --tags)"
 
 go_import_path: github.com/traefik/yaegi
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ internal/cmd/extract/extract:
 generate: gen_all_syscall
 	go generate
 
+install:
+	GOFLAGS=-ldflags=-X=main.version=$$(git describe --tags) go install ./...
+
 tests:
 	go test -v ./...
 	go test -race ./interp
@@ -24,4 +27,4 @@ tests:
 install.sh: .goreleaser.yml
 	godownloader --repo=traefik/yaegi -o install.sh .goreleaser.yml
 
-.PHONY: check gen_all_syscall gen_tests generate_downloader internal/cmd/extract/extract
+.PHONY: check gen_all_syscall gen_tests generate_downloader internal/cmd/extract/extract install

--- a/cmd/yaegi/help.go
+++ b/cmd/yaegi/help.go
@@ -14,6 +14,7 @@ The commands are:
     help        print usage information
     run         execute a Go program from source
     test        execute test functions in a Go package
+    version     print version
 
 Use "yaegi help <command>" for more information about a command.
 
@@ -37,6 +38,9 @@ func help(arg []string) error {
 		return run([]string{"-h"})
 	case Test:
 		return test([]string{"-h"})
+	case Version:
+		fmt.Println("Usage: yaegi version")
+		return nil
 	default:
 		return fmt.Errorf("help: invalid yaegi command: %v", cmd)
 	}

--- a/cmd/yaegi/yaegi.go
+++ b/cmd/yaegi/yaegi.go
@@ -106,7 +106,10 @@ const (
 	Help    = "help"
 	Run     = "run"
 	Test    = "test"
+	Version = "version"
 )
+
+var version = "devel" // This may be overwritten at build time.
 
 func main() {
 	var cmd string
@@ -128,6 +131,8 @@ func main() {
 		err = run(os.Args[2:])
 	case Test:
 		err = test(os.Args[2:])
+	case Version:
+		fmt.Println(version)
 	default:
 		// If no command is given, fallback to default "run" command.
 		// This allows scripts starting with "#!/usr/bin/env yaegi",


### PR DESCRIPTION
A version sub-command is implemented.
A local install target is added to Makefile, to set version from git at build.

Fixes #840.