### PR TITLE
Add an option to suppress output from assignments

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1490,3 +1490,15 @@ func TestREPLDivision(t *testing.T) {
 		t.Fatal("timeout")
 	}
 }
+
+func TestEvalSupressAssignmentResult(t *testing.T) {
+	i := interp.New(interp.Options{SupressAssignmentResult: true})
+	runTests(t, i, []testCase{
+		{desc: "define", src: "a := 1", res: "{}"},
+		{desc: "define multiple", src: "a, b := 1, 2", res: "{}"},
+		{desc: "assign", src: "a = 2", res: "{}"},
+		{desc: "assign multiple", src: "a, b = 2, 3", res: "{}"},
+		{desc: "declare", src: `var c = 1.2`, skip: "can't test for new(interface{})"},
+		{desc: "declare after code", src: `_ = ""; var d = 1.2`, res: "{}"},
+	})
+}


### PR DESCRIPTION
This MR adds an option, `interp.Options.SuppressAssignmentResult`, which causes assignments to output `interp.EmptyResult`.