### PR TITLE
interp: API change for Symbols method

### DIFF
--- a/cmd/yaegi/test.go
+++ b/cmd/yaegi/test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"go/build"
@@ -117,7 +118,11 @@ func test(arg []string) (err error) {
 
 	benchmarks := []testing.InternalBenchmark{}
 	tests := []testing.InternalTest{}
-	for name, sym := range i.Symbols(path) {
+	syms, ok := i.Symbols(path)[path]
+	if !ok {
+		return errors.New("No tests found")
+	}
+	for name, sym := range syms {
 		switch fun := sym.Interface().(type) {
 		case func(*testing.B):
 			benchmarks = append(benchmarks, testing.InternalBenchmark{name, fun})


### PR DESCRIPTION
Often enough when debugging, one does not know exactly what argument
should be given to Symbols, as it's not always clear in which
scope/namespace the symbol one is looking for is stored in.

Therefore, this change enables the Symbols method to now take the empty
string as an argument, which results in all the known symbols to be
returned (keyed by import path).

As a consequence, when an non-empty argument is given, the returned
result should be similar to what we had before, except it is now
returned as the sole entry of an encompassing map.

In addition, the "binary" symbols (i.e. the ones ingested through a
Use call), are now also taken into account.