### PR TITLE
interp: fix method lookup on pointers to binary types

### DIFF
--- a/_test/method37.go
+++ b/_test/method37.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net"
+	"os"
+)
+
+func writeBufs(bufs ...[]byte) error {
+	b := net.Buffers(bufs)
+	_, err := b.WriteTo(os.Stdout)
+	return err
+}
+
+func main() {
+	writeBufs([]byte("hello"))
+}
+
+// Output:
+// hello


### PR DESCRIPTION
This case was missing in the selector expression processing.

Fixes #1083.