### PR TITLE
interp: fix map assignment from arithmetic operations

### DIFF
--- a/_test/issue-981.go
+++ b/_test/issue-981.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func main() {
+	dp := make(map[int]int)
+	dp[0] = 1
+	for i := 1; i < 10; i++ {
+		dp[i] = dp[i-1] + dp[i-2]
+	}
+	fmt.Printf("%v\n", dp)
+}
+
+// Output:
+// map[0:1 1:1 2:2 3:3 4:5 5:8 6:13 7:21 8:34 9:55]

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -567,8 +567,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					break
 				case isMapEntry(dest):
 					// Setting a map entry needs an additional step, do not optimize.
-					// But, as we only write, skip the default getIndexMap dest action
-					// used for reading a map entry, useless here.
+					// As we only write, skip the default useless getIndexMap dest action.
 					dest.gen = nop
 					break
 				case isCall(src) && dest.typ.cat != interfaceT && !isRecursiveField(dest):
@@ -591,9 +590,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					}
 					if dest.action == aGetIndex {
 						// Optimization does not work when assigning to a struct field.
-						// Maybe we're not setting the right frame index or something,
-						// and we would end up not writing at the right place.
-						// So disabling it for now.
 						break
 					}
 					n.gen = nop

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -564,12 +564,11 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				//
 				switch {
 				case n.action != aAssign:
-					// Skip assign combined with another operator
+					// Do not optimize assign combined with another operator.
 				case isMapEntry(dest):
 					// Setting a map entry needs an additional step, do not optimize.
 					// As we only write, skip the default useless getIndexMap dest action.
 					dest.gen = nop
-					break
 				case isCall(src) && dest.typ.cat != interfaceT && !isRecursiveField(dest):
 					// Call action may perform the assignment directly.
 					n.gen = nop

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -564,7 +564,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				//
 				switch {
 				case n.action != aAssign:
-					break
+					// Skip assign combined with another operator
 				case isMapEntry(dest):
 					// Setting a map entry needs an additional step, do not optimize.
 					// As we only write, skip the default useless getIndexMap dest action.


### PR DESCRIPTION
The logic to trigger assigment optimizations has been refactored for
clarity, and to exclude assignments to map entries.

Fixes #981.