### PR TITLE
interp: allow early constant evaluation from builtin call

### DIFF
--- a/_test/const23.go
+++ b/_test/const23.go
@@ -1,0 +1,12 @@
+package main
+
+const maxlen = len("hello")
+
+var gfm = [maxlen]byte{}
+
+func main() {
+	println(len(gfm))
+}
+
+// Output:
+// 5

--- a/_test/const24.go
+++ b/_test/const24.go
@@ -1,0 +1,14 @@
+package main
+
+var aa = [...]int{1, 2, 3}
+
+const maxlen = cap(aa)
+
+var gfm = [maxlen]byte{}
+
+func main() {
+	println(len(gfm))
+}
+
+// Output:
+// 3

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -876,7 +876,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				case n.anc.kind == returnStmt:
 					// Store result directly to frame output location, to avoid a frame copy.
 					n.findex = 0
-				case bname == "len" && n.child[1].rval.IsValid(): //  && n.anc.action != aAssign:
+				case bname == "len" && n.child[1].rval.IsValid():
 					lenConstString(n)
 					n.findex = notInFrame
 					n.gen = nop

--- a/interp/run.go
+++ b/interp/run.go
@@ -2847,6 +2847,11 @@ func _delete(n *node) {
 	})
 }
 
+func lenConstString(n *node) {
+	n.rval = reflect.New(reflect.TypeOf(int(0))).Elem()
+	n.rval.SetInt(int64(len(vString(n.child[1].rval))))
+}
+
 func _len(n *node) {
 	dest := genValueOutput(n, reflect.TypeOf(int(0)))
 	value := genValue(n.child[1])

--- a/interp/run.go
+++ b/interp/run.go
@@ -2847,9 +2847,19 @@ func _delete(n *node) {
 	})
 }
 
-func lenConstString(n *node) {
+func capConst(n *node) {
 	n.rval = reflect.New(reflect.TypeOf(int(0))).Elem()
-	n.rval.SetInt(int64(len(vString(n.child[1].rval))))
+	// There is no Cap() method for reflect.Type, just return Len() instead.
+	n.rval.SetInt(int64(n.child[1].typ.TypeOf().Len()))
+}
+
+func lenConst(n *node) {
+	n.rval = reflect.New(reflect.TypeOf(int(0))).Elem()
+	if c1 := n.child[1]; c1.rval.IsValid() {
+		n.rval.SetInt(int64(len(vString(c1.rval))))
+	} else {
+		n.rval.SetInt(int64(c1.typ.TypeOf().Len()))
+	}
 }
 
 func _len(n *node) {

--- a/interp/type.go
+++ b/interp/type.go
@@ -198,7 +198,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			if sym.kind != constSym {
 				return nil, c0.cfgErrorf("non-constant array bound %q", c0.ident)
 			}
-			if sym.typ == nil || sym.typ.cat != intT {
+			if sym.typ == nil || sym.typ.cat != intT || !sym.rval.IsValid() {
 				t.incomplete = true
 				break
 			}


### PR DESCRIPTION
One builtin has been identified to be used for constant definition:
len(), with a constant string argument. Add support for this.

Fixes #1012.