### PR TITLE
interp: fix type check on function signature

### DIFF
--- a/_test/time14.go
+++ b/_test/time14.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+var t time.Time
+
+func f() time.Time {
+	time := t
+	return time
+}
+
+func main() {
+	fmt.Println(f())
+}
+
+// Output:
+// 0001-01-01 00:00:00 +0000 UTC

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1381,7 +1381,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 			n.val = sc.def
 			for i, c := range n.child {
 				var typ *itype
-				typ, err = nodeType(interp, sc, returnSig.child[1].fieldType(i))
+				typ, err = nodeType(interp, global(sc), returnSig.child[1].fieldType(i))
 				if err != nil {
 					return
 				}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1381,7 +1381,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 			n.val = sc.def
 			for i, c := range n.child {
 				var typ *itype
-				typ, err = nodeType(interp, global(sc), returnSig.child[1].fieldType(i))
+				typ, err = nodeType(interp, sc.upperLevel(), returnSig.child[1].fieldType(i))
 				if err != nil {
 					return
 				}

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -113,9 +113,9 @@ func (s *scope) pop() *scope {
 	return s.anc
 }
 
-// global returns the global scope from the current one.
-func global(s *scope) *scope {
-	for s != nil && !s.global {
+func (s *scope) upperLevel() *scope {
+	level := s.level
+	for s != nil && s.level == level {
 		s = s.anc
 	}
 	return s

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -113,6 +113,14 @@ func (s *scope) pop() *scope {
 	return s.anc
 }
 
+// global returns the global scope from the current one.
+func global(s *scope) *scope {
+	for s != nil && !s.global {
+		s = s.anc
+	}
+	return s
+}
+
 // lookup searches for a symbol in the current scope, and upper ones if not found
 // it returns the symbol, the number of indirections level from the current scope
 // and status (false if no result).


### PR DESCRIPTION
Perform function declaration type check from the upper level scope (the scope where the
function is declared), to avoid possible collisions of local variables with package names.

Fixes #957.