### PR TITLE
interp: preserve concrete type when converting type to interface

### DIFF
--- a/_test/issue-1136.go
+++ b/_test/issue-1136.go
@@ -5,8 +5,18 @@ import (
 	"io"
 )
 
+type T struct {
+	r io.Reader
+}
+
+func (t *T) Read(p []byte) (n int, err error) { n, err = t.r.Read(p); return }
+
 func main() {
 	x := io.LimitedReader{}
 	y := io.Reader(&x)
-	fmt.Println(y)
+	y = &T{y}
+	fmt.Println(y.Read([]byte("")))
 }
+
+// Output:
+// 0 EOF

--- a/_test/issue-1136.go
+++ b/_test/issue-1136.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+func main() {
+	x := io.LimitedReader{}
+	y := io.Reader(&x)
+	fmt.Println(y)
+}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -931,7 +931,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 						err = n.cfgErrorf("type %v does not implement interface %v", c1.typ.id(), c0.typ.id())
 					}
 					// Convert type to interface while keeping a reference to the original concrete type.
-					// beside type, the node value remains preserved.
+					// besides type, the node value remains preserved.
 					n.gen = nop
 					t := *c0.typ
 					n.typ = &t

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -930,9 +930,12 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					if !c1.typ.implements(c0.typ) {
 						err = n.cfgErrorf("type %v does not implement interface %v", c1.typ.id(), c0.typ.id())
 					}
-					// Pass value as is
+					// Convert type to interface while keeping a reference to the original concrete type.
+					// beside type, the node value remains preserved.
 					n.gen = nop
-					n.typ = c1.typ
+					t := *c0.typ
+					n.typ = &t
+					n.typ.val = c1.typ
 					n.findex = c1.findex
 					n.level = c1.level
 					n.val = c1.val

--- a/interp/type.go
+++ b/interp/type.go
@@ -1558,7 +1558,7 @@ func (t *itype) frameType() (r reflect.Type) {
 }
 
 func (t *itype) implements(it *itype) bool {
-	if t.cat == valueT {
+	if isBin(t) {
 		return t.TypeOf().Implements(it.TypeOf())
 	}
 	return t.methods().contains(it.methods())
@@ -1728,6 +1728,17 @@ func isInterfaceBin(t *itype) bool {
 
 func isInterface(t *itype) bool {
 	return isInterfaceSrc(t) || t.TypeOf() != nil && t.TypeOf().Kind() == reflect.Interface
+}
+
+func isBin(t *itype) bool {
+	switch t.cat {
+	case valueT:
+		return true
+	case aliasT, ptrT:
+		return isBin(t.val)
+	default:
+		return false
+	}
 }
 
 func isStruct(t *itype) bool {


### PR DESCRIPTION
This allows to fix the reassignment of an non empty interface value.
Before, reassignment was limited to empty interfaces.
    
Fixes #1138.