### PR TITLE
interp: implement conversion for interpreter function types

### DIFF
--- a/_test/convert0.go
+++ b/_test/convert0.go
@@ -1,0 +1,21 @@
+package main
+
+type T struct {
+	v int
+}
+
+type comparator func(T, T) bool
+
+func sort(items []T, comp comparator) {
+	println("in sort")
+}
+
+func compT(t0, t1 T) bool { return t0.v < t1.v }
+
+func main() {
+	a := []T{}
+	sort(a, comparator(compT))
+}
+
+// Output:
+// in sort

--- a/interp/run.go
+++ b/interp/run.go
@@ -390,6 +390,21 @@ func convert(n *node) {
 		return
 	}
 
+	if n.child[0].typ.cat == funcT && c.typ.cat == funcT {
+		value := genValue(c)
+		n.exec = func(f *frame) bltn {
+			n, ok := value(f).Interface().(*node)
+			if !ok || !n.typ.convertibleTo(c.typ) {
+				panic("cannot convert")
+			}
+			n1 := *n
+			n1.typ = c.typ
+			dest(f).Set(reflect.ValueOf(&n1))
+			return next
+		}
+		return
+	}
+
 	var value func(*frame) reflect.Value
 	if c.typ.cat == funcT {
 		value = genFunctionWrapper(c)


### PR DESCRIPTION
Interpreter function types are represented internally by the AST node
of their definition. The conversion operation creates a new node with
the type field pointing to the target type.

Fixes #936.