### PR TITLE
interp: fix append on variadic recursive struct

### DIFF
--- a/_test/issue-1065.go
+++ b/_test/issue-1065.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+type AST struct {
+	Num      int
+	Children []AST
+}
+
+func newAST(num int, root AST, children ...AST) AST {
+	return AST{num, append([]AST{root}, children...)}
+}
+
+func main() {
+	ast := newAST(1, AST{}, AST{})
+	fmt.Println(ast)
+}
+
+// Output:
+// {1 [{0 []} {0 []}]}

--- a/interp/run.go
+++ b/interp/run.go
@@ -2947,7 +2947,7 @@ func _append(n *node) {
 	if len(n.child) == 3 {
 		c1, c2 := n.child[1], n.child[2]
 		if (c1.typ.cat == valueT || c2.typ.cat == valueT) && c1.typ.rtype == c2.typ.rtype ||
-			c2.typ.cat == arrayT && c2.typ.val.id() == n.typ.val.id() ||
+			(c2.typ.cat == arrayT || c2.typ.cat == variadicT) && c2.typ.val.id() == n.typ.val.id() ||
 			isByteArray(c1.typ.TypeOf()) && isString(c2.typ.TypeOf()) {
 			appendSlice(n)
 			return

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -48,6 +48,10 @@ func (check typecheck) assignment(n *node, typ *itype, context string) error {
 		return nil
 	}
 
+	if typ.isRecursive() || typ.val != nil && typ.val.isRecursive() {
+		return nil
+	}
+
 	if !n.typ.assignableTo(typ) {
 		if context == "" {
 			return n.cfgErrorf("cannot use type %s as type %s", n.typ.id(), typ.id())


### PR DESCRIPTION
Fixes #1065. Improves #1058.