### PR TITLE
interp: fix nil value check in case of interface

### DIFF
--- a/_test/issue-1022.go
+++ b/_test/issue-1022.go
@@ -5,7 +5,7 @@ import "fmt"
 func main() {
 	defer func() {
 		r := recover()
-		if r != nil { // <- panic here
+		if r != nil {
 			fmt.Println(r)
 		}
 	}()

--- a/_test/issue-1022.go
+++ b/_test/issue-1022.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+func main() {
+	defer func() {
+		r := recover()
+		if r != nil { // <- panic here
+			fmt.Println(r)
+		}
+	}()
+
+	panic("Ho Ho Ho!")
+}
+
+// Output:
+// Ho Ho Ho!

--- a/interp/run.go
+++ b/interp/run.go
@@ -3432,7 +3432,6 @@ func isNil(n *node) {
 		dest(f).SetBool(false)
 		return fnext
 	}
-
 }
 
 func isNotNil(n *node) {

--- a/interp/run.go
+++ b/interp/run.go
@@ -3381,47 +3381,58 @@ func isNil(n *node) {
 	tnext := getExec(n.tnext)
 	dest := genValue(n)
 
-	if n.fnext != nil {
-		fnext := getExec(n.fnext)
-		if c0.typ.cat == interfaceT {
-			n.exec = func(f *frame) bltn {
-				v := value(f)
-				vi, ok := v.Interface().(valueInterface)
-				if ok && (vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT) || v.IsNil() {
-					dest(f).SetBool(true)
-					return tnext
-				}
-				dest(f).SetBool(false)
-				return fnext
-			}
-		} else {
-			n.exec = func(f *frame) bltn {
-				if value(f).IsNil() {
-					dest(f).SetBool(true)
-					return tnext
-				}
-				dest(f).SetBool(false)
-				return fnext
-			}
-		}
-	} else {
-		if c0.typ.cat == interfaceT {
-			n.exec = func(f *frame) bltn {
-				v := value(f)
-				if vi, ok := v.Interface().(valueInterface); ok {
-					dest(f).SetBool(vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT)
-				} else {
-					dest(f).SetBool(v.IsNil())
-				}
-				return tnext
-			}
-		} else {
+	if n.fnext == nil {
+		if c0.typ.cat != interfaceT {
 			n.exec = func(f *frame) bltn {
 				dest(f).SetBool(value(f).IsNil())
 				return tnext
 			}
+			return
 		}
+		n.exec = func(f *frame) bltn {
+			v := value(f)
+			if vi, ok := v.Interface().(valueInterface); ok {
+				dest(f).SetBool(vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT)
+			} else {
+				dest(f).SetBool(v.IsNil())
+			}
+			return tnext
+		}
+		return
 	}
+
+	fnext := getExec(n.fnext)
+
+	if c0.typ.cat != interfaceT {
+		n.exec = func(f *frame) bltn {
+			if value(f).IsNil() {
+				dest(f).SetBool(true)
+				return tnext
+			}
+			dest(f).SetBool(false)
+			return fnext
+		}
+		return
+	}
+
+	n.exec = func(f *frame) bltn {
+		v := value(f)
+		if vi, ok := v.Interface().(valueInterface); ok {
+			if (vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT) {
+				dest(f).SetBool(true)
+				return tnext
+			}
+			dest(f).SetBool(false)
+			return fnext
+		}
+		if v.IsNil() {
+			dest(f).SetBool(true)
+			return tnext
+		}
+		dest(f).SetBool(false)
+		return fnext
+	}
+
 }
 
 func isNotNil(n *node) {
@@ -3435,46 +3446,57 @@ func isNotNil(n *node) {
 	tnext := getExec(n.tnext)
 	dest := genValue(n)
 
-	if n.fnext != nil {
-		fnext := getExec(n.fnext)
-		if c0.typ.cat == interfaceT {
-			n.exec = func(f *frame) bltn {
-				v := value(f)
-				vi, ok := v.Interface().(valueInterface)
-				if ok && (vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT) || v.IsNil() {
-					dest(f).SetBool(false)
-					return fnext
-				}
-				dest(f).SetBool(true)
-				return tnext
-			}
-		} else {
-			n.exec = func(f *frame) bltn {
-				if value(f).IsNil() {
-					dest(f).SetBool(false)
-					return fnext
-				}
-				dest(f).SetBool(true)
-				return tnext
-			}
-		}
-	} else {
-		if c0.typ.cat == interfaceT {
-			n.exec = func(f *frame) bltn {
-				v := value(f)
-				if vi, ok := v.Interface().(valueInterface); ok {
-					dest(f).SetBool(!(vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT))
-				} else {
-					dest(f).SetBool(!v.IsNil())
-				}
-				return tnext
-			}
-		} else {
+	if n.fnext == nil {
+		if c0.typ.cat != interfaceT {
 			n.exec = func(f *frame) bltn {
 				dest(f).SetBool(!value(f).IsNil())
 				return tnext
 			}
+			return
 		}
+
+		n.exec = func(f *frame) bltn {
+			v := value(f)
+			if vi, ok := v.Interface().(valueInterface); ok {
+				dest(f).SetBool(!(vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT))
+			} else {
+				dest(f).SetBool(!v.IsNil())
+			}
+			return tnext
+		}
+		return
+	}
+
+	fnext := getExec(n.fnext)
+
+	if c0.typ.cat != interfaceT {
+		n.exec = func(f *frame) bltn {
+			if value(f).IsNil() {
+				dest(f).SetBool(false)
+				return fnext
+			}
+			dest(f).SetBool(true)
+			return tnext
+		}
+		return
+	}
+
+	n.exec = func(f *frame) bltn {
+		v := value(f)
+		if vi, ok := v.Interface().(valueInterface); ok {
+			if (vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT) {
+				dest(f).SetBool(false)
+				return fnext
+			}
+			dest(f).SetBool(true)
+			return tnext
+		}
+		if v.IsNil() {
+			dest(f).SetBool(false)
+			return fnext
+		}
+		dest(f).SetBool(true)
+		return tnext
 	}
 }
 


### PR DESCRIPTION
A wrong logic was leading to panic in recover. Simplify the
workflow for clarity.

Fixes #1022.