### PR TITLE
interp: fix setting interface objects from operators

### DIFF
--- a/_test/interface50.go
+++ b/_test/interface50.go
@@ -1,0 +1,13 @@
+package main
+
+func main() {
+	a := true
+	var b interface{} = 5
+	println(b.(int))
+	b = a == true
+	println(b.(bool))
+}
+
+// Output:
+// 5
+// true

--- a/internal/cmd/genop/genop.go
+++ b/internal/cmd/genop/genop.go
@@ -193,31 +193,31 @@ func {{$name}}(n *node) {
 	case reflect.Complex64, reflect.Complex128:
 		switch {
 		case isInterface:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
+			v0 := genComplex(c0)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).Set(reflect.ValueOf(v0(f).Complex() {{$op.Name}} v1(f).Complex()).Convert(typ))
+				dest(f).Set(reflect.ValueOf(v0(f) {{$op.Name}} v1(f)).Convert(typ))
 				return next
 			}
 		case c0.rval.IsValid():
 			r0 := vComplex(c0.rval)
-			v1 := genValue(c1)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(r0 {{$op.Name}} v1(f).Complex())
+				dest(f).SetComplex(r0 {{$op.Name}} v1(f))
 				return next
 			}
 		case c1.rval.IsValid():
 			r1 := vComplex(c1.rval)
-			v0 := genValue(c0)
+			v0 := genComplex(c0)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(v0(f).Complex() {{$op.Name}} r1)
+				dest(f).SetComplex(v0(f) {{$op.Name}} r1)
 				return next
 			}
 		default:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
+			v0 := genComplex(c0)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(v0(f).Complex() {{$op.Name}} v1(f).Complex())
+				dest(f).SetComplex(v0(f) {{$op.Name}} v1(f))
 				return next
 			}
 		}

--- a/interp/op.go
+++ b/interp/op.go
@@ -163,31 +163,31 @@ func add(n *node) {
 	case reflect.Complex64, reflect.Complex128:
 		switch {
 		case isInterface:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
+			v0 := genComplex(c0)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).Set(reflect.ValueOf(v0(f).Complex() + v1(f).Complex()).Convert(typ))
+				dest(f).Set(reflect.ValueOf(v0(f) + v1(f)).Convert(typ))
 				return next
 			}
 		case c0.rval.IsValid():
 			r0 := vComplex(c0.rval)
-			v1 := genValue(c1)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(r0 + v1(f).Complex())
+				dest(f).SetComplex(r0 + v1(f))
 				return next
 			}
 		case c1.rval.IsValid():
 			r1 := vComplex(c1.rval)
-			v0 := genValue(c0)
+			v0 := genComplex(c0)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(v0(f).Complex() + r1)
+				dest(f).SetComplex(v0(f) + r1)
 				return next
 			}
 		default:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
+			v0 := genComplex(c0)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(v0(f).Complex() + v1(f).Complex())
+				dest(f).SetComplex(v0(f) + v1(f))
 				return next
 			}
 		}
@@ -549,31 +549,31 @@ func mul(n *node) {
 	case reflect.Complex64, reflect.Complex128:
 		switch {
 		case isInterface:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
+			v0 := genComplex(c0)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).Set(reflect.ValueOf(v0(f).Complex() * v1(f).Complex()).Convert(typ))
+				dest(f).Set(reflect.ValueOf(v0(f) * v1(f)).Convert(typ))
 				return next
 			}
 		case c0.rval.IsValid():
 			r0 := vComplex(c0.rval)
-			v1 := genValue(c1)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(r0 * v1(f).Complex())
+				dest(f).SetComplex(r0 * v1(f))
 				return next
 			}
 		case c1.rval.IsValid():
 			r1 := vComplex(c1.rval)
-			v0 := genValue(c0)
+			v0 := genComplex(c0)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(v0(f).Complex() * r1)
+				dest(f).SetComplex(v0(f) * r1)
 				return next
 			}
 		default:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
+			v0 := genComplex(c0)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(v0(f).Complex() * v1(f).Complex())
+				dest(f).SetComplex(v0(f) * v1(f))
 				return next
 			}
 		}
@@ -829,31 +829,31 @@ func quo(n *node) {
 	case reflect.Complex64, reflect.Complex128:
 		switch {
 		case isInterface:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
+			v0 := genComplex(c0)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).Set(reflect.ValueOf(v0(f).Complex() / v1(f).Complex()).Convert(typ))
+				dest(f).Set(reflect.ValueOf(v0(f) / v1(f)).Convert(typ))
 				return next
 			}
 		case c0.rval.IsValid():
 			r0 := vComplex(c0.rval)
