### PR TITLE
Fix handling of ImportUsed packages

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2186,7 +2186,10 @@ func (n *node) isType(sc *scope) bool {
 		suffixedPkg := filepath.Join(pkg, baseName)
 		sym, _, ok := sc.lookup(suffixedPkg)
 		if !ok {
-			return false
+			sym, _, ok = sc.lookup(pkg)
+			if !ok {
+				return false
+			}
 		}
 		if sym.kind != pkgSym {
 			return false

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1511,3 +1511,22 @@ func TestIssue1142(t *testing.T) {
 		{src: "a := 1; // foo bar", res: "1"},
 	})
 }
+
+func TestIssue1151(t *testing.T) {
+	type pkgStruct struct{ X int }
+	type pkgArray [1]int
+
+	i := interp.New(interp.Options{})
+	i.Use(interp.Exports{
+		"pkg/pkg": map[string]reflect.Value{
+			"Struct": reflect.ValueOf((*pkgStruct)(nil)),
+			"Array":  reflect.ValueOf((*pkgArray)(nil)),
+		},
+	})
+	i.ImportUsed()
+
+	runTests(t, i, []testCase{
+		{src: "x := pkg.Struct{1}", res: "{1}"},
+		{src: "x := pkg.Array{1}", res: "[1]"},
+	})
+}


### PR DESCRIPTION
Fixes #1151

If I add a package with `Use` and import it with `ImportUsed`, the package is added to the universe scope as `<pkg>`. If I import with `Eval`, the package is added as `<pkg>/_.go`. However, `(*node).isType` (in cfg.go) only checks for `<pkg>/_.go`. Thus, packages imported with `ImportUsed` can be inaccessible.

This MR updates `(*node).isType` to fall back to `<pkg>` if `<pkg>/_.go` does not exist.