### PR TITLE
interp: add indexExpr check for reflect.Array

### DIFF
--- a/_test/slice.go
+++ b/_test/slice.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+    a := [2][2]int{{0, 1}, {2, 3}}
+    fmt.Println(a[0][0:])
+}
+
+// Output:
+// [0 1]

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -486,7 +486,7 @@ func (check typecheck) sliceExpr(n *node) error {
 	case reflect.Array:
 		valid = true
 		l = t.Len()
-		if c.kind != selectorExpr && (c.sym == nil || c.sym.kind != varSym) {
+		if c.kind != indexExpr && c.kind != selectorExpr && (c.sym == nil || c.sym.kind != varSym) {
 			return c.cfgErrorf("cannot slice type %s", c.typ.id())
 		}
 	case reflect.Slice:


### PR DESCRIPTION
In typecheck.go, type check was failing for expressions like `[2]int{0, 1}[0:]`.
```
cannot slice type [2]int
```

Fixes #914 .