### PR TITLE
interp: fix method lookup on aliased types

### DIFF
--- a/_test/time15.go
+++ b/_test/time15.go
@@ -1,0 +1,15 @@
+package main
+
+import "time"
+
+type TimeValue time.Time
+
+func (v *TimeValue) decode() { println("in decode") }
+
+func main() {
+	var tv TimeValue
+	tv.decode()
+}
+
+// Output:
+// in decode

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -415,9 +415,10 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				return false
 			}
 
-			if n.child[1].kind == identExpr {
+			switch n.child[1].kind {
+			case identExpr, selectorExpr:
 				n.typ = &itype{cat: aliasT, val: typ, name: typeName}
-			} else {
+			default:
 				n.typ = typ
 				n.typ.name = typeName
 			}

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -253,10 +253,11 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 				return false
 			}
 
-			if n.child[1].kind == identExpr {
+			switch n.child[1].kind {
+			case identExpr, selectorExpr:
 				n.typ = &itype{cat: aliasT, val: typ, name: typeName, path: importPath, field: typ.field, incomplete: typ.incomplete, scope: sc, node: n.child[0]}
 				copy(n.typ.method, typ.method)
-			} else {
+			default:
 				n.typ = typ
 				n.typ.name = typeName
 				n.typ.path = importPath

--- a/interp/type.go
+++ b/interp/type.go
@@ -557,7 +557,8 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			if v, ok := pkg[name]; ok {
 				t.cat = valueT
 				t.rtype = v.Type()
-				if isBinType(v) { // a bin type is encoded as a pointer on nil value
+				if isBinType(v) {
+					// A bin type is encoded as a pointer on a typed nil value.
 					t.rtype = t.rtype.Elem()
 				}
 			} else {
@@ -736,7 +737,7 @@ func (t *itype) finalize() (*itype, error) {
 }
 
 // ReferTo returns true if the type contains a reference to a
-// full type name. It allows to asses a type recursive status.
+// full type name. It allows to assess a type recursive status.
 func (t *itype) referTo(name string, seen map[*itype]bool) bool {
 	if t.path+"/"+t.name == name {
 		return true


### PR DESCRIPTION
In aliased type declarations, when the target type was imported from
an external package rather than declared locally, the aliased type was
overwritten by target, loosing ability to lookup methods on the aliased
type. Aliasing on imported types is now properly detected and handled.

Fixes #971.