### PR TITLE
chore: rename github to tap, following goreleaser deprecation notice

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,7 +47,7 @@ archives:
       - LICENSE
 
 brews:
-  - github:
+  - tap:
       owner: traefik
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
The release of v0.9.9 failed, due to
https://goreleaser.com/deprecations/#brewsgithub.