### PR TITLE
fix: untyped check

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2570,11 +2570,7 @@ func isValueUntyped(v reflect.Value) bool {
 	if v.CanSet() {
 		return false
 	}
-	t := v.Type()
-	if t.Implements(constVal) {
-		return true
-	}
-	return t.String() == t.Kind().String()
+	return v.Type().Implements(constVal)
 }
 
 // isArithmeticAction returns true if the node action is an arithmetic operator.

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -103,6 +103,16 @@ func TestEvalStar(t *testing.T) {
 
 func TestEvalAssign(t *testing.T) {
 	i := interp.New(interp.Options{})
+	i.Use(interp.Exports{
+		"testpkg": {
+			"val": reflect.ValueOf(int64(11)),
+		},
+	})
+	_, e := i.Eval(`import "testpkg"`)
+	if e != nil {
+		t.Fatal(e)
+	}
+
 	runTests(t, i, []testCase{
 		{src: `a := "Hello"; a += " world"`, res: "Hello world"},
 		{src: `b := "Hello"; b += 1`, err: "1:42: invalid operation: mismatched types string and int"},
@@ -112,6 +122,7 @@ func TestEvalAssign(t *testing.T) {
 		{src: "g := 1; g <<= 8", res: "256"},
 		{src: "h := 1; h >>= 8", res: "0"},
 		{src: "i := 1; j := &i; (*j) = 2", res: "2"},
+		{src: "i64 := testpkg.val; i64 == 11", res: "true"},
 	})
 }
 


### PR DESCRIPTION
When checking for untyped values, we can be sure at this stage that they must be a const value or already untyped. Checking for type string equality is no longer a good measure.

Fixes #1000 