### PR TITLE
interp: fix detection of type recursivity

### DIFF
--- a/_test/issue-1007.go
+++ b/_test/issue-1007.go
@@ -1,0 +1,40 @@
+package main
+
+type TypeA struct {
+	B TypeB
+}
+
+type TypeB struct {
+	C1 *TypeC
+	C2 *TypeC
+}
+
+type TypeC struct {
+	Val string
+	D   *TypeD
+	D2  *TypeD
+}
+
+type TypeD struct {
+	Name string
+}
+
+func build() *TypeA {
+	return &TypeA{
+		B: TypeB{
+			C2: &TypeC{Val: "22"},
+		},
+	}
+}
+
+func Bar(s string) string {
+	a := build()
+	return s + "-" + a.B.C2.Val
+}
+
+func main() {
+	println(Bar("test"))
+}
+
+// Output:
+// test-22

--- a/interp/type.go
+++ b/interp/type.go
@@ -1551,7 +1551,7 @@ func hasRecursiveStruct(t *itype, defined map[string]*itype) bool {
 		defined[typ.path+"/"+typ.name] = typ
 
 		for _, f := range typ.field {
-			if hasRecursiveStruct(f.typ, defined) {
+			if hasRecursiveStruct(f.typ, copyDefined(defined)) {
 				return true
 			}
 		}


### PR DESCRIPTION
If a struct contains several fields of the same temporary incomplete
type, it could be detected incorrectly as a recursive struct. Pass
a copy of defined types map to avoid this issue.

Fixes #1007.