### PR TITLE
fix: detect a wrong number of arguments at return

### DIFF
--- a/_test/fun23.go
+++ b/_test/fun23.go
@@ -1,0 +1,10 @@
+package main
+
+func f(x int) { return x }
+
+func main() {
+	print("hello")
+}
+
+// Error:
+// 3:17: too many arguments to return

--- a/cmd/yaegi/run.go
+++ b/cmd/yaegi/run.go
@@ -70,13 +70,12 @@ func run(arg []string) error {
 
 	if cmd != "" {
 		_, err = i.Eval(cmd)
-		showError(err)
 	}
 
 	if len(args) == 0 {
 		if interactive || cmd == "" {
-			_, err = i.REPL()
 			showError(err)
+			_, err = i.REPL()
 		}
 		return err
 	}
@@ -91,7 +90,6 @@ func run(arg []string) error {
 	} else {
 		_, err = i.EvalPath(path)
 	}
-	showError(err)
 
 	if err != nil {
 		return err
@@ -99,7 +97,6 @@ func run(arg []string) error {
 
 	if interactive {
 		_, err = i.REPL()
-		showError(err)
 	}
 	return err
 }

--- a/cmd/yaegi/yaegi.go
+++ b/cmd/yaegi/yaegi.go
@@ -99,6 +99,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+
+	"github.com/traefik/yaegi/interp"
 )
 
 const (
@@ -143,8 +145,10 @@ func main() {
 	}
 
 	if err != nil && !errors.Is(err, flag.ErrHelp) {
-		err = fmt.Errorf("%s: %w", cmd, err)
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, fmt.Errorf("%s: %w", cmd, err))
+		if p, ok := err.(interp.Panic); ok {
+			fmt.Fprintln(os.Stderr, string(p.Stack))
+		}
 		exitCode = 1
 	}
 	os.Exit(exitCode)

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1298,6 +1298,10 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 			}
 
 		case returnStmt:
+			if len(n.child) > sc.def.typ.numOut() {
+				err = n.cfgErrorf("too many arguments to return")
+				break
+			}
 			if mustReturnValue(sc.def.child[2]) {
 				nret := len(n.child)
 				if nret == 1 && isCall(n.child[0]) {
@@ -1307,10 +1311,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					err = n.cfgErrorf("not enough arguments to return")
 					break
 				}
-			}
-			if len(n.child) > sc.def.typ.numOut() {
-				err = n.cfgErrorf("too many arguments to return")
-				break
 			}
 			wireChild(n)
 			n.tnext = nil

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1308,6 +1308,10 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					break
 				}
 			}
+			if len(n.child) > sc.def.typ.numOut() {
+				err = n.cfgErrorf("too many arguments to return")
+				break
+			}
 			wireChild(n)
 			n.tnext = nil
 			n.val = sc.def

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -43,6 +43,7 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "for7.go" || // expect error
 			file.Name() == "fun21.go" || // expect error
 			file.Name() == "fun22.go" || // expect error
+			file.Name() == "fun23.go" || // expect error
 			file.Name() == "if2.go" || // expect error
 			file.Name() == "import6.go" || // expect error
 			file.Name() == "init1.go" || // expect error
@@ -200,6 +201,11 @@ func TestInterpErrorConsistency(t *testing.T) {
 			fileName:       "fun22.go",
 			expectedInterp: "6:2: not enough arguments in call to time.Date",
 			expectedExec:   "6:11: not enough arguments in call to time.Date",
+		},
+		{
+			fileName:       "fun23.go",
+			expectedInterp: "3:17: too many arguments to return",
+			expectedExec:   "3:17: too many arguments to return",
 		},
 		{
 			fileName:       "op1.go",


### PR DESCRIPTION
Also fix error ouptut in the run command to avoid displaying twice
the same error.

Fixes #819.