### PR TITLE
interp: remove incorrect type check on array object

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -445,19 +445,15 @@ func TestEvalSliceExpression(t *testing.T) {
 		{src: `a := []int{0,1,2}[:]`, res: "[0 1 2]"},
 		{src: `a := []int{0,1,2,3}[1:3:4]`, res: "[1 2]"},
 		{src: `a := []int{0,1,2,3}[:3:4]`, res: "[0 1 2]"},
-		{src: `ar := [3]int{0,1,2}
-			   a := ar[1:3]`, res: "[1 2]"},
+		{src: `ar := [3]int{0,1,2}; a := ar[1:3]`, res: "[1 2]"},
 		{src: `a := (&[3]int{0,1,2})[1:3]`, res: "[1 2]"},
 		{src: `a := (&[3]int{0,1,2})[1:3]`, res: "[1 2]"},
 		{src: `s := "hello"[1:3]`, res: "el"},
-		{src: `str := "hello"
-			   s := str[1:3]`, res: "el"},
+		{src: `str := "hello"; s := str[1:3]`, res: "el"},
 		{src: `a := int(1)[0:1]`, err: "1:33: cannot slice type int"},
-		{src: `a := ([3]int{0,1,2})[1:3]`, err: "1:33: cannot slice type [3]int"},
 		{src: `a := (&[]int{0,1,2,3})[1:3]`, err: "1:33: cannot slice type *[]int"},
 		{src: `a := "hello"[1:3:4]`, err: "1:45: invalid operation: 3-index slice of string"},
-		{src: `ar := [3]int{0,1,2}
-			   a := ar[:4]`, err: "2:16: index int is out of bounds"},
+		{src: `ar := [3]int{0,1,2}; a := ar[:4]`, err: "1:58: index int is out of bounds"},
 		{src: `a := []int{0,1,2,3}[1::4]`, err: "1:49: 2nd index required in 3-index slice"},
 		{src: `a := []int{0,1,2,3}[1:3:]`, err: "1:51: 3rd index required in 3-index slice"},
 		{src: `a := []int{0,1,2}[3:1]`, err: "invalid index values, must be low <= high <= max"},

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -499,9 +499,7 @@ func (check typecheck) sliceExpr(n *node) error {
 	case reflect.Array:
 		valid = true
 		l = t.Len()
-		if c.kind != indexExpr && c.kind != selectorExpr && (c.sym == nil || c.sym.kind != varSym) {
-			return c.cfgErrorf("cannot slice type %s", c.typ.id())
-		}
+		// TODO(marc): check addressable status of array object (i.e. composite arrays are not).
 	case reflect.Slice:
 		valid = true
 	case reflect.Ptr:


### PR DESCRIPTION
The type check was generating false negatives. A correct test to check the
adressable status of an array is more complex to implement, and will
be done later.

Fixes #973.