### PR TITLE
interp: fix return of function call involving a type conversion

### DIFF
--- a/_test/issue-1091.go
+++ b/_test/issue-1091.go
@@ -1,0 +1,24 @@
+package main
+
+import "fmt"
+
+type CustomError string
+
+func (s CustomError) Error() string {
+	return string(s)
+}
+
+func NewCustomError(errorText string) CustomError {
+	return CustomError(errorText)
+}
+
+func fail() (err error) {
+	return NewCustomError("Everything is going wrong!")
+}
+
+func main() {
+	fmt.Println(fail())
+}
+
+// Output:
+// Everything is going wrong!

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1004,7 +1004,9 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				}
 				if typ := n.child[0].typ; len(typ.ret) > 0 {
 					n.typ = typ.ret[0]
-					if n.anc.kind == returnStmt {
+					if n.anc.kind == returnStmt && n.typ.id() == sc.def.typ.ret[0].id() {
+						// Store the result to directly to the return value area of frame.
+						// It can be done only if no type conversion at return is involved.
 						n.findex = childPos(n)
 					} else {
 						n.findex = sc.add(n.typ)

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1005,7 +1005,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				if typ := n.child[0].typ; len(typ.ret) > 0 {
 					n.typ = typ.ret[0]
 					if n.anc.kind == returnStmt && n.typ.id() == sc.def.typ.ret[0].id() {
-						// Store the result to directly to the return value area of frame.
+						// Store the result directly to the return value area of frame.
 						// It can be done only if no type conversion at return is involved.
 						n.findex = childPos(n)
 					} else {

--- a/interp/run.go
+++ b/interp/run.go
@@ -2259,12 +2259,16 @@ func _return(n *node) {
 	case 0:
 		n.exec = nil
 	case 1:
-		// This is an optimisation that is applied for binary expressions or function
-		// calls, but not for (binary) expressions involving const, as the values are not
-		// stored in the frame in that case.
-		if !child[0].rval.IsValid() && child[0].kind == binaryExpr || isCall(child[0]) {
+		switch {
+		case !child[0].rval.IsValid() && child[0].kind == binaryExpr:
+			// No additional runtime operation is necessary for constants (not in frame) or
+			// binary expressions (stored directly at the right location in frame).
 			n.exec = nil
-		} else {
+		case isCall(child[0]) && n.child[0].typ.id() == def.typ.ret[0].id():
+			// Calls are optmized as long as no type conversion is involved.
+			n.exec = nil
+		default:
+			// Regular return: store the value to return at to start of the frame.
 			v := values[0]
 			n.exec = func(f *frame) bltn {
 				f.data[0].Set(v(f))


### PR DESCRIPTION
In that case, direct propagation of result can not be attempted,
as the frame types will be different between the source and destination.
Disabling the optimisation and using The regular case involves an intermediate
frame entry, which enables the type conversion.

Fixes #1091.