### PR TITLE
interp: fix incorrect infinite loop on for statement

### DIFF
--- a/_test/for15.go
+++ b/_test/for15.go
@@ -1,0 +1,16 @@
+package main
+
+func f() int { println("in f"); return 1 }
+
+func main() {
+	for i := f(); ; {
+		println("in loop")
+		if i > 0 {
+			break
+		}
+	}
+}
+
+// Output:
+// in f
+// in loop

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -51,6 +51,7 @@ const (
 	fieldList
 	fileStmt
 	forStmt0     // for {}
+	forStmt0a    // for init; ; {}
 	forStmt1     // for cond {}
 	forStmt2     // for init; cond; {}
 	forStmt3     // for ; cond; post {}
@@ -131,6 +132,7 @@ var kinds = [...]string{
 	fieldList:         "fieldList",
 	fileStmt:          "fileStmt",
 	forStmt0:          "forStmt0",
+	forStmt0a:         "forStmt0a",
 	forStmt1:          "forStmt1",
 	forStmt2:          "forStmt2",
 	forStmt3:          "forStmt3",
@@ -655,8 +657,12 @@ func (interp *Interpreter) ast(src, name string, inc bool) (string, *node, error
 			// Disambiguate variants of FOR statements with a node kind per variant
 			var kind nkind
 			if a.Cond == nil {
-				if a.Init != nil && a.Post != nil {
-					kind = forStmt3a
+				if a.Init != nil {
+					if a.Post != nil {
+						kind = forStmt3a
+					} else {
+						kind = forStmt0a
+					}
 				} else {
 					kind = forStmt0
 				}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -289,7 +289,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 			sc = sc.pushBloc()
 			sc.loop, sc.loopRestart = n, n.child[0]
 
-		case forStmt1, forStmt2, forStmt3, forStmt3a, forStmt4:
+		case forStmt0a, forStmt1, forStmt2, forStmt3, forStmt3a, forStmt4:
 			sc = sc.pushBloc()
 			sc.loop, sc.loopRestart = n, n.lastChild()
 
@@ -1002,6 +1002,13 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 		case forStmt0: // for {}
 			body := n.child[0]
 			n.start = body.start
+			body.tnext = n.start
+			sc = sc.pop()
+
+		case forStmt0a: // for init; ; {}
+			init, body := n.child[0], n.child[1]
+			n.start = init.start
+			init.tnext = body.start
 			body.tnext = n.start
 			sc = sc.pop()
 


### PR DESCRIPTION
Add a for statement variant for the case of a "for" with an init, no
condition and no post-increment.

Fixes #933.