### PR TITLE
test: chdir to package directory prior to launch tests

### DIFF
--- a/cmd/yaegi/test.go
+++ b/cmd/yaegi/test.go
@@ -103,10 +103,19 @@ func test(arg []string) (err error) {
 	testing.Init()
 	os.Args = tf
 	flag.Parse()
+	path += string(filepath.Separator)
+	var dir string
 
-	if err = os.Chdir(filepath.Join(build.Default.GOPATH, "src", path)); err != nil {
+	switch strings.Split(path, string(filepath.Separator))[0] {
+	case ".", "..", string(filepath.Separator):
+		dir = path
+	default:
+		dir = filepath.Join(build.Default.GOPATH, "src", path)
+	}
+	if err = os.Chdir(dir); err != nil {
 		return err
 	}
+
 	i := interp.New(interp.Options{GoPath: build.Default.GOPATH, BuildTags: strings.Split(tags, ",")})
 	i.Use(stdlib.Symbols)
 	i.Use(interp.Symbols)

--- a/cmd/yaegi/test.go
+++ b/cmd/yaegi/test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go/build"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -103,6 +104,9 @@ func test(arg []string) (err error) {
 	os.Args = tf
 	flag.Parse()
 
+	if err = os.Chdir(filepath.Join(build.Default.GOPATH, "src", path)); err != nil {
+		return err
+	}
 	i := interp.New(interp.Options{GoPath: build.Default.GOPATH, BuildTags: strings.Split(tags, ",")})
 	i.Use(stdlib.Symbols)
 	i.Use(interp.Symbols)


### PR DESCRIPTION
Because this is what `go test` does, and some packages depend on that,
for example `github.com/jjcollinge/servicefabric`.