### PR TITLE
interp: implement unsafe.Offsetof

### DIFF
--- a/_test/unsafe5.go
+++ b/_test/unsafe5.go
@@ -12,11 +12,13 @@ type S struct {
 }
 
 func main() {
-	size := unsafe.Sizeof(S{})
-	align := unsafe.Alignof(S{})
+	x := S{}
+	size := unsafe.Sizeof(x)
+	align := unsafe.Alignof(x.Y)
+	offset := unsafe.Offsetof(x.Z)
 
-	fmt.Println(size, align)
+	fmt.Println(size, align, offset)
 }
 
 // Output:
-// 24 8
+// 24 8 16

--- a/stdlib/unsafe/unsafe.go
+++ b/stdlib/unsafe/unsafe.go
@@ -22,6 +22,7 @@ func init() {
 	// Add builtin functions to unsafe.
 	Symbols["unsafe"]["Sizeof"] = reflect.ValueOf(sizeof)
 	Symbols["unsafe"]["Alignof"] = reflect.ValueOf(alignof)
+	Symbols["unsafe"]["Offsetof"] = reflect.ValueOf("Offsetof") // This symbol is handled directly in interpreter.
 }
 
 func convert(from, to reflect.Type) func(src, dest reflect.Value) {


### PR DESCRIPTION
Offsetof returns the offset of a field in a struct. It is computed
during parsing at CFG, due to the constraint of operating on a
struct selector expression.

With this function, the support of 'unsafe' package is now
complete in yaegi.

Fixes #1062.