### PR TITLE
interp: fix assign of function call with implicit type assert.

### DIFF
--- a/_test/ret8.go
+++ b/_test/ret8.go
@@ -18,7 +18,11 @@ func fail() (err error) {
 
 func main() {
 	fmt.Println(fail())
+	var myError error
+	myError = NewCustomError("ok")
+	fmt.Println(myError)
 }
 
 // Output:
 // Everything is going wrong!
+// ok

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -557,9 +557,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				n.findex = dest.findex
 				n.level = dest.level
 
-				// Propagate type.
-				// TODO: Check that existing destination type matches source type.
-
 				// In the following, we attempt to optimize by skipping the assign
 				// operation and setting the source location directly to the destination
 				// location in the frame.

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -577,6 +577,10 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					// Setting a struct field of function type requires an extra step. Do not optimize.
 				case isCall(src) && !isInterfaceSrc(dest.typ) && !isRecursiveField(dest) && n.kind != defineStmt:
 					// Call action may perform the assignment directly.
+					if dest.typ.id() != src.typ.id() {
+						// Skip optimitization if returned type doesn't match assigned one.
+						break
+					}
 					n.gen = nop
 					src.level = level
 					src.findex = dest.findex


### PR DESCRIPTION
De-optimize a use case to avoid skipping an assign operation with an implicit type assertion at function call return.

Fixes #1122.