### PR TITLE
interp: add ImportUsed method to pre-import compiled packages

### DIFF
--- a/cmd/yaegi/run.go
+++ b/cmd/yaegi/run.go
@@ -35,7 +35,7 @@ func run(arg []string) error {
 	rflag.BoolVar(&useUnrestricted, "unrestricted", useUnrestricted, "include unrestricted symbols")
 	rflag.StringVar(&tags, "tags", "", "set a list of build tags")
 	rflag.BoolVar(&useUnsafe, "unsafe", useUnsafe, "include unsafe symbols")
-	rflag.BoolVar(&noAutoImport, "noautoimport", false, "do not auto import pre-compiled packages")
+	rflag.BoolVar(&noAutoImport, "noautoimport", false, "do not auto import pre-compiled packages. Import names that would result in collisions (e.g. rand from crypto/rand and rand from math/rand) are automatically renamed (crypto_rand and math_rand)"
 	rflag.StringVar(&cmd, "e", "", "set the command to be executed (instead of script or/and shell)")
 	rflag.Usage = func() {
 		fmt.Println("Usage: yaegi run [options] [path] [args]")

--- a/cmd/yaegi/run.go
+++ b/cmd/yaegi/run.go
@@ -35,7 +35,7 @@ func run(arg []string) error {
 	rflag.BoolVar(&useUnrestricted, "unrestricted", useUnrestricted, "include unrestricted symbols")
 	rflag.StringVar(&tags, "tags", "", "set a list of build tags")
 	rflag.BoolVar(&useUnsafe, "unsafe", useUnsafe, "include unsafe symbols")
-	rflag.BoolVar(&noAutoImport, "noautoimport", false, "do not auto import pre-compiled packages. Import names that would result in collisions (e.g. rand from crypto/rand and rand from math/rand) are automatically renamed (crypto_rand and math_rand)"
+	rflag.BoolVar(&noAutoImport, "noautoimport", false, "do not auto import pre-compiled packages. Import names that would result in collisions (e.g. rand from crypto/rand and rand from math/rand) are automatically renamed (crypto_rand and math_rand)")
 	rflag.StringVar(&cmd, "e", "", "set the command to be executed (instead of script or/and shell)")
 	rflag.Usage = func() {
 		fmt.Println("Usage: yaegi run [options] [path] [args]")

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -202,7 +202,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 					if name == "" {
 						name = identifier.FindString(ipath)
 					}
-					// imports of a same package are all mapped in the same scope, so we cannot just
+					// Imports of a same package are all mapped in the same scope, so we cannot just
 					// map them by their names, otherwise we could have collisions from same-name
 					// imports in different source files of the same package. Therefore, we suffix
 					// the key with the basename of the source file.
@@ -210,7 +210,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 					if sym, exists := sc.sym[name]; !exists {
 						sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: ipath, scope: sc}}
 						break
-					} else if sym.kind == pkgSym && sym.typ.cat == binPkgT && sym.typ.path == ipath {
+					} else if sym.kind == pkgSym && sym.typ.cat == srcPkgT && sym.typ.path == ipath {
 						// ignore re-import of identical package
 						break
 					}

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -210,7 +210,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 					if sym, exists := sc.sym[name]; !exists {
 						sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: ipath, scope: sc}}
 						break
-					} else if sym.kind == pkgSym && sym.typ.cat == srcPkgT && sym.typ.path == ipath {
+					} else if sym.kind == pkgSym && sym.typ.cat == binPkgT && sym.typ.path == ipath {
 						// ignore re-import of identical package
 						break
 					}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"runtime/debug"
@@ -742,24 +743,45 @@ func ignoreScannerError(e *scanner.Error, s string) bool {
 	return false
 }
 
+// ImportUsed pre-imports used binary packages, as the packages are already loaded anyway.
+// This is mainly useful for REPLs, or single command lines. In case of an ambiguous default
+// package name, for example "rand" for crypto/rand and math/rand, the package name is
+// constructed by replacing the last "/" by a "_", producing crypto_rand and math_rand.
+func (interp *Interpreter) ImportUsed() {
+	sc := interp.universe
+	for k := range interp.binPkg {
+		name := key2name(k)
+		if sym, ok := sc.sym[name]; ok {
+			// Handle collision by renaming old and new entries.
+			name2 := key2name(fixKey(sym.typ.path))
+			sc.sym[name2] = sym
+			if name2 != name {
+				delete(sc.sym, name)
+			}
+			name = key2name(fixKey(k))
+		}
+		sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: k, scope: sc}}
+	}
+}
+
+func key2name(k string) string {
+	name := identifier.FindString(k)
+	return filepath.Join(name, DefaultSourceName)
+}
+
+func fixKey(k string) string {
+	i := strings.LastIndex(k, "/")
+	if i >= 0 && i < len(k)-1 {
+		k = k[:i] + "_" + k[i+1:]
+	}
+	return k
+}
+
 // REPL performs a Read-Eval-Print-Loop on input reader.
 // Results are printed to the output writer of the Interpreter, provided as option
 // at creation time. Errors are printed to the similarly defined errors writer.
 // The last interpreter result value and error are returned.
 func (interp *Interpreter) REPL() (reflect.Value, error) {
-	// Preimport used bin packages, to avoid having to import these packages manually
-	// in REPL mode. These packages are already loaded anyway.
-	sc := interp.universe
-	for k := range interp.binPkg {
-		name := identifier.FindString(k)
-		if name == "" || name == "rand" || name == "scanner" || name == "template" || name == "pprof" {
-			// Skip any package with an ambiguous name (i.e crypto/rand vs math/rand).
-			// Those will have to be imported explicitly.
-			continue
-		}
-		sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: k, scope: sc}}
-	}
-
 	in, out, errs := interp.stdin, interp.stdout, interp.stderr
 	ctx, cancel := context.WithCancel(context.Background())
 	end := make(chan struct{})     // channel to terminate the REPL

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -743,10 +743,12 @@ func ignoreScannerError(e *scanner.Error, s string) bool {
 	return false
 }
 
