### PR TITLE
interp: fix array size definition in case of forward declared constant

### DIFF
--- a/_test/a44.go
+++ b/_test/a44.go
@@ -1,0 +1,12 @@
+package main
+
+var a = [max]int{}
+
+const max = 32
+
+func main() {
+	println(len(a))
+}
+
+// Output:
+// 32


### PR DESCRIPTION
In type.go, the symbol lookup on constant id was not performed. Handle
the ident kind explicitely to allow that.

Fixes #911.