### PR TITLE
interp: fix handling interface types in wrapped functions

### DIFF
--- a/_test/interface47.go
+++ b/_test/interface47.go
@@ -1,0 +1,32 @@
+package main
+
+type Doer interface {
+	Do() error
+}
+
+type T struct {
+	Name string
+}
+
+func (t *T) Do() error { println("in do"); return nil }
+
+func f() (Doer, error) { return &T{"truc"}, nil }
+
+type Ev struct {
+	doer func() (Doer, error)
+}
+
+func (e *Ev) do() {
+	d, _ := e.doer()
+	d.Do()
+}
+
+func main() {
+	e := &Ev{f}
+	println(e != nil)
+	e.do()
+}
+
+// Output:
+// true
+// in do

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1878,8 +1878,12 @@ func compDefineX(sc *scope, n *node) error {
 		if err != nil {
 			return err
 		}
+		for funtype.cat == valueT && funtype.val != nil {
+			// Retrieve original interpreter type from a wrapped function.
+			funtype = funtype.val
+		}
 		if funtype.cat == valueT {
-			// Handle functions imported from runtime
+			// Handle functions imported from runtime.
 			for i := 0; i < funtype.rtype.NumOut(); i++ {
 				types = append(types, &itype{cat: valueT, rtype: funtype.rtype.Out(i)})
 			}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1880,6 +1880,9 @@ func compDefineX(sc *scope, n *node) error {
 		}
 		for funtype.cat == valueT && funtype.val != nil {
 			// Retrieve original interpreter type from a wrapped function.
+			// Struct fields of function types are always wrapped in valueT to ensure
+			// their possible use in runtime. In that case, the val field retains the
+			// original interpreter type, which is used now.
 			funtype = funtype.val
 		}
 		if funtype.cat == valueT {

--- a/interp/value.go
+++ b/interp/value.go
@@ -297,6 +297,17 @@ func genValueOutput(n *node, t reflect.Type) func(*frame) reflect.Value {
 	return value
 }
 
+func valueInterfaceValue(v reflect.Value) reflect.Value {
+	for {
+		vv, ok := v.Interface().(valueInterface)
+		if !ok {
+			break
+		}
+		v = vv.value
+	}
+	return v
+}
+
 func genValueInterfaceValue(n *node) func(*frame) reflect.Value {
 	value := genValue(n)
 
@@ -307,7 +318,7 @@ func genValueInterfaceValue(n *node) func(*frame) reflect.Value {
 			v.Set(zeroInterfaceValue())
 			v = value(f)
 		}
-		return v.Interface().(valueInterface).value
+		return valueInterfaceValue(v)
 	}
 }
 


### PR DESCRIPTION
The interpreter interface type was replaced by a reflect.Value in
objects passed or return to function wrappers, losing the ability
to retrieve methods.

The valueInterface is now preserved, and correctly accessed if
wrapped multiple times.

Fixes #977.