### PR TITLE
add support for sandboxes (packages with plugins or extensions)

### DIFF
--- a/interp/src.go
+++ b/interp/src.go
@@ -33,6 +33,8 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 			rPath = "."
 		}
 		dir = filepath.Join(filepath.Dir(interp.name), rPath, importPath)
+	} else if sandboxPath, ok := findSandboxPath(interp.sandboxes, importPath); ok {
+		dir = sandboxPath
 	} else if dir, rPath, err = interp.pkgDir(interp.context.GOPATH, rPath, importPath); err != nil {
 		// Try again, assuming a root dir at the source location.
 		if rPath, err = interp.rootFromSourceLocation(); err != nil {
@@ -306,4 +308,14 @@ func effectivePkg(root, path string) string {
 func isPathRelative(s string) bool {
 	p := "." + string(filepath.Separator)
 	return strings.HasPrefix(s, p) || strings.HasPrefix(s, "."+p)
+}
+
+// checks if given import path belongs to some sandbox
+func findSandboxPath(sandboxes map[string]string, importPath string) (string, bool) {
+	for k, v := range sandboxes {
+		if strings.HasPrefix(importPath, k+"/") {
+			return filepath.Join(v, strings.TrimPrefix(importPath, k+"/")), true
+		}
+	}
+	return "", false
 }


### PR DESCRIPTION
Adds possibility to create a sandboxed dir where plugins/extensions can use/import each other.

For example:
`i := interp.New(interp.Options{
	Sandboxes: map[string]string{
		"ext": "extensions",
	},
})`

From now on it's possible to add packages with logic to "./extensions" dir and to import from a script:
`import "ext/plugin1"`

additionally any extension can import/use code from the other just by importing "ext/plugin2"

Thanks to this structure it's possible to invoke "go mod init ext" in extension directory and we can write extensions with full IDE support.