### PR TITLE
interp: fix special range on string

### DIFF
--- a/_test/issue-1088.go
+++ b/_test/issue-1088.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	for i, ch := range "日本語" {
+		fmt.Printf("%#U starts at byte position %d\n", ch, i)
+	}
+}
+
+// Output:
+// U+65E5 '日' starts at byte position 0
+// U+672C '本' starts at byte position 3
+// U+8A9E '語' starts at byte position 6

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -151,6 +151,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 							vtyp = &itype{cat: valueT, rtype: typ.Elem()}
 						case reflect.String:
 							sc.add(sc.getType("int")) // Add a dummy type to store array shallow copy for range
+							sc.add(sc.getType("int")) // Add a dummy type to store index for range
 							ktyp = sc.getType("int")
 							vtyp = sc.getType("rune")
 						case reflect.Array, reflect.Slice:
@@ -174,6 +175,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 						}
 					case stringT:
 						sc.add(sc.getType("int")) // Add a dummy type to store array shallow copy for range
+						sc.add(sc.getType("int")) // Add a dummy type to store index for range
 						ktyp = sc.getType("int")
 						vtyp = sc.getType("rune")
 					case arrayT, sliceT, variadicT:

--- a/interp/run.go
+++ b/interp/run.go
@@ -2619,31 +2619,47 @@ var rat = reflect.ValueOf((*[]rune)(nil)).Type().Elem() // runes array type
 func _range(n *node) {
 	index0 := n.child[0].findex // array index location in frame
 	index2 := index0 - 1        // shallow array for range, always just behind index0
+	index3 := index2 - 1        // additional location to stop string char position
 	fnext := getExec(n.fnext)
 	tnext := getExec(n.tnext)
 
 	var value func(*frame) reflect.Value
+	var an *node
 	if len(n.child) == 4 {
-		an := n.child[2]
+		an = n.child[2]
 		index1 := n.child[1].findex // array value location in frame
 		if isString(an.typ.TypeOf()) {
+			stringType := reflect.TypeOf("")
 			value = genValueAs(an, rat) // range on string iterates over runes
+			n.exec = func(f *frame) bltn {
+				a := f.data[index2]
+				v0 := f.data[index3]
+				v0.SetInt(v0.Int() + 1)
+				i := int(v0.Int())
+				if i >= a.Len() {
+					return fnext
+				}
+				pos := a.Slice(0, i).Convert(stringType).Len()
+				f.data[index0].SetInt(int64(pos))
+				f.data[index1].Set(a.Index(i))
+				return tnext
+			}
 		} else {
 			value = genValueRangeArray(an)
-		}
-		n.exec = func(f *frame) bltn {
-			a := f.data[index2]
-			v0 := f.data[index0]
-			v0.SetInt(v0.Int() + 1)
-			i := int(v0.Int())
-			if i >= a.Len() {
-				return fnext
+			n.exec = func(f *frame) bltn {
+				a := f.data[index2]
+				v0 := f.data[index0]
+				v0.SetInt(v0.Int() + 1)
+				i := int(v0.Int())
+				if i >= a.Len() {
+					return fnext
+				}
+				f.data[index1].Set(a.Index(i))
+				return tnext
 			}
-			f.data[index1].Set(a.Index(i))
-			return tnext
 		}
 	} else {
-		an := n.child[1]
+		an = n.child[1]
 		if isString(an.typ.TypeOf()) {
 			value = genValueAs(an, rat) // range on string iterates over runes
 		} else {
@@ -2661,6 +2677,14 @@ func _range(n *node) {
 
 	// Init sequence
 	next := n.exec
+	if isString(an.typ.TypeOf()) && len(n.child) == 4 {
+		n.child[0].exec = func(f *frame) bltn {
+			f.data[index2] = value(f) // set array shallow copy for range
+			f.data[index3].SetInt(-1) // assing index value
+			return next
+		}
+		return
+	}
 	n.child[0].exec = func(f *frame) bltn {
 		f.data[index2] = value(f) // set array shallow copy for range
 		f.data[index0].SetInt(-1) // assing index value

--- a/interp/run.go
+++ b/interp/run.go
@@ -2619,7 +2619,7 @@ var rat = reflect.ValueOf((*[]rune)(nil)).Type().Elem() // runes array type
 func _range(n *node) {
 	index0 := n.child[0].findex // array index location in frame
 	index2 := index0 - 1        // shallow array for range, always just behind index0
-	index3 := index2 - 1        // additional location to stop string char position
+	index3 := index2 - 1        // additional location to store string char position
 	fnext := getExec(n.fnext)
 	tnext := getExec(n.tnext)
 


### PR DESCRIPTION
In this range variant "for k, v := range aString", k must
be the byte position of the rune in the byte array, rather than
the index of the rune in the rune array.

Fixes #1088.