### PR TITLE
fix: behavior of select and time ticker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ generate: gen_all_syscall
 	go generate
 
 tests:
-	GO111MODULE=off go test -v ./...
-	GO111MODULE=off go test -race ./interp
+	go test -v ./...
+	go test -race ./interp
 
 # https://github.com/goreleaser/godownloader
 install.sh: .goreleaser.yml

--- a/_test/select14.go
+++ b/_test/select14.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	period    = 100 * time.Millisecond
+	precision = 5 * time.Millisecond
+)
+
+func main() {
+	counter := 0
+	p := time.Now()
+	ticker := time.NewTicker(period)
+	ch := make(chan int)
+
+	go func() {
+		for i := 0; i < 3; i++ {
+			select {
+			case t := <-ticker.C:
+				counter = counter + 1
+				ch <- counter
+				if d := t.Sub(p) - period; d < -precision || d > precision {
+					fmt.Println("wrong delay", d)
+				}
+				p = t
+			}
+		}
+		ch <- 0
+	}()
+	for c := range ch {
+		if c == 0 {
+			break
+		}
+		println(c)
+	}
+}
+
+// Output:
+// 1
+// 2
+// 3

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -443,10 +443,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				n.gen = nop
 				break
 			}
-			if n.anc.kind == commClause {
-				n.gen = nop
-				break
-			}
+
 			var atyp *itype
 			if n.nleft+n.nright < len(n.child) {
 				if atyp, err = nodeType(interp, sc, n.child[n.nleft]); err != nil {

--- a/interp/run.go
+++ b/interp/run.go
@@ -2966,37 +2966,38 @@ func _select(n *node) {
 	next := getExec(n.tnext)
 
 	for i := 0; i < nbClause; i++ {
-		if len(n.child[i].child) == 0 {
-			// The comm clause is an empty default, exit select.
+		cl := n.child[i]
+		if cl.kind == commClauseDefault {
 			cases[i].Dir = reflect.SelectDefault
-			clause[i] = func(*frame) bltn { return next }
-		} else {
-			switch c0 := n.child[i].child[0]; {
-			case len(n.child[i].child) > 1:
-				// The comm clause contains a channel operation and a clause body.
-				clause[i] = getExec(n.child[i].child[1].start)
-				chans[i], assigned[i], ok[i], cases[i].Dir = clauseChanDir(n.child[i])
-				chanValues[i] = genValue(chans[i])
-				if assigned[i] != nil {
-					assignedValues[i] = genValue(assigned[i])
-				}
-				if ok[i] != nil {
-					okValues[i] = genValue(ok[i])
-				}
-			case c0.kind == exprStmt && len(c0.child) == 1 && c0.child[0].action == aRecv:
-				// The comm clause has an empty body clause after channel receive.
-				chanValues[i] = genValue(c0.child[0].child[0])
-				cases[i].Dir = reflect.SelectRecv
-			case c0.kind == sendStmt:
-				// The comm clause as an empty body clause after channel send.
-				chanValues[i] = genValue(c0.child[0])
-				cases[i].Dir = reflect.SelectSend
-				assignedValues[i] = genValue(c0.child[1])
-			default:
-				// The comm clause has a default clause.
-				clause[i] = getExec(c0.start)
-				cases[i].Dir = reflect.SelectDefault
+			if len(cl.child) == 0 {
+				clause[i] = func(*frame) bltn { return next }
+			} else {
+				clause[i] = getExec(cl.child[0].start)
 			}
+			continue
+		}
+		// The comm clause is in send or recv direction.
+		switch c0 := cl.child[0]; {
+		case len(cl.child) > 1:
+			// The comm clause contains a channel operation and a clause body.
+			clause[i] = getExec(cl.child[1].start)
+			chans[i], assigned[i], ok[i], cases[i].Dir = clauseChanDir(c0)
+			chanValues[i] = genValue(chans[i])
+			if assigned[i] != nil {
+				assignedValues[i] = genValue(assigned[i])
+			}
+			if ok[i] != nil {
+				okValues[i] = genValue(ok[i])
+			}
+		case c0.kind == exprStmt && len(c0.child) == 1 && c0.child[0].action == aRecv:
+			// The comm clause has an empty body clause after channel receive.
+			chanValues[i] = genValue(c0.child[0].child[0])
+			cases[i].Dir = reflect.SelectRecv
+		case c0.kind == sendStmt:
+			// The comm clause as an empty body clause after channel send.
+			chanValues[i] = genValue(c0.child[0])
+			cases[i].Dir = reflect.SelectSend
+			assignedValues[i] = genValue(c0.child[1])
 		}
 	}
 

--- a/interp/type.go
+++ b/interp/type.go
@@ -1188,7 +1188,11 @@ func (t *itype) lookupBinField(name string) (s reflect.StructField, index []int,
 	if !isStruct(t) {
 		return
 	}
-	s, ok = t.TypeOf().FieldByName(name)
+	rt := t.rtype
+	if t.cat == valueT && rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+	s, ok = rt.FieldByName(name)
 	if !ok {
 		for i, f := range t.field {
 			if f.embed {


### PR DESCRIPTION
There was several issues:
- access to field on pointer to struct from runtime: fix in
  lookupBinField
- assign operation was skipped when performed in a comm clause
- the direction of comm clause was wrong if a channel send operation was
  performed in a body of a receive comm clause

Fixes #884.