### PR TITLE
interp: fix closure in a struct field

### DIFF
--- a/_test/method36.go
+++ b/_test/method36.go
@@ -1,0 +1,26 @@
+package main
+
+type I interface{ Hello() }
+
+type T struct{ Name string }
+
+func (t *T) Hello() { println("Hello", t.Name) }
+
+type FT func(i I)
+
+type ST struct{ Handler FT }
+
+func newF() FT {
+	return func(i I) {
+		i.Hello()
+	}
+}
+
+func main() {
+	st := &ST{}
+	st.Handler = newF()
+	st.Handler(&T{"test"})
+}
+
+// Output:
+// Hello test

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -82,15 +82,8 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					i--
 				}
 				dest := a.child[i]
-				if dest.typ == nil {
-					break
-				}
-				if dest.typ.incomplete {
-					err = n.cfgErrorf("invalid type declaration")
-					return false
-				}
-				if !isInterface(dest.typ) {
-					// Interface types are not propagated, and will be resolved at post-order.
+				if dest.typ != nil && !isInterface(dest.typ) {
+					// Interface type are not propagated, and will be resolved at post-order.
 					n.typ = dest.typ
 				}
 			case binaryExpr, unaryExpr, parenExpr:
@@ -578,6 +571,8 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					// Setting a map entry requires an additional step, do not optimize.
 					// As we only write, skip the default useless getIndexMap dest action.
 					dest.gen = nop
+				case isFuncField(dest):
+					// Setting a struct field of function type requires an extra step. Do not optimize.
 				case isCall(src) && dest.typ.cat != interfaceT && !isRecursiveField(dest) && n.kind != defineStmt:
 					// Call action may perform the assignment directly.
 					n.gen = nop
@@ -2393,6 +2388,10 @@ func isNewDefine(n *node, sc *scope) bool {
 
 func isMethod(n *node) bool {
 	return len(n.child[0].child) > 0 // receiver defined
+}
+
+func isFuncField(n *node) bool {
+	return isField(n) && isFunc(n.typ)
 }
 
 func isMapEntry(n *node) bool {

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -82,7 +82,13 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					i--
 				}
 				dest := a.child[i]
-				if dest.typ != nil && !isInterface(dest.typ) {
+				if dest.typ == nil {
+					break
+				}
+				if dest.typ.incomplete {
+					err = n.cfgErrorf("invalid type declaration")
+				}
+				if !isInterface(dest.typ) {
 					// Interface type are not propagated, and will be resolved at post-order.
 					n.typ = dest.typ
 				}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -87,6 +87,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				}
 				if dest.typ.incomplete {
 					err = n.cfgErrorf("invalid type declaration")
+					return false
 				}
 				if !isInterface(dest.typ) {
 					// Interface type are not propagated, and will be resolved at post-order.

--- a/interp/type.go
+++ b/interp/type.go
@@ -1631,6 +1631,13 @@ func defRecvType(n *node) *itype {
 	return nil
 }
 
+func wrappedType(n *node) *itype {
+	if n.typ.cat != valueT {
+		return nil
+	}
+	return n.typ.val
+}
+
 func isShiftNode(n *node) bool {
 	switch n.action {
 	case aShl, aShr, aShlAssign, aShrAssign:


### PR DESCRIPTION
Functions in a struct fields are always wrapped (as potentially
used by the runtime), so generate a function wrapper also for
closure when assigned to a struct field.

When such a function is called from the interpreter, ensure that
interface arguments are also wrapped so method and receiver resolution
can be performed.

Fixes partially #1043.