### PR TITLE
interp: sandbox to preserve type of os.Stdin os.Stdout and os.Stderr

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1491,3 +1491,16 @@ func TestREPLCommands(t *testing.T) {
 		t.Fatal("timeout")
 	}
 }
+
+func TestStdio(t *testing.T) {
+	i := interp.New(interp.Options{})
+	i.Use(stdlib.Symbols)
+	i.ImportUsed()
+	if _, err := i.Eval(`var x = os.Stdout`); err != nil {
+		t.Fatal(err)
+	}
+	v, _ := i.Eval(`x`)
+	if _, ok := v.Interface().(*os.File); !ok {
+		t.Fatalf("%v not *os.file", v.Interface())
+	}
+}

--- a/interp/interp_file_test.go
+++ b/interp/interp_file_test.go
@@ -23,7 +23,7 @@ func TestFile(t *testing.T) {
 	defer func() {
 		_ = os.Setenv("YAEGI_SPECIAL_STDIO", "0")
 	}()
-	os.Setenv("YAEGI_SPECIAL_STDIO", "1")
+	_ = os.Setenv("YAEGI_SPECIAL_STDIO", "1")
 
 	baseDir := filepath.Join("..", "_test")
 	files, err := ioutil.ReadDir(baseDir)

--- a/interp/interp_file_test.go
+++ b/interp/interp_file_test.go
@@ -20,6 +20,11 @@ func TestFile(t *testing.T) {
 	filePath := "../_test/str.go"
 	runCheck(t, filePath)
 
+	defer func() {
+		_ = os.Setenv("YAEGI_SPECIAL_STDIO", "0")
+	}()
+	os.Setenv("YAEGI_SPECIAL_STDIO", "1")
+
 	baseDir := filepath.Join("..", "_test")
 	files, err := ioutil.ReadDir(baseDir)
 	if err != nil {


### PR DESCRIPTION
Use YAEGI_SPECIAL_STDIO env boolean to overwrite os.Stdxxx by
non file descriptors io.Writer / io.Reader interfaces. It is set
to true when testing to allow redirection to byte buffers.

The default behaviour is now to preserve the original concrete type
when sandboxing stdio, which maintains compatibility.

Fixes #1092.