### PR TITLE
interp: fix type in assign of shift operations

### DIFF
--- a/_test/assign16.go
+++ b/_test/assign16.go
@@ -1,0 +1,15 @@
+package main
+
+type H struct {
+	bits uint
+}
+
+func main() {
+	h := &H{8}
+	var x uint = (1 << h.bits) >> 6
+
+	println(x)
+}
+
+// Output:
+// 4

--- a/_test/select1.go
+++ b/_test/select1.go
@@ -1,18 +1,20 @@
 package main
 
-import "time"
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 func main() {
 	c1 := make(chan string)
 	c2 := make(chan string)
 
 	go func() {
-		time.Sleep(1e9)
+		time.Sleep(1e7)
 		c1 <- "one"
 	}()
 	go func() {
-		time.Sleep(2e9)
+		time.Sleep(2e7)
 		c2 <- "two"
 	}()
 

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -677,7 +677,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				n.gen = nop
 				n.findex = -1
 			case n.anc.kind == assignStmt && n.anc.action == aAssign:
-				//case (n.anc.kind == assignStmt || n.anc.kind == defineStmt) && n.anc.action == aAssign:
 				// To avoid a copy in frame, if the result is to be assigned, store it directly
 				// at the frame location of destination.
 				dest := n.anc.child[childPos(n)-n.anc.nright]
@@ -2459,7 +2458,7 @@ func isValueUntyped(v reflect.Value) bool {
 	return t.String() == t.Kind().String()
 }
 
-// isArithmeticAction returns true if the node action is an arithmetic operator
+// isArithmeticAction returns true if the node action is an arithmetic operator.
 func isArithmeticAction(n *node) bool {
 	switch n.action {
 	case aAdd, aAnd, aAndNot, aBitNot, aMul, aQuo, aRem, aShl, aShr, aSub, aXor:

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -986,6 +986,9 @@ func TestConcurrentEvals(t *testing.T) {
 // called by EvalWithContext is sequential. And that there is no data race for the
 // interp package global vars or the interpreter fields in this case.
 func TestConcurrentEvals2(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	pin, pout := io.Pipe()
 	defer func() {
 		_ = pin.Close()
@@ -1045,6 +1048,9 @@ func TestConcurrentEvals2(t *testing.T) {
 // - when calling Interpreter.Use, the symbols given as argument should be
 // copied when being inserted into interp.binPkg, and not directly used as-is.
 func TestConcurrentEvals3(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	allDone := make(chan bool)
 	runREPL := func() {
 		done := make(chan error)
@@ -1123,6 +1129,9 @@ func TestConcurrentComposite2(t *testing.T) {
 }
 
 func testConcurrentComposite(t *testing.T, filePath string) {
+	if testing.Short() {
+		return
+	}
 	pin, pout := io.Pipe()
 	i := interp.New(interp.Options{Stdout: pout})
 	i.Use(stdlib.Symbols)
@@ -1160,6 +1169,9 @@ func testConcurrentComposite(t *testing.T, filePath string) {
 }
 
 func TestEvalScanner(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	type testCase struct {
 		desc      string
 		src       []string
@@ -1333,6 +1345,9 @@ func applyCIMultiplier(timeout time.Duration) time.Duration {
 }
 
 func TestREPLDivision(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	_ = os.Setenv("YAEGI_PROMPT", "1")
 	defer func() {
 		_ = os.Setenv("YAEGI_PROMPT", "0")

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -486,7 +486,7 @@ func (check typecheck) sliceExpr(n *node) error {
 	case reflect.Array:
 		valid = true
 		l = t.Len()
-		if c.kind != selectorExpr && c.kind != indexExpr && (c.sym == nil || c.sym.kind != varSym) {
+		if c.kind != indexExpr && c.kind != selectorExpr && (c.sym == nil || c.sym.kind != varSym) {
 			return c.cfgErrorf("cannot slice type %s", c.typ.id())
 		}
 	case reflect.Slice:

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -151,7 +151,7 @@ func (check typecheck) shift(n *node) error {
 	t0, t1 := c0.typ.TypeOf(), c1.typ.TypeOf()
 
 	var v0 constant.Value
-	if c0.typ.untyped {
+	if c0.typ.untyped && c0.rval.IsValid() {
 		v0 = constant.ToInt(c0.rval.Interface().(constant.Value))
 		c0.rval = reflect.ValueOf(v0)
 	}
@@ -486,7 +486,7 @@ func (check typecheck) sliceExpr(n *node) error {
 	case reflect.Array:
 		valid = true
 		l = t.Len()
-		if c.kind != selectorExpr && (c.sym == nil || c.sym.kind != varSym) {
+		if c.kind != selectorExpr && c.kind != indexExpr && (c.sym == nil || c.sym.kind != varSym) {
 			return c.cfgErrorf("cannot slice type %s", c.typ.id())
 		}
 	case reflect.Slice:


### PR DESCRIPTION
Type checking on shift operands was failing for untyped variable values.

Fix propagation of type in assignment. Optimize assignment of arithmetic
operations on variables by skipping the assign and writing directly to
destination frame value in the operator function.

Skip some slow tests when given -short test option.

Fixes #917.