### PR TITLE
interp: do not skip use of tmp frame in multi-assign

### DIFF
--- a/_test/issue-1052.go
+++ b/_test/issue-1052.go
@@ -1,0 +1,23 @@
+package main
+
+import "fmt"
+
+func main() {
+	a, b := 1, 1
+	for i := 0; i < 10; i++ {
+		fmt.Println(a)
+		a, b = b, a+b
+	}
+}
+
+// Output:
+// 1
+// 1
+// 2
+// 3
+// 5
+// 8
+// 13
+// 21
+// 34
+// 55

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -733,7 +733,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				// by constOp and available in n.rval. Nothing else to do at execution.
 				n.gen = nop
 				n.findex = notInFrame
-			case n.anc.kind == assignStmt && n.anc.action == aAssign:
+			case n.anc.kind == assignStmt && n.anc.action == aAssign && n.anc.nleft == 1:
 				// To avoid a copy in frame, if the result is to be assigned, store it directly
 				// at the frame location of destination.
 				dest := n.anc.child[childPos(n)-n.anc.nright]


### PR DESCRIPTION
Fixes #1052.