### PR TITLE
interp: fix assignable check

### DIFF
--- a/_test/fun24.go
+++ b/_test/fun24.go
@@ -1,0 +1,10 @@
+package main
+
+func f(x int) (int, int) { return x, "foo" }
+
+func main() {
+	print("hello")
+}
+
+// Error:
+// cannot use "foo" (type stringT) as type intT in return argument

--- a/_test/fun25.go
+++ b/_test/fun25.go
@@ -1,0 +1,10 @@
+package main
+
+func f(x string) (a int, b int) { return x, 5 }
+
+func main() {
+	print("hello")
+}
+
+// Error:
+// cannot use x (type stringT) as type intT in return argument

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -44,6 +44,8 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "fun21.go" || // expect error
 			file.Name() == "fun22.go" || // expect error
 			file.Name() == "fun23.go" || // expect error
+			file.Name() == "fun24.go" || // expect error
+			file.Name() == "fun25.go" || // expect error
 			file.Name() == "if2.go" || // expect error
 			file.Name() == "import6.go" || // expect error
 			file.Name() == "init1.go" || // expect error


### PR DESCRIPTION
The assignable check used to be too strict as it lacked the property that
if an untyped const can be represented as a T, then it is assignable to T.

And we can now use that fixed check to add a missing check: in a return
statement, we now make sure that any of the returned elements are
assignable to what the signature tells us they should be.