### PR TITLE
interp: produce meaningful output for file statements

### DIFF
--- a/interp/result.go
+++ b/interp/result.go
@@ -1,0 +1,30 @@
+package interp
+
+// FileResult is the result of evaluating a file-like source.
+type FileResult struct {
+	Statements []FileStatementResult
+}
+
+// FileStatementResult is the result of a top-level statement in a file-like source.
+type FileStatementResult interface {
+	isFileStatementResult()
+}
+
+func (*PackageImportResult) isFileStatementResult()       {}
+func (*FunctionDeclarationResult) isFileStatementResult() {}
+func (*TypeDeclarationResult) isFileStatementResult()     {}
+
+// PackageImportResult is the result of a package import statement.
+type PackageImportResult struct {
+	Name, Path string
+}
+
+// FunctionDeclarationResult is the result of a top-level function declaration statement.
+type FunctionDeclarationResult struct {
+	Name string
+}
+
+// TypeDeclarationResult is the result of a top-level type declaration statement.
+type TypeDeclarationResult struct {
+	Name string
+}

--- a/interp/result_test.go
+++ b/interp/result_test.go
@@ -1,0 +1,60 @@
+package interp_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/traefik/yaegi/interp"
+	"github.com/traefik/yaegi/stdlib"
+)
+
+type resultTestCase struct {
+	desc, src string
+	res       interface{}
+}
+
+func TestEvalFileResult(t *testing.T) {
+	type Results = []interp.FileStatementResult
+	type Import = interp.PackageImportResult
+	type Func = interp.FunctionDeclarationResult
+	type Type = interp.TypeDeclarationResult
+
+	i := interp.New(interp.Options{})
+	_ = i.Use(stdlib.Symbols)
+	runResultTests(t, i, []resultTestCase{
+		{desc: "bare import", src: `import "time"`, res: &Import{Path: "time"}},
+		{desc: "named import", src: `import x "time"`, res: &Import{Name: "x", Path: "time"}},
+		{desc: "multiple imports", src: "import (\ny \"time\"\nz \"fmt\"\n)", res: Results{&Import{Name: "y", Path: "time"}, &Import{Name: "z", Path: "fmt"}}},
+
+		{desc: "func", src: `func foo() { }`, res: &Func{Name: "foo"}},
+
+		{desc: "struct type", src: `type Foo struct {}`, res: &Type{Name: "Foo"}},
+	})
+}
+
+func runResultTests(t *testing.T, i *interp.Interpreter, tests []resultTestCase) {
+	t.Helper()
+
+	for _, test := range tests {
+		expected := test.res
+		if stmtResult, ok := expected.(interp.FileStatementResult); ok {
+			expected = []interp.FileStatementResult{stmtResult}
+		}
+		if stmtResults, ok := expected.([]interp.FileStatementResult); ok {
+			expected = &interp.FileResult{Statements: stmtResults}
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			res, err := i.Eval(test.src)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !res.IsValid() {
+				t.Fatal("Result is not valid")
+			}
+			if !reflect.DeepEqual(expected, res.Interface()) {
+				t.Fatalf("Got %v, expected %v", res, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This MR modifies `interp.eval` to produce meaningful result values for file statements. Currently, the return value of `interp.eval` for file-like input is effectively `new(interface{})` (as a `reflect.Value`). With these changes, `interp.eval` for file-like input will return meaningful values.

- At the top level, a file-like input will produce a struct with an array of statement results
- Import specs will produce a struct with the import path, and name if specified
- Top-level function declarations will produce a struct with the function name
- Top-level type declarations will produce a struct with the type name

Variable and constant declarations do not currently produce any result.

### Motivation

I am working on a [notebook extension](https://gitlab.com/ethan.reesor/vscode-notebooks/go-kernel) for Visual Studio Code, powered by Yaegi. This MR is a step towards enabling me to improve the user experience. Specifically, I want to be able to intelligently detect whether the user expects the evaluation result to be displayed. If the input is file-like, I will assume that the user does not wish to inspect/display some value. For my purposes, it doesn't matter exactly what result file-like inputs produce (as long as I can detect it), so I chose to implement something simple that could be extended in the future.