### PR TITLE
interp: fix and refactor typeAssertStatus in

### DIFF
--- a/_test/assert0.go
+++ b/_test/assert0.go
@@ -48,6 +48,14 @@ func main() {
 	bType := reflect.TypeOf(TestStruct{})
 	fmt.Println(bType.Implements(aType))
 
+	// not redundant with the above, because it goes through a slightly different code path.
+	if _, ok := t.(MyWriter); !ok {
+		fmt.Println("TestStruct does not implement MyWriter")
+		return
+	} else {
+		fmt.Println("TestStruct implements MyWriter")
+	}
+
 	t = 42
 	foo, ok := t.(MyWriter)
 	if !ok {
@@ -56,6 +64,12 @@ func main() {
 		fmt.Println("42 implements MyWriter")
 	}
 	_ = foo
+
+	if _, ok := t.(MyWriter); !ok {
+		fmt.Println("42 does not implement MyWriter")
+	} else {
+		fmt.Println("42 implements MyWriter")
+	}
 
 	var tt interface{}
 	tt = time.Nanosecond
@@ -72,6 +86,12 @@ func main() {
 	dType := reflect.TypeOf(time.Nanosecond)
 	fmt.Println(dType.Implements(cType))
 
+	if _, ok := tt.(MyStringer); !ok {
+		fmt.Println("time.Nanosecond does not implement MyStringer")
+	} else {
+		fmt.Println("time.Nanosecond implements MyStringer")
+	}
+
 	tt = 42
 	bar, ok := tt.(MyStringer)
 	if !ok {
@@ -81,6 +101,11 @@ func main() {
 	}
 	_ = bar
 
+	if _, ok := tt.(MyStringer); !ok {
+		fmt.Println("42 does not implement MyStringer")
+	} else {
+		fmt.Println("42 implements MyStringer")
+	}
 }
 
 // Output:
@@ -88,9 +113,13 @@ func main() {
 // 11
 // 11
 // true
+// TestStruct implements MyWriter
+// 42 does not implement MyWriter
 // 42 does not implement MyWriter
 // time.Nanosecond implements MyStringer
 // 1ns
 // 1ns
 // true
+// time.Nanosecond implements MyStringer
+// 42 does not implement MyStringer
 // 42 does not implement MyStringer

--- a/_test/assert1.go
+++ b/_test/assert1.go
@@ -27,6 +27,13 @@ func main() {
 	bType := reflect.TypeOf(time.Nanosecond)
 	fmt.Println(bType.Implements(aType))
 
+	// not redundant with the above, because it goes through a slightly different code path.
+	if _, ok := t.(fmt.Stringer); !ok {
+		fmt.Println("time.Nanosecond does not implement fmt.Stringer")
+		return
+	} else {
+		fmt.Println("time.Nanosecond implements fmt.Stringer")
+	}
 
 	t = 42
 	foo, ok := t.(fmt.Stringer)
@@ -34,8 +41,16 @@ func main() {
 		fmt.Println("42 does not implement fmt.Stringer")
 	} else {
 		fmt.Println("42 implements fmt.Stringer")
+		return
 	}
 	_ = foo
+
+	if _, ok := t.(fmt.Stringer); !ok {
+		fmt.Println("42 does not implement fmt.Stringer")
+	} else {
+		fmt.Println("42 implements fmt.Stringer")
+		return
+	}
 
 	var tt interface{}
 	tt = TestStruct{}
@@ -49,12 +64,22 @@ func main() {
 	// TODO(mpl): uncomment when fixed
 	// cType := reflect.TypeOf(TestStruct{})
 	// fmt.Println(cType.Implements(aType))
+
+	if _, ok := tt.(fmt.Stringer); !ok {
+		fmt.Println("TestStuct does not implement fmt.Stringer")
+		return
+	} else {
+		fmt.Println("TestStuct implements fmt.Stringer")
+	}
 }
 
 // Output:
 // 1ns
 // 1ns
 // true
+// time.Nanosecond implements fmt.Stringer
+// 42 does not implement fmt.Stringer
 // 42 does not implement fmt.Stringer
 // hello world
 // hello world
+// TestStuct implements fmt.Stringer

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -648,7 +648,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				if n.child[0].ident == "_" {
 					lc.gen = typeAssertStatus
 				} else {
-					lc.gen = typeAssert2
+					lc.gen = typeAssertLong
 				}
 				n.gen = nop
 			case unaryExpr:
@@ -1903,7 +1903,7 @@ func compDefineX(sc *scope, n *node) error {
 		if n.child[0].ident == "_" {
 			n.child[l].gen = typeAssertStatus
 		} else {
-			n.child[l].gen = typeAssert2
+			n.child[l].gen = typeAssertLong
 		}
 		types = append(types, n.child[l].child[1].typ, sc.getType("bool"))
 		n.gen = nop

--- a/interp/run.go
+++ b/interp/run.go
@@ -191,47 +191,6 @@ func runCfg(n *node, f *frame) {
 	}
 }
 
-/*
-func typeAssertStatus(n *node) {
-	c0, c1 := n.child[0], n.child[1]   // cO contains the input value, c1 the type to assert
-	value := genValue(c0)              // input value
-	value1 := genValue(n.anc.child[1]) // returned status
-	rtype := c1.typ.rtype              // type to assert
-	next := getExec(n.tnext)
-
-	switch {
-	case isInterfaceSrc(c1.typ):
-		typ := c1.typ
-		n.exec = func(f *frame) bltn {
-			v, ok := value(f).Interface().(valueInterface)
-			value1(f).SetBool(ok && v.node.typ.implements(typ))
-			return next
-		}
-	case isInterface(c1.typ):
-		n.exec = func(f *frame) bltn {
-			v := value(f)
-			ok := v.IsValid() && canAssertTypes(v.Elem().Type(), rtype)
-			value1(f).SetBool(ok)
-			return next
-		}
-	case c0.typ.cat == valueT || c0.typ.cat == errorT:
-		n.exec = func(f *frame) bltn {
-			v := value(f)
-			ok := v.IsValid() && canAssertTypes(v.Elem().Type(), rtype)
-			value1(f).SetBool(ok)
-			return next
-		}
-	default:
-		n.exec = func(f *frame) bltn {
-			v, ok := value(f).Interface().(valueInterface)
-			ok = ok && v.value.IsValid() && canAssertTypes(v.value.Type(), rtype)
-			value1(f).SetBool(ok)
-			return next
-		}
-	}
-}
-*/
-
 func stripReceiverFromArgs(signature string) (string, error) {
 	fields := receiverStripperRxp.FindStringSubmatch(signature)
 	if len(fields) < 5 {


### PR DESCRIPTION
typeAssertStatus deals with the 3rd form of type assertion ("_, ok"), for
when one does not care about the result of the assertion itself.
Some cases for it, which are already fixed for the two other forms of
type assertions, had not been fixed for this form yet.

Therefore, this change fixes such cases for this form, while integrating
typeAssertStatus to the same code path as for the two other forms.