### PR TITLE
interp: allow redeclaration of imports

### DIFF
--- a/interp/gta.go
+++ b/interp/gta.go
@@ -209,8 +209,11 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 					// imports in different source files of the same package. Therefore, we suffix
 					// the key with the basename of the source file.
 					name = filepath.Join(name, baseName)
-					if _, exists := sc.sym[name]; interp.allowRedecl || !exists {
+					if sym, exists := sc.sym[name]; !exists {
 						sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: ipath, scope: sc}}
+						break
+					} else if sym.kind == pkgSym && sym.typ.cat == srcPkgT && sym.typ.path == ipath {
+						// ignore re-import of identical package
 						break
 					}
 
@@ -233,8 +236,11 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 						name = pkgName
 					}
 					name = filepath.Join(name, baseName)
-					if _, exists := sc.sym[name]; interp.allowRedecl || !exists {
+					if sym, exists := sc.sym[name]; !exists {
 						sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: srcPkgT, path: ipath, scope: sc}}
+						break
+					} else if sym.kind == pkgSym && sym.typ.cat == srcPkgT && sym.typ.path == ipath {
+						// ignore re-import of identical package
 						break
 					}
 

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -209,7 +209,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 					// imports in different source files of the same package. Therefore, we suffix
 					// the key with the basename of the source file.
 					name = filepath.Join(name, baseName)
-					if _, exists := sc.sym[name]; !exists {
+					if _, exists := sc.sym[name]; interp.allowRedecl || !exists {
 						sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: ipath, scope: sc}}
 						break
 					}
@@ -233,7 +233,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 						name = pkgName
 					}
 					name = filepath.Join(name, baseName)
-					if _, exists := sc.sym[name]; !exists {
+					if _, exists := sc.sym[name]; interp.allowRedecl || !exists {
 						sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: srcPkgT, path: ipath, scope: sc}}
 						break
 					}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -124,14 +124,13 @@ type opt struct {
 	cfgDot bool // display CFG graph (debug)
 	// dotCmd is the command to process the dot graph produced when astDot and/or
 	// cfgDot is enabled. It defaults to 'dot -Tdot -o <filename>.dot'.
-	dotCmd      string
-	noRun       bool          // compile, but do not run
-	fastChan    bool          // disable cancellable chan operations
-	context     build.Context // build context: GOPATH, build constraints
-	stdin       io.Reader     // standard input
-	stdout      io.Writer     // standard output
-	stderr      io.Writer     // standard error
-	allowRedecl bool          // allow redeclaration
+	dotCmd   string
+	noRun    bool          // compile, but do not run
+	fastChan bool          // disable cancellable chan operations
+	context  build.Context // build context: GOPATH, build constraints
+	stdin    io.Reader     // standard input
+	stdout   io.Writer     // standard output
+	stderr   io.Writer     // standard error
 }
 
 // Interpreter contains global resources and state.
@@ -245,9 +244,6 @@ type Options struct {
 	// They default to os.Stding, os.Stdout and os.Stderr respectively.
 	Stdin          io.Reader
 	Stdout, Stderr io.Writer
-
-	// AllowRedeclaration sets whether declarations can be overridden
-	AllowRedeclaration bool
 }
 
 // New returns a new interpreter.
@@ -264,8 +260,6 @@ func New(options Options) *Interpreter {
 		rdir:     map[string]bool{},
 		hooks:    &hooks{},
 	}
-
-	i.opt.allowRedecl = options.AllowRedeclaration
 
 	if i.opt.stdin = options.Stdin; i.opt.stdin == nil {
 		i.opt.stdin = os.Stdin

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -124,13 +124,14 @@ type opt struct {
 	cfgDot bool // display CFG graph (debug)
 	// dotCmd is the command to process the dot graph produced when astDot and/or
 	// cfgDot is enabled. It defaults to 'dot -Tdot -o <filename>.dot'.
-	dotCmd   string
-	noRun    bool          // compile, but do not run
-	fastChan bool          // disable cancellable chan operations
-	context  build.Context // build context: GOPATH, build constraints
-	stdin    io.Reader     // standard input
-	stdout   io.Writer     // standard output
-	stderr   io.Writer     // standard error
+	dotCmd      string
+	noRun       bool          // compile, but do not run
+	fastChan    bool          // disable cancellable chan operations
+	context     build.Context // build context: GOPATH, build constraints
+	stdin       io.Reader     // standard input
+	stdout      io.Writer     // standard output
+	stderr      io.Writer     // standard error
+	allowRedecl bool          // allow redeclaration
 }
 
 // Interpreter contains global resources and state.
@@ -244,6 +245,9 @@ type Options struct {
 	// They default to os.Stding, os.Stdout and os.Stderr respectively.
 	Stdin          io.Reader
 	Stdout, Stderr io.Writer
+
+	// AllowRedeclaration sets whether declarations can be overridden
+	AllowRedeclaration bool
 }
 
 // New returns a new interpreter.
@@ -260,6 +264,8 @@ func New(options Options) *Interpreter {
 		rdir:     map[string]bool{},
 		hooks:    &hooks{},
 	}
+
+	i.opt.allowRedecl = options.AllowRedeclaration
 
 	if i.opt.stdin = options.Stdin; i.opt.stdin == nil {
 		i.opt.stdin = os.Stdin


### PR DESCRIPTION
This PR adds an interpreter option, `AllowRedeclaration`. If this option is set, `(*Interpreter).Eval` will allow package imports to be redeclared. That is, no error will be raised and the package symbol will be overwritten.

I would like to use Yaegi to power a Go notebook (VSCode extension), somewhat like Jupyter. A notebook can have multiple Go 'cells' which can be evaluated (using Yaegi). As much as is possible, evaluating cells should be idempotent - that is, evaluating a cell multiple times should have the same effect as evaluating it once, ideally. Cells that are not idempotent can degrade the user experience.

Specifically, Go files tend to declare all imports in a single block. In a notebook, I'd put all imports in a single block, in their own cell. When I decide I need to import an additional package, I want to add that import to the existing cell and evaluate it. Without this MR, reevaluating that block usually causes an error.