### PR TITLE
interp: added kind to log for typecheck

### DIFF
--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -101,7 +101,7 @@ func (check typecheck) addressExpr(n *node) error {
 			found = true
 			continue
 		}
-		return n.cfgErrorf("invalid operation: cannot take address of %s", c0.typ.id())
+		return n.cfgErrorf("invalid operation: cannot take address of %s [kind: %s]", c0.typ.id(), kinds[c0.kind])
 	}
 	return nil
 }


### PR DESCRIPTION
added `kind` to log
```
invalid operation: cannot take address of []github.com/rsteube/traefik-plugin-brotli/vendor/github.com/andybalholm/brotli.huffmanTree [kind: sliceExpr]
```