### PR TITLE
interp: fix type conversion for constant expressions

### DIFF
--- a/_test/const21.go
+++ b/_test/const21.go
@@ -1,0 +1,12 @@
+package main
+
+const a = 64
+
+var b uint = a * a / 2
+
+func main() {
+	println(b)
+}
+
+// Output:
+// 2048


### PR DESCRIPTION
The case of a constant arithmetic expression being of float kind because
of quotient was not handled correctly. Simplify constant extraction to
reflect.Value first, then conversion to target type, and let reflect Convert
method panic if conversion is not valid.

Fixes #920.