### PR TITLE
Correctly resolve type aliases when building array literals

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1511,3 +1511,36 @@ func TestIssue1142(t *testing.T) {
 		{src: "a := 1; // foo bar", res: "1"},
 	})
 }
+
+func TestIssue1150(t *testing.T) {
+	i := interp.New(interp.Options{})
+	_, err := i.Eval(`
+		type ArrayT [3]float32
+		type SliceT []float32
+		type StructT struct { A, B, C float32 }
+		type StructT2 struct { A, B, C float32 }
+		type FooerT interface { Foo() string }
+
+		func (v ArrayT) Foo() string { return "foo" }
+		func (v SliceT) Foo() string { return "foo" }
+		func (v StructT) Foo() string { return "foo" }
+		func (v *StructT2) Foo() string { return "foo" }
+
+		type Array = ArrayT
+		type Slice = SliceT
+		type Struct = StructT
+		type Struct2 = StructT2
+		type Fooer = FooerT
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runTests(t, i, []testCase{
+		{desc: "array", src: "Array{1, 2, 3}.Foo()", res: "foo"},
+		{desc: "slice", src: "Slice{1, 2, 3}.Foo()", res: "foo"},
+		{desc: "struct", src: "Struct{1, 2, 3}.Foo()", res: "foo"},
+		{desc: "*struct", src: "Struct2{1, 2, 3}.Foo()", res: "foo"},
+		{desc: "interface", src: "v := Fooer(Array{1, 2, 3}); v.Foo()", res: "foo"},
+	})
+}

--- a/interp/run.go
+++ b/interp/run.go
@@ -2280,12 +2280,13 @@ func arrayLit(n *node) {
 	index := make([]int, len(child))
 	var max, prev int
 
+	ntyp := n.typ.resolveAlias()
 	for i, c := range child {
 		if c.kind == keyValueExpr {
-			values[i] = genDestValue(n.typ.val, c.child[1])
+			values[i] = genDestValue(ntyp.val, c.child[1])
 			index[i] = int(vInt(c.child[0].rval))
 		} else {
-			values[i] = genDestValue(n.typ.val, c)
+			values[i] = genDestValue(ntyp.val, c)
 			index[i] = prev
 		}
 		prev = index[i] + 1

--- a/interp/type.go
+++ b/interp/type.go
@@ -1335,7 +1335,7 @@ func (t *itype) lookupMethod(name string) (*node, []int) {
 		return t.val.lookupMethod(name)
 	}
 	var index []int
-	m := t.resolveAlias().getMethod(name)
+	m := t.getMethod(name)
 	if m == nil {
 		for i, f := range t.field {
 			if f.embed {
@@ -1344,6 +1344,9 @@ func (t *itype) lookupMethod(name string) (*node, []int) {
 					return n, index
 				}
 			}
+		}
+		if t.cat == aliasT {
+			return t.val.lookupMethod(name)
 		}
 	}
 	return m, index

--- a/interp/type.go
+++ b/interp/type.go
@@ -1311,6 +1311,13 @@ func (t *itype) methodCallType() reflect.Type {
 	return reflect.FuncOf(it, ot, t.rtype.IsVariadic())
 }
 
+func (t *itype) resolveAlias() *itype {
+	for t.cat == aliasT {
+		t = t.val
+	}
+	return t
+}
+
 // GetMethod returns a pointer to the method definition.
 func (t *itype) getMethod(name string) *node {
 	for _, m := range t.method {
@@ -1328,7 +1335,7 @@ func (t *itype) lookupMethod(name string) (*node, []int) {
 		return t.val.lookupMethod(name)
 	}
 	var index []int
-	m := t.getMethod(name)
+	m := t.resolveAlias().getMethod(name)
 	if m == nil {
 		for i, f := range t.field {
 			if f.embed {


### PR DESCRIPTION
Fixes #1150

1. When resolving a selector expression involving an aliased type, resolve the aliased type
2. When building an array literal, resolve the aliased type

Aliases of named array and slice types were the only ones that didn't work, but I added the other test cases for the sake of completeness and through testing.