### PR TITLE
interp: improve handling of aliased types

### DIFF
--- a/_test/issue-1068.go
+++ b/_test/issue-1068.go
@@ -1,0 +1,19 @@
+package main
+
+type I interface {
+	Hello()
+}
+
+type T struct{}
+
+func (t T) Hello() { println("hello") }
+
+type I2 I
+
+func main() {
+	var i I2 = T{}
+	i.Hello()
+}
+
+// Output:
+// hello

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -580,7 +580,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					dest.gen = nop
 				case isFuncField(dest):
 					// Setting a struct field of function type requires an extra step. Do not optimize.
-				case isCall(src) && dest.typ.cat != interfaceT && !isRecursiveField(dest) && n.kind != defineStmt:
+				case isCall(src) && !isInterfaceSrc(dest.typ) && !isRecursiveField(dest) && n.kind != defineStmt:
 					// Call action may perform the assignment directly.
 					n.gen = nop
 					src.level = level

--- a/interp/run.go
+++ b/interp/run.go
@@ -1104,7 +1104,9 @@ func call(n *node) {
 				convertLiteralValue(c, argType)
 			}
 			switch {
-			case isInterfaceSrc(arg) && !isEmptyInterface(arg):
+			case isEmptyInterface(arg):
+				values = append(values, genValue(c))
+			case isInterfaceSrc(arg):
 				values = append(values, genValueInterface(c))
 			case isRecursiveType(c.typ, c.typ.rtype):
 				values = append(values, genValueRecursiveInterfacePtrValue(c))
@@ -1136,7 +1138,8 @@ func call(n *node) {
 			j := n.findex + i
 			ret := n.child[0].typ.ret[i]
 			callret := n.anc.val.(*node).typ.ret[i]
-			if isInterfaceSrc(callret) && !isEmptyInterface(callret) {
+
+			if isInterfaceSrc(callret) && !isEmptyInterface(callret) && !isInterfaceSrc(ret) {
 				// Wrap the returned value in a valueInterface in caller frame.
 				rvalues[i] = func(f *frame) reflect.Value {
 					v := reflect.New(ret.rtype).Elem()

--- a/interp/run.go
+++ b/interp/run.go
@@ -1387,7 +1387,6 @@ func callBin(n *node) {
 				break
 			}
 
-			//switch c.typ.cat {
 			switch {
 			case isFuncSrc(c.typ):
 				values = append(values, genFunctionWrapper(c))

--- a/interp/type.go
+++ b/interp/type.go
@@ -1680,6 +1680,18 @@ func isFunc(t *itype) bool { return t.TypeOf().Kind() == reflect.Func }
 func isMap(t *itype) bool  { return t.TypeOf().Kind() == reflect.Map }
 func isPtr(t *itype) bool  { return t.TypeOf().Kind() == reflect.Ptr }
 
+func isEmptyInterface(t *itype) bool {
+	return t.cat == interfaceT && len(t.field) == 0
+}
+
+func isFuncSrc(t *itype) bool {
+	return t.cat == funcT || (t.cat == aliasT && isFuncSrc(t.val))
+}
+
+func isPtrSrc(t *itype) bool {
+	return t.cat == ptrT || (t.cat == aliasT && isPtrSrc(t.val))
+}
+
 func isSendChan(t *itype) bool {
 	rt := t.TypeOf()
 	return rt.Kind() == reflect.Chan && rt.ChanDir() == reflect.SendDir


### PR DESCRIPTION
Avoid to test directly for a type category, as it may give wrong
results for aliased types, where the interesting category remains
masked.  Instead, use some property helpers, such as isFuncSrc,
isPtrSrc and isInterfaceSrc to check if a type is of source function,
source pointer or source interface respectively (versus runtime
defined function, pointer or interface).

Fixes #1068.