-			v1 := genValue(c1)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(r0 / v1(f).Complex())
+				dest(f).SetComplex(r0 / v1(f))
 				return next
 			}
 		case c1.rval.IsValid():
 			r1 := vComplex(c1.rval)
-			v0 := genValue(c0)
+			v0 := genComplex(c0)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(v0(f).Complex() / r1)
+				dest(f).SetComplex(v0(f) / r1)
 				return next
 			}
 		default:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
+			v0 := genComplex(c0)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(v0(f).Complex() / v1(f).Complex())
+				dest(f).SetComplex(v0(f) / v1(f))
 				return next
 			}
 		}
@@ -1326,31 +1326,31 @@ func sub(n *node) {
 	case reflect.Complex64, reflect.Complex128:
 		switch {
 		case isInterface:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
+			v0 := genComplex(c0)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).Set(reflect.ValueOf(v0(f).Complex() - v1(f).Complex()).Convert(typ))
+				dest(f).Set(reflect.ValueOf(v0(f) - v1(f)).Convert(typ))
 				return next
 			}
 		case c0.rval.IsValid():
 			r0 := vComplex(c0.rval)
-			v1 := genValue(c1)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(r0 - v1(f).Complex())
+				dest(f).SetComplex(r0 - v1(f))
 				return next
 			}
 		case c1.rval.IsValid():
 			r1 := vComplex(c1.rval)
-			v0 := genValue(c0)
+			v0 := genComplex(c0)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(v0(f).Complex() - r1)
+				dest(f).SetComplex(v0(f) - r1)
 				return next
 			}
 		default:
-			v0 := genValue(c0)
-			v1 := genValue(c1)
+			v0 := genComplex(c0)
+			v1 := genComplex(c1)
 			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(v0(f).Complex() - v1(f).Complex())
+				dest(f).SetComplex(v0(f) - v1(f))
 				return next
 			}
 		}

--- a/interp/run.go
+++ b/interp/run.go
@@ -2008,11 +2008,11 @@ func neg(n *node) {
 				dest(f).Set(reflect.ValueOf(-value(f).Int()).Convert(typ))
 				return next
 			}
-		} else {
-			n.exec = func(f *frame) bltn {
-				dest(f).SetInt(-value(f).Int())
-				return next
-			}
+			return
+		}
+		n.exec = func(f *frame) bltn {
+			dest(f).SetInt(-value(f).Int())
+			return next
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		if isInterface {
@@ -2020,11 +2020,11 @@ func neg(n *node) {
 				dest(f).Set(reflect.ValueOf(-value(f).Uint()).Convert(typ))
 				return next
 			}
-		} else {
-			n.exec = func(f *frame) bltn {
-				dest(f).SetUint(-value(f).Uint())
-				return next
-			}
+			return
+		}
+		n.exec = func(f *frame) bltn {
+			dest(f).SetUint(-value(f).Uint())
+			return next
 		}
 	case reflect.Float32, reflect.Float64:
 		if isInterface {
@@ -2032,11 +2032,11 @@ func neg(n *node) {
 				dest(f).Set(reflect.ValueOf(-value(f).Float()).Convert(typ))
 				return next
 			}
-		} else {
-			n.exec = func(f *frame) bltn {
-				dest(f).SetFloat(-value(f).Float())
-				return next
-			}
+			return
+		}
+		n.exec = func(f *frame) bltn {
+			dest(f).SetFloat(-value(f).Float())
+			return next
 		}
 	case reflect.Complex64, reflect.Complex128:
 		if isInterface {
@@ -2044,11 +2044,11 @@ func neg(n *node) {
 				dest(f).Set(reflect.ValueOf(-value(f).Complex()).Convert(typ))
 				return next
 			}
-		} else {
-			n.exec = func(f *frame) bltn {
-				dest(f).SetComplex(-value(f).Complex())
-				return next
-			}
+			return
+		}
+		n.exec = func(f *frame) bltn {
+			dest(f).SetComplex(-value(f).Complex())
+			return next
 		}
 	}
 }
@@ -2078,11 +2078,11 @@ func bitNot(n *node) {
 				dest(f).Set(reflect.ValueOf(^value(f).Int()).Convert(typ))
 				return next
 			}
