### PR TITLE
interp: resolve type for untyped shift expressions

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -672,7 +672,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 			wireChild(n)
 			nilSym := interp.universe.sym[nilIdent]
 			c0, c1 := n.child[0], n.child[1]
-			rval0, rval1 := c0.rval, c1.rval
 
 			err = check.binaryExpr(n)
 			if err != nil {
@@ -680,10 +679,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 			}
 
 			switch n.action {
-			case aQuo:
-				// Restore original constant values as before check to allow automatic integer conversion.
-				// TODO(marc) To avoid this, constant values should be stored separately than rval.
-				c0.rval, c1.rval = rval0, rval1
 			case aRem:
 				n.typ = c0.typ
 			case aShl, aShr:

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -66,6 +66,24 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 			return false
 		}
 		switch n.kind {
+		case binaryExpr, unaryExpr, parenExpr:
+			if isBoolAction(n) {
+				break
+			}
+			// Gather assigned type if set, to give context for type propagation at post-order.
+			switch n.anc.kind {
+			case assignStmt, defineStmt:
+				a := n.anc
+				i := childPos(n) - a.nright
+				if len(a.child) > a.nright+a.nleft {
+					i--
+				}
+				dest := a.child[i]
+				n.typ = dest.typ
+			case binaryExpr, unaryExpr, parenExpr:
+				n.typ = n.anc.typ
+			}
+
 		case blockStmt:
 			if n.anc != nil && n.anc.kind == rangeStmt {
 				// For range block: ensure that array or map type is propagated to iterators
@@ -644,7 +662,12 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 			}
 
 			switch n.action {
-			case aRem, aShl, aShr:
+			case aRem:
+				n.typ = c0.typ
+			case aShl, aShr:
+				if c0.typ.untyped {
+					break
+				}
 				n.typ = c0.typ
 			case aEqual, aNotEqual:
 				n.typ = sc.getType("bool")
@@ -860,7 +883,12 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					n.gen = nop
 					n.findex = -1
 					n.typ = c0.typ
-					n.rval = c1.rval.Convert(c0.typ.rtype)
+					if c, ok := c1.rval.Interface().(constant.Value); ok {
+						i, _ := constant.Int64Val(constant.ToInt(c))
+						n.rval = reflect.ValueOf(i).Convert(c0.typ.rtype)
+					} else {
+						n.rval = c1.rval.Convert(c0.typ.rtype)
+					}
 				default:
 					n.gen = convert
 					n.typ = c0.typ
@@ -2469,6 +2497,15 @@ func isValueUntyped(v reflect.Value) bool {
 func isArithmeticAction(n *node) bool {
 	switch n.action {
 	case aAdd, aAnd, aAndNot, aBitNot, aMul, aQuo, aRem, aShl, aShr, aSub, aXor:
+		return true
+	default:
+		return false
+	}
+}
+
+func isBoolAction(n *node) bool {
+	switch n.action {
+	case aEqual, aGreater, aGreaterEqual, aLand, aLor, aLower, aLowerEqual, aNot, aNotEqual:
 		return true
 	default:
 		return false

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -76,6 +76,7 @@ func TestEvalShift(t *testing.T) {
 	runTests(t, i, []testCase{
 		{src: "a, b, m := uint32(1), uint32(2), uint32(0); m = a + (1 << b)", res: "5"},
 		{src: "c := uint(1); d := uint(+(-(1 << c)))", res: "18446744073709551614"},
+		{src: "e, f := uint32(0), uint32(0); f = 1 << -(e * 2)", res: "1"},
 		{pre: func() { eval(t, i, "const k uint = 1 << 17") }, src: "int(k)", res: "131072"},
 	})
 }

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -71,6 +71,14 @@ func TestEvalArithmetic(t *testing.T) {
 	})
 }
 
+func TestEvalShift(t *testing.T) {
+	i := interp.New(interp.Options{})
+	runTests(t, i, []testCase{
+		{src: "a, b, m := uint32(1), uint32(2), uint32(0); m = a + (1 << b)", res: "5"},
+		{pre: func() { eval(t, i, "const k uint = 1 << 17") }, src: "int(k)", res: "131072"},
+	})
+}
+
 func TestEvalStar(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -75,6 +75,7 @@ func TestEvalShift(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{
 		{src: "a, b, m := uint32(1), uint32(2), uint32(0); m = a + (1 << b)", res: "5"},
+		{src: "c := uint(1); d := uint(+(-(1 << c)))", res: "18446744073709551614"},
 		{pre: func() { eval(t, i, "const k uint = 1 << 17") }, src: "int(k)", res: "131072"},
 	})
 }

--- a/interp/run.go
+++ b/interp/run.go
@@ -1766,6 +1766,11 @@ func neg(n *node) {
 			dest(f).SetInt(-value(f).Int())
 			return next
 		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		n.exec = func(f *frame) bltn {
+			dest(f).SetUint(-value(f).Uint())
+			return next
+		}
 	case reflect.Float32, reflect.Float64:
 		n.exec = func(f *frame) bltn {
 			dest(f).SetFloat(-value(f).Float())

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -217,6 +217,7 @@ var binaryOpPredicates = opPredicates{
 // binaryExpr type checks a binary expression.
 func (check typecheck) binaryExpr(n *node) error {
 	c0, c1 := n.child[0], n.child[1]
+
 	a := n.action
 	if isAssignAction(a) {
 		a--
@@ -224,6 +225,21 @@ func (check typecheck) binaryExpr(n *node) error {
 
 	if isShiftAction(a) {
 		return check.shift(n)
+	}
+
+	switch n.action {
+	case aRem:
+		if zeroConst(c1) {
+			return n.cfgErrorf("invalid operation: division by zero")
+		}
+	case aQuo:
+		if zeroConst(c1) {
+			return n.cfgErrorf("invalid operation: division by zero")
+		}
+		if c0.rval.IsValid() && c1.rval.IsValid() {
+			// Avoid constant conversions below to ensure correct constant integer quotient.
+			return nil
+		}
 	}
 
 	_ = check.convertUntyped(c0, c1.typ)
@@ -241,14 +257,11 @@ func (check typecheck) binaryExpr(n *node) error {
 	if err := check.op(binaryOpPredicates, a, n, c0, t0); err != nil {
 		return err
 	}
-
-	switch n.action {
-	case aQuo, aRem:
-		if (c0.typ.untyped || isInt(t0)) && c1.typ.untyped && constant.Sign(c1.rval.Interface().(constant.Value)) == 0 {
-			return n.cfgErrorf("invalid operation: division by zero")
-		}
-	}
 	return nil
+}
+
+func zeroConst(n *node) bool {
+	return n.typ.untyped && constant.Sign(n.rval.Interface().(constant.Value)) == 0
 }
 
 func (check typecheck) index(n *node, max int) error {


### PR DESCRIPTION
A non-constant shift expression can be untyped, requiring to apply a
type from inherited context. This change insures that such context is
propagated during CFG pre-order walk, to be used if necessary.
    
Fixes #927.