### PR TITLE
fix: do not confuse function call with type conversion

### DIFF
--- a/_test/fun26.go
+++ b/_test/fun26.go
@@ -1,0 +1,17 @@
+package main
+
+type F func() (int, error)
+
+func f1() (int, error) { return 3, nil }
+
+func f2(a string, f F) {
+	c, _ := f()
+	println(a, c)
+}
+
+func main() {
+	f2("hello", F(f1))
+}
+
+// Output:
+// hello 3

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2333,7 +2333,7 @@ func isCall(n *node) bool {
 }
 
 func isBinCall(n *node) bool {
-	return n.kind == callExpr && n.child[0].typ.cat == valueT && n.child[0].typ.rtype.Kind() == reflect.Func
+	return isCall(n) && n.child[0].typ.cat == valueT && n.child[0].typ.rtype.Kind() == reflect.Func
 }
 
 func mustReturnValue(n *node) bool {
@@ -2349,7 +2349,7 @@ func mustReturnValue(n *node) bool {
 }
 
 func isRegularCall(n *node) bool {
-	return n.kind == callExpr && n.child[0].typ.cat == funcT
+	return isCall(n) && n.child[0].typ.cat == funcT
 }
 
 func variadicPos(n *node) int {


### PR DESCRIPTION
Use node action to better discriminate between function call and type
conversion which have the same pattern at AST level.

Fixes #960.