### PR TITLE
interp: fix sending object implementing an interface through channel

### DIFF
--- a/_test/issue-1010.go
+++ b/_test/issue-1010.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type MyJsonMarshaler struct{ n int }
+
+func (m MyJsonMarshaler) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`{"num": %d}`, m.n)), nil
+}
+
+func main() {
+	ch := make(chan json.Marshaler, 1)
+	ch <- MyJsonMarshaler{2}
+	m, err := json.Marshal(<-ch)
+	fmt.Println(string(m), err)
+}
+
+// Output:
+// {"num":2} <nil>

--- a/interp/type.go
+++ b/interp/type.go
@@ -1625,6 +1625,10 @@ func isInterfaceSrc(t *itype) bool {
 	return t.cat == interfaceT || (t.cat == aliasT && isInterfaceSrc(t.val))
 }
 
+func isInterfaceBin(t *itype) bool {
+	return t.cat == valueT && t.rtype.Kind() == reflect.Interface
+}
+
 func isInterface(t *itype) bool {
 	return isInterfaceSrc(t) || t.TypeOf() != nil && t.TypeOf().Kind() == reflect.Interface
 }


### PR DESCRIPTION
A channel can be used to interchange data with the pre-compiled
runtime and therefore objects impletementing interfaces must be
wrapped if necessary, using genInterfaceWrapper.

A similar treatment could be applied when sending interpreted
functions over a channel, to be provided in a new PR.

Fixes #1010.