-		} else {
-			n.exec = func(f *frame) bltn {
-				dest(f).SetInt(^value(f).Int())
-				return next
-			}
+			return
+		}
+		n.exec = func(f *frame) bltn {
+			dest(f).SetInt(^value(f).Int())
+			return next
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		if isInterface {
@@ -2090,11 +2090,11 @@ func bitNot(n *node) {
 				dest(f).Set(reflect.ValueOf(^value(f).Uint()).Convert(typ))
 				return next
 			}
-		} else {
-			n.exec = func(f *frame) bltn {
-				dest(f).SetUint(^value(f).Uint())
-				return next
-			}
+			return
+		}
+		n.exec = func(f *frame) bltn {
+			dest(f).SetUint(^value(f).Uint())
+			return next
 		}
 	}
 }
@@ -2124,11 +2124,11 @@ func land(n *node) {
 			dest(f).Set(reflect.ValueOf(value0(f).Bool() && value1(f).Bool()).Convert(typ))
 			return tnext
 		}
-	} else {
-		n.exec = func(f *frame) bltn {
-			dest(f).SetBool(value0(f).Bool() && value1(f).Bool())
-			return tnext
-		}
+		return
+	}
+	n.exec = func(f *frame) bltn {
+		dest(f).SetBool(value0(f).Bool() && value1(f).Bool())
+		return tnext
 	}
 }
 
@@ -2157,11 +2157,11 @@ func lor(n *node) {
 			dest(f).Set(reflect.ValueOf(value0(f).Bool() || value1(f).Bool()).Convert(typ))
 			return tnext
 		}
-	} else {
-		n.exec = func(f *frame) bltn {
-			dest(f).SetBool(value0(f).Bool() || value1(f).Bool())
-			return tnext
-		}
+		return
+	}
+	n.exec = func(f *frame) bltn {
+		dest(f).SetBool(value0(f).Bool() || value1(f).Bool())
+		return tnext
 	}
 }
 
@@ -3631,11 +3631,11 @@ func isNil(n *node) {
 					dest(f).Set(reflect.ValueOf(value(f).IsNil()).Convert(typ))
 					return tnext
 				}
-			} else {
-				n.exec = func(f *frame) bltn {
-					dest(f).SetBool(value(f).IsNil())
-					return tnext
-				}
+				return
+			}
+			n.exec = func(f *frame) bltn {
+				dest(f).SetBool(value(f).IsNil())
+				return tnext
 			}
 			return
 		}
@@ -3651,18 +3651,18 @@ func isNil(n *node) {
 				dest(f).Set(reflect.ValueOf(r).Convert(typ))
 				return tnext
 			}
-		} else {
-			n.exec = func(f *frame) bltn {
-				v := value(f)
-				var r bool
-				if vi, ok := v.Interface().(valueInterface); ok {
-					r = (vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT)
-				} else {
-					r = v.IsNil()
-				}
-				dest(f).SetBool(r)
-				return tnext
+			return
+		}
+		n.exec = func(f *frame) bltn {
+			v := value(f)
+			var r bool
+			if vi, ok := v.Interface().(valueInterface); ok {
+				r = (vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT)
+			} else {
+				r = v.IsNil()
 			}
+			dest(f).SetBool(r)
+			return tnext
 		}
 		return
 	}
@@ -3720,11 +3720,11 @@ func isNotNil(n *node) {
 					dest(f).Set(reflect.ValueOf(!value(f).IsNil()).Convert(typ))
 					return tnext
 				}
-			} else {
-				n.exec = func(f *frame) bltn {
-					dest(f).SetBool(!value(f).IsNil())
-					return tnext
-				}
+				return
+			}
+			n.exec = func(f *frame) bltn {
+				dest(f).SetBool(!value(f).IsNil())
+				return tnext
 			}
 			return
 		}
@@ -3741,18 +3741,18 @@ func isNotNil(n *node) {
 				dest(f).Set(reflect.ValueOf(!r).Convert(typ))
 				return tnext
 			}
-		} else {
-			n.exec = func(f *frame) bltn {
-				v := value(f)
-				var r bool
-				if vi, ok := v.Interface().(valueInterface); ok {
-					r = (vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT)
-				} else {
-					r = v.IsNil()
-				}
-				dest(f).SetBool(!r)
-				return tnext
+			return
+		}
+		n.exec = func(f *frame) bltn {
+			v := value(f)
+			var r bool
+			if vi, ok := v.Interface().(valueInterface); ok {
+				r = (vi == valueInterface{} || vi.node.kind == basicLit && vi.node.typ.cat == nilT)
+			} else {
+				r = v.IsNil()
 			}
+			dest(f).SetBool(!r)
+			return tnext
 		}
 		return
 	}


### PR DESCRIPTION
This is a follow-up of #1017, generalizing the use of reflect.Set
method to set, and possibly overwrite, the concrete value of
interface objects all accross the implementation of operators.
Previous optimized implementation for non-interface objects is
preserved.