### PR TITLE
interp: improve type check of binary methods

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -770,7 +770,7 @@ func (interp *Interpreter) ImportUsed() {
 			}
 			name = key2name(fixKey(k))
 		}
-		sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: path.Dir(k), scope: sc}}
+		sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: k, scope: sc}}
 	}
 }
 

--- a/interp/type.go
+++ b/interp/type.go
@@ -877,6 +877,10 @@ func (t *itype) isRecursive() bool {
 	return false
 }
 
+func (t *itype) isIndirectRecursive() bool {
+	return t.isRecursive() || t.val != nil && t.val.isIndirectRecursive()
+}
+
 // isVariadic returns true if the function type is variadic.
 // If the type is not a function or is not variadic, it will
 // return false.

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -51,7 +51,7 @@ func (check typecheck) assignment(n *node, typ *itype, context string) error {
 		return nil
 	}
 
-	if typ.isRecursive() || typ.val != nil && typ.val.isRecursive() {
+	if typ.isIndirectRecursive() || n.typ.isIndirectRecursive() {
 		return nil
 	}
 
@@ -997,6 +997,8 @@ func getArg(ftyp *itype, i int) *itype {
 		return arg
 	case i < l:
 		return ftyp.in(i)
+	case ftyp.cat == valueT && i < ftyp.rtype.NumIn():
+		return &itype{cat: valueT, rtype: ftyp.rtype.In(i)}
 	default:
 		return nil
 	}


### PR DESCRIPTION
Some binary method calls were wrongly rejected. There is still
some ambiguous cases as binary method signature may include or
not the receiver as first argument, depending on how the method
was resolved.

With this fix, `import "golang.org/x/net/html"` doesn't panic
anymore, but not all tests are passing yet, i.e.
`yaegi test golang.org/x/net/html` still has failures, to be
investigated.

Fixes #1107.