### PR TITLE
fix: use the import path for types

### DIFF
--- a/example/pkg/_pkg13/src/guthib.com/foo/bar/main.go
+++ b/example/pkg/_pkg13/src/guthib.com/foo/bar/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+
+	"guthib.com/bat/baz"
+)
+
+func main() {
+	t := baz.NewT()
+
+	fmt.Printf("%s", t.A3)
+}

--- a/example/pkg/_pkg13/src/guthib.com/foo/bar/vendor/guthib.com/bat/baz/baz.go
+++ b/example/pkg/_pkg13/src/guthib.com/foo/bar/vendor/guthib.com/bat/baz/baz.go
@@ -1,0 +1,22 @@
+package baz
+
+func NewT() *T {
+	return &T{
+		A1: make([]U, 0),
+		A3: "foobar",
+	}
+}
+
+type T struct {
+	A1 []U
+	A3 string
+}
+
+type U struct {
+	B1 V
+	B2 V
+}
+
+type V struct {
+	C1 string
+}

--- a/example/pkg/pkg_test.go
+++ b/example/pkg/pkg_test.go
@@ -93,6 +93,12 @@ func TestPackages(t *testing.T) {
 			expected: "Yo hello",
 			evalFile: "./_pkg12/src/guthib.com/foo/main.go",
 		},
+		{
+			desc:     "eval main with vendor",
+			goPath:   "./_pkg13/",
+			expected: "foobar",
+			evalFile: "./_pkg13/src/guthib.com/foo/bar/main.go",
+		},
 	}
 
 	for _, test := range testCases {

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -145,7 +145,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 					elementType := sc.getType(typeName)
 					if elementType == nil {
 						// Add type if necessary, so method can be registered
-						sc.sym[typeName] = &symbol{kind: typeSym, typ: &itype{name: typeName, path: rpath, incomplete: true, node: rtn.child[0], scope: sc}}
+						sc.sym[typeName] = &symbol{kind: typeSym, typ: &itype{name: typeName, path: importPath, incomplete: true, node: rtn.child[0], scope: sc}}
 						elementType = sc.sym[typeName].typ
 					}
 					rcvrtype = &itype{cat: ptrT, val: elementType, incomplete: elementType.incomplete, node: rtn, scope: sc}
@@ -154,7 +154,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 					rcvrtype = sc.getType(typeName)
 					if rcvrtype == nil {
 						// Add type if necessary, so method can be registered
-						sc.sym[typeName] = &symbol{kind: typeSym, typ: &itype{name: typeName, path: rpath, incomplete: true, node: rtn, scope: sc}}
+						sc.sym[typeName] = &symbol{kind: typeSym, typ: &itype{name: typeName, path: importPath, incomplete: true, node: rtn, scope: sc}}
 						rcvrtype = sc.sym[typeName].typ
 					}
 				}
@@ -254,12 +254,12 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 			}
 
 			if n.child[1].kind == identExpr {
-				n.typ = &itype{cat: aliasT, val: typ, name: typeName, path: rpath, field: typ.field, incomplete: typ.incomplete, scope: sc, node: n.child[0]}
+				n.typ = &itype{cat: aliasT, val: typ, name: typeName, path: importPath, field: typ.field, incomplete: typ.incomplete, scope: sc, node: n.child[0]}
 				copy(n.typ.method, typ.method)
 			} else {
 				n.typ = typ
 				n.typ.name = typeName
-				n.typ.path = rpath
+				n.typ.path = importPath
 			}
 
 			asImportName := filepath.Join(typeName, baseName)


### PR DESCRIPTION
When running GTA, the type `path` was set to `rpath`. This equates to the package path (`github.com/traefik/yaegi`) in most cases. In the vendored case the `rpath` is the sub package path `something/vendor/github.com/traefik/yaegi` causing issues in typecheck and likely further down the line. By using the `importPath` it makes this consistent.

**Note:** I have no clue how to test this decently. I am open to options here.

Potentially Fixes #916 