### PR TITLE
interp: fix a wrong control flow in switch

### DIFF
--- a/_test/addr2.go
+++ b/_test/addr2.go
@@ -57,7 +57,7 @@ func main() {
 	fmt.Println(err, vvv)
 }
 
-// Ouput:
+// Output:
 // <nil> {work bob@work.com}
 // <nil> {work bob@work.com}
 // <nil> {work bob@work.com}

--- a/_test/addr4.go
+++ b/_test/addr4.go
@@ -103,7 +103,7 @@ func main() {
 	intoMap()
 }
 
-// Ouput:
+// Output:
 // 0 : foo
 // 1 : bar
 // 0 : foo

--- a/_test/issue-1094.go
+++ b/_test/issue-1094.go
@@ -8,5 +8,5 @@ func main() {
 	fmt.Printf("%v %T\n", x, x)
 }
 
-// Ouput:
+// Output:
 // ab string

--- a/_test/issue-1126.go
+++ b/_test/issue-1126.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func main() {
+	err := errors.New("hello there")
+
+	switch true {
+	case err == nil:
+		break
+	case strings.Contains(err.Error(), "hello"):
+		fmt.Println("True!")
+	default:
+		fmt.Println("False!")
+	}
+}
+
+// Output:
+// True!

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1744,7 +1744,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				} else {
 					body := c.lastChild()
 					c.tnext = body.start
-
 					c.child[0].tnext = c
 					c.start = c.child[0].start
 
@@ -1770,7 +1769,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				} else {
 					setFNext(c, clauses[i+1])
 				}
-
 			}
 			setFNext(clauses[l-1], n)
 			n.start = n.child[0].start

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1762,6 +1762,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				}
 
 				if i == l-1 {
+					setFNext(clauses[i], n)
 					continue
 				}
 				if len(clauses[i+1].child) > 1 {
@@ -1770,7 +1771,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					setFNext(c, clauses[i+1])
 				}
 			}
-			setFNext(clauses[l-1], n)
 			n.start = n.child[0].start
 			n.child[0].tnext = sbn.start
 


### PR DESCRIPTION
In switch case expressions, the condition on case clause was
not always properly evaluated. Reverse the order of case clause
evaluations (as already done for if-else-if fashion), and fix the
wiring to false-next and true-next nodes.

Fixes #1126.