-// ImportUsed pre-imports used binary packages, as the packages are already loaded anyway.
+// ImportUsed automatically imports pre-compiled packages included by Use().
 // This is mainly useful for REPLs, or single command lines. In case of an ambiguous default
 // package name, for example "rand" for crypto/rand and math/rand, the package name is
 // constructed by replacing the last "/" by a "_", producing crypto_rand and math_rand.
+// ImportUsed should not be called more than once, and not after a first Eval, as it may
+// rename packages.
 func (interp *Interpreter) ImportUsed() {
 	sc := interp.universe
 	for k := range interp.binPkg {
@@ -771,7 +773,7 @@ func key2name(k string) string {
 
 func fixKey(k string) string {
 	i := strings.LastIndex(k, "/")
-	if i >= 0 && i < len(k)-1 {
+	if i >= 0 {
 		k = k[:i] + "_" + k[i+1:]
 	}
 	return k

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -32,6 +32,9 @@ func (check typecheck) op(p opPredicates, a action, n, c *node, t reflect.Type) 
 //
 // Use typ == nil to indicate assignment to an untyped blank identifier.
 func (check typecheck) assignment(n *node, typ *itype, context string) error {
+	if n.typ == nil {
+		return n.cfgErrorf("invalid type in %s", context)
+	}
 	if n.typ.untyped {
 		if typ == nil || isInterface(typ) {
 			if typ == nil && n.typ.cat == nilT {


### PR DESCRIPTION
This feature was already present, but part of REPL only.
It's now also possible to apply it when evaluating a string
(-e flag). Default package names collision handling is no
longer hard-coded.

With -e flag, the eval result is now printed if valid, allowing
simpler commands:

     yaegi -e 'reflect.TypeOf(fmt.Printf)'

instead of:

     yaegi -e 'println(reflect.TypeOf(fmt.Printf))'

Fixes #1084.