### PR TITLE
interp: parse circular interface definitions

### DIFF
--- a/_test/interface48.go
+++ b/_test/interface48.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+type I1 interface{ A }
+
+type A = I2
+
+type I2 interface{ F() I1 }
+
+func main() {
+	var i I1
+	fmt.Println(i)
+}
+
+// Output:
+// <nil>

--- a/_test/interface49.go
+++ b/_test/interface49.go
@@ -1,0 +1,45 @@
+package main
+
+type Descriptor interface {
+	ParentFile() FileDescriptor
+}
+
+type FileDescriptor interface {
+	Enums() EnumDescriptors
+	Services() ServiceDescriptors
+}
+
+type EnumDescriptors interface {
+	Get(i int) EnumDescriptor
+}
+
+type EnumDescriptor interface {
+	Values() EnumValueDescriptors
+}
+
+type EnumValueDescriptors interface {
+	Get(i int) EnumValueDescriptor
+}
+
+type EnumValueDescriptor interface {
+	Descriptor
+}
+
+type ServiceDescriptors interface {
+	Get(i int) ServiceDescriptor
+}
+
+type ServiceDescriptor interface {
+	Descriptor
+	isServiceDescriptor
+}
+
+type isServiceDescriptor interface{ ProtoType(ServiceDescriptor) }
+
+func main() {
+	var d Descriptor
+	println(d == nil)
+}
+
+// Output:
+// true

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -319,7 +319,56 @@ func (interp *Interpreter) gtaRetry(nodes []*node, importPath string) error {
 	}
 
 	if len(revisit) > 0 {
-		return revisit[0].cfgErrorf("constant definition loop")
+		for _, n := range revisit {
+			if n.kind == typeSpec {
+				if err := definedType(n.typ); err != nil {
+					return err
+				}
+			}
+		}
+		switch revisit[0].kind {
+		case typeSpec:
+			return revisit[0].cfgErrorf("incomplete type definition: %s", revisit[0].typ.name)
+		default:
+			return revisit[0].cfgErrorf("constant definition loop")
+		}
+	}
+	return nil
+}
+
+func definedType(typ *itype) error {
+	if !typ.incomplete {
+		return nil
+	}
+	switch typ.cat {
+	case interfaceT, structT:
+		for _, f := range typ.field {
+			if err := definedType(f.typ); err != nil {
+				return err
+			}
+		}
+	case funcT:
+		for _, t := range typ.arg {
+			if err := definedType(t); err != nil {
+				return err
+			}
+		}
+		for _, t := range typ.ret {
+			if err := definedType(t); err != nil {
+				return err
+			}
+		}
+	case mapT:
+		if err := definedType(typ.key); err != nil {
+			return err
+		}
+		fallthrough
+	case aliasT, arrayT, chanT, chanSendT, chanRecvT, ptrT, variadicT:
+		if err := definedType(typ.val); err != nil {
+			return err
+		}
+	case nilT:
+		return typ.node.cfgErrorf("undefined: %s", typ.node.ident)
 	}
 	return nil
 }

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -319,19 +319,13 @@ func (interp *Interpreter) gtaRetry(nodes []*node, importPath string) error {
 	}
 
 	if len(revisit) > 0 {
-		for _, n := range revisit {
-			if n.kind == typeSpec {
-				if err := definedType(n.typ); err != nil {
-					return err
-				}
+		n := revisit[0]
+		if n.kind == typeSpec {
+			if err := definedType(n.typ); err != nil {
+				return err
 			}
 		}
-		switch revisit[0].kind {
-		case typeSpec:
-			return revisit[0].cfgErrorf("incomplete type definition: %s", revisit[0].typ.name)
-		default:
-			return revisit[0].cfgErrorf("constant definition loop")
-		}
+		return n.cfgErrorf("constant definition loop")
 	}
 	return nil
 }

--- a/interp/type.go
+++ b/interp/type.go
@@ -882,7 +882,7 @@ func isComplete(t *itype, visited map[string]bool) bool {
 	}
 	name := t.path + "/" + t.name
 	if visited[name] {
-		return !t.incomplete
+		return true
 	}
 	if t.name != "" {
 		visited[name] = true
@@ -908,7 +908,7 @@ func isComplete(t *itype, visited map[string]bool) bool {
 	case interfaceT, structT:
 		complete := true
 		for _, f := range t.field {
-			// Fiedld implicit type names must be marked as visited, to break false circles.
+			// Field implicit type names must be marked as visited, to break false circles.
 			visited[f.typ.path+"/"+f.typ.name] = true
 			complete = complete && isComplete(f.typ, visited)
 		}

--- a/interp/type.go
+++ b/interp/type.go
@@ -889,7 +889,7 @@ func isComplete(t *itype, visited map[string]bool) bool {
 	}
 	switch t.cat {
 	case aliasT:
-		if t.val != nil && t.val.incomplete && t.val.cat != nilT {
+		if t.val != nil && t.val.cat != nilT {
 			// A type aliased to a partially defined type is considered complete, to allow recursivity.
 			return true
 		}


### PR DESCRIPTION
An undefined type detection function has been added to better diagnose
incomplete type definitions. Implicit type names in interface or struct
declarations are now better handled. The incomplete status is not
fowarded to aliased type declarations to handle circular definitions.

Fixes #999 and #995. Improves #260 (goes farther, but still fails).