### PR TITLE
Use fmt.Fprintln instead of fmt.Println in runCfg

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -208,7 +208,7 @@ type Panic struct {
 }
 
 // TODO: Capture interpreter stack frames also and remove
-// fmt.Println(n.cfgErrorf("panic")) in runCfg.
+// fmt.Fprintln(n.interp.stderr, oNode.cfgErrorf("panic")) in runCfg.
 
 func (e Panic) Error() string { return fmt.Sprint(e.Value) }
 

--- a/interp/run.go
+++ b/interp/run.go
@@ -180,7 +180,7 @@ func runCfg(n *node, f *frame) {
 			if oNode == nil {
 				oNode = n
 			}
-			fmt.Println(oNode.cfgErrorf("panic"))
+			fmt.Fprintln(n.interp.stderr, oNode.cfgErrorf("panic"))
 			f.mutex.Unlock()
 			panic(f.recovered)
 		}


### PR DESCRIPTION
As mentioned in #1030, when an Eval panic, it is print with `fmt.Println()` and not to the configured `interp.Options.Stderr`. According to https://github.com/traefik/yaegi/blob/master/interp/interp.go#L210, it should be removed in future version so I'm not sure if this pull request is necessary. However, it could fix the issue in the meanwhile.

Fixes #1030.