### PR TITLE
Add option to produce array of results for blocks

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -131,6 +131,8 @@ type opt struct {
 	stdin    io.Reader     // standard input
 	stdout   io.Writer     // standard output
 	stderr   io.Writer     // standard error
+
+	blockStmtAsArray bool
 }
 
 // Interpreter contains global resources and state.
@@ -244,6 +246,8 @@ type Options struct {
 	// They default to os.Stding, os.Stdout and os.Stderr respectively.
 	Stdin          io.Reader
 	Stdout, Stderr io.Writer
+
+	BlockStatementAsArray bool
 }
 
 // New returns a new interpreter.
@@ -294,6 +298,8 @@ func New(options Options) *Interpreter {
 
 	// fastChan disables the cancellable version of channel operations in evalWithContext
 	i.opt.fastChan, _ = strconv.ParseBool(os.Getenv("YAEGI_FAST_CHAN"))
+
+	i.opt.blockStmtAsArray = options.BlockStatementAsArray
 	return &i
 }
 
@@ -582,6 +588,12 @@ func (interp *Interpreter) eval(src, name string, inc bool) (res reflect.Value, 
 	for _, n := range initNodes {
 		interp.run(n, interp.frame)
 	}
+
+	if interp.blockStmtAsArray && root.kind == blockStmt {
+		v := blockStmtAsArray(root, interp.frame)
+		return reflect.ValueOf(v), err
+	}
+
 	v := genValue(root)
 	res = v(interp.frame)
 
@@ -593,6 +605,31 @@ func (interp *Interpreter) eval(src, name string, inc bool) (res reflect.Value, 
 	}
 
 	return res, err
+}
+
+// BlockResult is the result of a block statement.
+type BlockResult []interface{}
+
+func blockStmtAsArray(n *node, f *frame) BlockResult {
+	res := make(BlockResult, len(n.child))
+	for i, child := range n.child {
+		if child.kind == blockStmt {
+			res[i] = blockStmtAsArray(child, f)
+			continue
+		}
+
+		v := genValue(child)
+		rv := v(f)
+		if !rv.IsValid() {
+			continue
+		}
+
+		res[i] = rv.Interface()
+		if n, ok := res[i].(*node); ok {
+			res[i] = genFunctionWrapper(n)(f)
+		}
+	}
+	return res
 }
 
 // EvalWithContext evaluates Go code represented as a string. It returns

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1490,3 +1490,12 @@ func TestREPLDivision(t *testing.T) {
 		t.Fatal("timeout")
 	}
 }
+
+func TestEvalBlockAsArray(t *testing.T) {
+	i := interp.New(interp.Options{BlockStatementAsArray: true})
+	runTests(t, i, []testCase{
+		{src: "a := 5", res: "[5]"},
+		{src: "a = 1; b := 2", res: "[1 2]"},
+		{src: "a = 3; {b = 4}", res: "[3 [4]]"},
+	})
+}


### PR DESCRIPTION
This PR adds an option, `interp.Options.BlockStatementAsArray`, which configures the interpreter to return an array of results for each statement of a block, instead of just the last statement.