### PR TITLE
interp: fix getting unsigned constant value

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -82,6 +82,16 @@ func TestEvalShift(t *testing.T) {
 	})
 }
 
+func TestOpVarConst(t *testing.T) {
+	i := interp.New(interp.Options{})
+	runTests(t, i, []testCase{
+		{pre: func() { eval(t, i, "const a uint = 8 + 2") }, src: "a", res: "10"},
+		{src: "b := uint(5); a+b", res: "15"},
+		{src: "b := uint(5); b+a", res: "15"},
+		{src: "b := uint(5); b>a", res: "false"},
+	})
+}
+
 func TestEvalStar(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{

--- a/interp/value.go
+++ b/interp/value.go
@@ -342,6 +342,10 @@ func vInt(v reflect.Value) (i int64) {
 }
 
 func vUint(v reflect.Value) (i uint64) {
+	if c := vConstantValue(v); c != nil {
+		i, _ = constant.Uint64Val(constant.ToInt(c))
+		return i
+	}
 	switch v.Type().Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		i = uint64(v.Int())


### PR DESCRIPTION
The function vUint, used to get the unsigned integer value of a value,
variable (frame) or constant, was broken for constant.Value expression.

Fixes #948.