### PR TITLE
interp: refactor slice type management

### DIFF
--- a/interp/run.go
+++ b/interp/run.go
@@ -571,7 +571,7 @@ func isRecursiveType(t *itype, rtype reflect.Type) bool {
 		return true
 	}
 	switch t.cat {
-	case ptrT, arrayT, mapT:
+	case arrayT, mapT, ptrT, sliceT:
 		return isRecursiveType(t.val, t.val.rtype)
 	default:
 		return false
@@ -1409,7 +1409,7 @@ func callBin(n *node) {
 				}
 				// empty interface, do not wrap it.
 				values = append(values, genValue(c))
-			case arrayT, variadicT:
+			case arrayT, sliceT, variadicT:
 				switch c.typ.val.cat {
 				case interfaceT:
 					if len(c.typ.val.field) > 0 {
@@ -2340,12 +2340,13 @@ func arrayLit(n *node) {
 	}
 
 	typ := n.typ.frameType()
+	kind := typ.Kind()
 	n.exec = func(f *frame) bltn {
 		var a reflect.Value
-		if n.typ.sizedef {
-			a, _ = n.typ.zero()
-		} else {
+		if kind == reflect.Slice {
 			a = reflect.MakeSlice(typ, max, max)
+		} else {
+			a, _ = n.typ.zero()
 		}
 		for i, v := range values {
 			a.Index(index[i]).Set(v(f))
@@ -2452,12 +2453,13 @@ func compositeBinSlice(n *node) {
 	}
 
 	typ := n.typ.frameType()
+	kind := typ.Kind()
 	n.exec = func(f *frame) bltn {
 		var a reflect.Value
-		if n.typ.sizedef {
-			a, _ = n.typ.zero()
-		} else {
+		if kind == reflect.Slice {
 			a = reflect.MakeSlice(typ, max, max)
+		} else {
+			a, _ = n.typ.zero()
 		}
 		for i, v := range values {
 			a.Index(index[i]).Set(v(f))
@@ -2947,7 +2949,7 @@ func _append(n *node) {
 	if len(n.child) == 3 {
 		c1, c2 := n.child[1], n.child[2]
 		if (c1.typ.cat == valueT || c2.typ.cat == valueT) && c1.typ.rtype == c2.typ.rtype ||
-			(c2.typ.cat == arrayT || c2.typ.cat == variadicT) && c2.typ.val.id() == n.typ.val.id() ||
+			(c2.typ.cat == arrayT || c2.typ.cat == sliceT || c2.typ.cat == variadicT) && c2.typ.val.id() == n.typ.val.id() ||
 			isByteArray(c1.typ.TypeOf()) && isString(c2.typ.TypeOf()) {
 			appendSlice(n)
 			return

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -289,7 +289,10 @@ func (check typecheck) index(n *node, max int) error {
 }
 
 // arrayLitExpr type checks an array composite literal expression.
-func (check typecheck) arrayLitExpr(child []*node, typ *itype, length int) error {
+func (check typecheck) arrayLitExpr(child []*node, typ *itype) error {
+	cat := typ.cat
+	length := typ.length
+	typ = typ.val
 	visited := make(map[int]bool, len(child))
 	index := 0
 	for _, c := range child {
@@ -301,7 +304,7 @@ func (check typecheck) arrayLitExpr(child []*node, typ *itype, length int) error
 			}
 			n = c.child[1]
 			index = int(vInt(c.child[0].rval))
-		case length > 0 && index >= length:
+		case cat == arrayT && index >= length:
 			return c.cfgErrorf("index %d is out of bounds (>= %d)", index, length)
 		}
 
@@ -904,7 +907,7 @@ func arrayDeref(typ *itype) *itype {
 		return typ
 	}
 
-	if typ.cat == ptrT && typ.val.cat == arrayT && typ.val.sizedef {
+	if typ.cat == ptrT && typ.val.cat == arrayT {
 		return typ.val
 	}
 	return typ
@@ -960,7 +963,7 @@ func (check typecheck) argument(p param, ftyp *itype, i, l int, ellipsis bool) e
 		}
 		t := p.Type().TypeOf()
 		if t.Kind() != reflect.Slice || !(&itype{cat: valueT, rtype: t.Elem()}).assignableTo(atyp) {
-			return p.nod.cfgErrorf("cannot use %s as type %s", p.nod.typ.id(), (&itype{cat: arrayT, val: atyp}).id())
+			return p.nod.cfgErrorf("cannot use %s as type %s", p.nod.typ.id(), (&itype{cat: sliceT, val: atyp}).id())
 		}
 		return nil
 	}


### PR DESCRIPTION
Add missing `sliceT` type category for consistency. Remove
`sizedef` field in `itype` struct. Rename field `size` to `length`.
Clean the various hacks used to cope with the absence of `sliceT`.