### PR TITLE
interp: handle binary array literals

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2575,7 +2575,7 @@ func compositeGenerator(n *node, typ *itype, rtyp reflect.Type) (gen bltnGenerat
 			gen = compositeBinMap
 		case reflect.Ptr:
 			gen = compositeGenerator(n, typ, n.typ.val.rtype)
-		case reflect.Slice:
+		case reflect.Slice, reflect.Array:
 			gen = compositeBinSlice
 		default:
 			log.Panic(n.cfgErrorf("compositeGenerator not implemented for type kind: %s", k))


### PR DESCRIPTION
This is a small change that allows use of composite array literals, such as:

```go
type Vec3 [3]float32

var foo = []Vec3{
	{1, 0, 0},
	{6, 0, 0},
	{6, 2, 0},
	{2, 2, 0},
	{1, 1, 0},
}
```