### PR TITLE
interp: fix memory handling of global values

### DIFF
--- a/_test/issue-993.go
+++ b/_test/issue-993.go
@@ -1,0 +1,15 @@
+package main
+
+var m map[string]int64
+
+func initVar() {
+	m = make(map[string]int64)
+}
+
+func main() {
+	initVar()
+	println(len(m))
+}
+
+// Output:
+// 0

--- a/_test/var15.go
+++ b/_test/var15.go
@@ -1,0 +1,15 @@
+package main
+
+var a int = 2
+
+func inca() {
+	a = a + 1
+}
+
+func main() {
+	inca()
+	println(a)
+}
+
+// Output:
+// 3

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -115,6 +115,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 					sc.sym[c.ident] = &symbol{index: sc.add(n.typ), kind: varSym, global: true, typ: n.typ, node: n}
 					continue
 				}
+				c.level = globalFrame
 
 				// redeclaration error
 				if sym.typ.node != nil && sym.typ.node.anc != nil {

--- a/interp/run.go
+++ b/interp/run.go
@@ -1221,6 +1221,8 @@ func call(n *node) {
 
 func getFrame(f *frame, l int) *frame {
 	switch l {
+	case globalFrame:
+		return f.root
 	case 0:
 		return f
 	case 1:

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -130,6 +130,9 @@ func (s *scope) lookup(ident string) (*symbol, int, bool) {
 	level := s.level
 	for {
 		if sym, ok := s.sym[ident]; ok {
+			if sym.global {
+				return sym, globalFrame, true
+			}
 			return sym, level - s.level, true
 		}
 		if s.anc == nil {


### PR DESCRIPTION
In some cases, the global character of a value was lost, leading to
undefined behaviour. Now a node level field of -1 means that the value
is global, and that it should be accessed from the root data frame.

Fixes #993.