### PR TITLE
interp: resolve type for untyped shift expressions

### DIFF
--- a/_test/composite14.go
+++ b/_test/composite14.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+type T struct {
+	b []byte
+}
+
+func main() {
+	t := T{nil}
+	fmt.Println(t)
+}
+
+// Output:
+// {[]}

--- a/_test/const21.go
+++ b/_test/const21.go
@@ -1,0 +1,12 @@
+package main
+
+const a = 64
+
+var b uint = a * a / 2
+
+func main() {
+	println(b)
+}
+
+// Output:
+// 2048

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -71,6 +71,14 @@ func TestEvalArithmetic(t *testing.T) {
 	})
 }
 
+func TestEvalShift(t *testing.T) {
+	i := interp.New(interp.Options{})
+	runTests(t, i, []testCase{
+		{src: "a, b, m := uint32(1), uint32(2), uint32(0); m = a + (1 << b)", res: "5"},
+		{pre: func() { eval(t, i, "const k uint = 1 << 17") }, src: "int(k)", res: "131072"},
+	})
+}
+
 func TestEvalStar(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{


### PR DESCRIPTION
A non-constant shift expression can be untyped, requiring to apply a
type from inherited context. This change insures that such context is
propagated during CFG pre-order walk, to be used if necessary.
    
Fixes #927.