### PR TITLE
fix: handle function references in composite bin map

### DIFF
--- a/_test/composite17.go
+++ b/_test/composite17.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"html/template"
+)
+
+var str = `{{ stringOr .Data "test" }}`
+
+func main() {
+	_, err := template.New("test").
+		Funcs(template.FuncMap{
+			"stringOr": stringOr,
+		}).
+		Parse(str)
+	if err != nil {
+		println(err.Error())
+		return
+	}
+	println("success")
+}
+
+func stringOr(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+// Output:
+// success

--- a/interp/run.go
+++ b/interp/run.go
@@ -2220,7 +2220,12 @@ func compositeBinMap(n *node) {
 		convertLiteralValue(c.child[0], typ.Key())
 		convertLiteralValue(c.child[1], typ.Elem())
 		keys[i] = genValue(c.child[0])
-		values[i] = genValue(c.child[1])
+
+		if c.child[1].typ.cat == funcT {
+			values[i] = genFunctionWrapper(c.child[1])
+		} else {
+			values[i] = genValue(c.child[1])
+		}
 	}
 
 	n.exec = func(f *frame) bltn {


### PR DESCRIPTION
When passing a function reference as an interface in a composite binary map, the case should be handled to not take the value of the the node.

Related to #886