### PR TITLE
interp: fix constant types from imported packages

### DIFF
--- a/_test/issue-1101.go
+++ b/_test/issue-1101.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	method := "POST"
+	switch method {
+	case http.MethodPost:
+		fmt.Println("It's a post!")
+	}
+}
+
+// Output:
+// It's a post!

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1543,7 +1543,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					if isBinType(s) {
 						n.typ = &itype{cat: valueT, rtype: s.Type().Elem()}
 					} else {
-						n.typ = &itype{cat: valueT, rtype: s.Type(), untyped: isValueUntyped(s)}
+						n.typ = &itype{cat: valueT, rtype: constType(s.Type()), untyped: isValueUntyped(s)}
 						n.rval = s
 					}
 					n.action = aGetSym

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1543,7 +1543,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					if isBinType(s) {
 						n.typ = &itype{cat: valueT, rtype: s.Type().Elem()}
 					} else {
-						n.typ = &itype{cat: valueT, rtype: constType(s.Type()), untyped: isValueUntyped(s)}
+						n.typ = &itype{cat: valueT, rtype: fixPossibleConstType(s.Type()), untyped: isValueUntyped(s)}
 						n.rval = s
 					}
 					n.action = aGetSym

--- a/interp/type.go
+++ b/interp/type.go
@@ -1163,7 +1163,7 @@ func (t *itype) id() (res string) {
 		res += "}"
 	case valueT:
 		if isConstantValue(t.rtype) {
-			res = constType(t.rtype).String()
+			res = fixPossibleConstType(t.rtype).String()
 			break
 		}
 		res = ""
@@ -1177,7 +1177,10 @@ func (t *itype) id() (res string) {
 	return res
 }
 
-func constType(t reflect.Type) (r reflect.Type) {
+// fixPossibleConstType returns the input type if it not a constant value,
+// otherwise, it returns the default Go type corresponding to the
+// constant.Value.
+func fixPossibleConstType(t reflect.Type) (r reflect.Type) {
 	cv, ok := reflect.New(t).Elem().Interface().(constant.Value)
 	if !ok {
 		return t

--- a/interp/type.go
+++ b/interp/type.go
@@ -1163,7 +1163,7 @@ func (t *itype) id() (res string) {
 		res += "}"
 	case valueT:
 		if isConstantValue(t.rtype) {
-			res = constTypeString(t.rtype)
+			res = constType(t.rtype).String()
 			break
 		}
 		res = ""
@@ -1177,24 +1177,24 @@ func (t *itype) id() (res string) {
 	return res
 }
 
-func constTypeString(t reflect.Type) (s string) {
+func constType(t reflect.Type) (r reflect.Type) {
 	cv, ok := reflect.New(t).Elem().Interface().(constant.Value)
 	if !ok {
-		return
+		return t
 	}
 	switch cv.Kind() {
 	case constant.Bool:
-		s = "bool"
+		r = reflect.TypeOf(true)
 	case constant.Int:
-		s = "int"
+		r = reflect.TypeOf(0)
 	case constant.String:
-		s = "string"
+		r = reflect.TypeOf("")
 	case constant.Float:
-		s = "float64"
+		r = reflect.TypeOf(float64(0))
 	case constant.Complex:
-		s = "complex128"
+		r = reflect.TypeOf(complex128(0))
 	}
-	return
+	return r
 }
 
 // zero instantiates and return a zero value object for the given type during execution.


### PR DESCRIPTION
In binary packages, constants are wrapped in constant.Values, to
support arbitrary precision. Their type must therefore be converted
back to a regular type at import.

Fixes #1101.