### PR TITLE
interp: give a self to the interpreter

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -180,6 +180,9 @@ const (
 	NoTest = true
 )
 
+// Self points to the current interpreter if accessed from within itself, or is nil.
+var Self *Interpreter
+
 // Symbols exposes interpreter values.
 var Symbols = Exports{
 	selfPath: map[string]reflect.Value{
@@ -654,6 +657,9 @@ func (interp *Interpreter) Use(values Exports) {
 
 		for s, sym := range v {
 			interp.binPkg[k][s] = sym
+		}
+		if k == selfPath {
+			interp.binPkg[k]["Self"] = reflect.ValueOf(interp)
 		}
 	}
 


### PR DESCRIPTION
The interpreter is exposed to itself through a "Self" var which
is set on "Use" of the interpreter package.

It allows meta-programming features, for example using "Eval" in
the current interpreter context, or enabling self-inspection
capabilities.