### PR TITLE
interp: fix assign of function values with binary methods

### DIFF
--- a/_test/issue-1145.go
+++ b/_test/issue-1145.go
@@ -1,0 +1,14 @@
+package main
+
+import "sync"
+
+type F func()
+
+func main() {
+	var wg sync.WaitGroup
+	var f F = wg.Done
+	println(f != nil)
+}
+
+// Output:
+// true

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1511,7 +1511,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					if m2, ok2 := pt.MethodByName(n.child[1].ident); ok2 {
 						n.val = m2.Index
 						n.gen = getIndexBinPtrMethod
-						n.typ = &itype{cat: valueT, rtype: m2.Type, recv: &itype{cat: valueT, rtype: pt}}
+						n.typ = &itype{cat: valueT, rtype: m2.Type, recv: &itype{cat: valueT, rtype: pt}, isBinMethod: true}
 						n.recv = &receiver{node: n.child[0]}
 						n.action = aGetMethod
 						break
@@ -1522,14 +1522,14 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				// Handle pointer on object defined in runtime
 				if method, ok := n.typ.val.rtype.MethodByName(n.child[1].ident); ok {
 					n.val = method.Index
-					n.typ = &itype{cat: valueT, rtype: method.Type, recv: n.typ}
+					n.typ = &itype{cat: valueT, rtype: method.Type, recv: n.typ, isBinMethod: true}
 					n.recv = &receiver{node: n.child[0]}
 					n.gen = getIndexBinMethod
 					n.action = aGetMethod
 				} else if method, ok := reflect.PtrTo(n.typ.val.rtype).MethodByName(n.child[1].ident); ok {
 					n.val = method.Index
 					n.gen = getIndexBinMethod
-					n.typ = &itype{cat: valueT, rtype: method.Type, recv: &itype{cat: valueT, rtype: reflect.PtrTo(n.typ.val.rtype)}}
+					n.typ = &itype{cat: valueT, rtype: method.Type, recv: &itype{cat: valueT, rtype: reflect.PtrTo(n.typ.val.rtype)}, isBinMethod: true}
 					n.recv = &receiver{node: n.child[0]}
 					n.action = aGetMethod
 				} else if field, ok := n.typ.val.rtype.FieldByName(n.child[1].ident); ok {
@@ -1598,7 +1598,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				}
 				n.recv = &receiver{node: n.child[0], index: lind}
 				n.val = append([]int{m.Index}, lind...)
-				n.typ = &itype{cat: valueT, rtype: m.Type, recv: n.child[0].typ}
+				n.typ = &itype{cat: valueT, rtype: m.Type, recv: n.child[0].typ, isBinMethod: true}
 			} else if ti := n.typ.lookupField(n.child[1].ident); len(ti) > 0 {
 				// Handle struct field
 				n.val = ti

--- a/interp/type.go
+++ b/interp/type.go
@@ -955,7 +955,7 @@ func (t *itype) assignableTo(o *itype) bool {
 		return true
 	}
 	if t.cat == aliasT && o.cat == aliasT {
-		// if alias types are not identical, it is not assignable.
+		// If alias types are not identical, it is not assignable.
 		return false
 	}
 	if t.isNil() && o.hasNil() || o.isNil() && t.hasNil() {
@@ -967,6 +967,11 @@ func (t *itype) assignableTo(o *itype) bool {
 	}
 
 	if isInterface(o) && t.implements(o) {
+		return true
+	}
+
+	if t.isBinMethod && isFunc(o) {
+		// TODO (marc): check that t without receiver as first parameter is equivalent to o.
 		return true
 	}
 

--- a/interp/value.go
+++ b/interp/value.go
@@ -157,8 +157,8 @@ func genValueAsFunctionWrapper(n *node) func(*frame) reflect.Value {
 		if v.IsNil() {
 			return reflect.New(typ).Elem()
 		}
-		vn := v.Interface().(*node)
-		if vn.rval.IsValid() && vn.rval.Type().Kind() == reflect.Func {
+		vn, ok := v.Interface().(*node)
+		if ok && vn.rval.IsValid() && vn.rval.Type().Kind() == reflect.Func {
 			// The node value is already a callable func, no need to wrap it.
 			return vn.rval
 		}

--- a/interp/value.go
+++ b/interp/value.go
@@ -157,7 +157,12 @@ func genValueAsFunctionWrapper(n *node) func(*frame) reflect.Value {
 		if v.IsNil() {
 			return reflect.New(typ).Elem()
 		}
-		return genFunctionWrapper(v.Interface().(*node))(f)
+		vn := v.Interface().(*node)
+		if vn.rval.IsValid() && vn.rval.Type().Kind() == reflect.Func {
+			// The node value is already a callable func, no need to wrap it.
+			return vn.rval
+		}
+		return genFunctionWrapper(vn)(f)
 	}
 }
 


### PR DESCRIPTION
In typecheck.go, detect binary methods so we know when to skip the receiver as first parameter when checking function signatures. The signature check is not yet performed, we just avoid a false error.

In cfg.go, take care to label types with isBinMethod field to true whenever a binary method is resolved.

Also, do not attempt to wrap node in functions if the node value is already a binary function.

Fixes #1145.