### PR TITLE
Avoid unnecessary calls to FieldByIndex

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1511,3 +1511,30 @@ func TestIssue1142(t *testing.T) {
 		{src: "a := 1; // foo bar", res: "1"},
 	})
 }
+
+type Issue1149_Array [3]float32
+
+func (v Issue1149_Array) Foo() string  { return "foo" }
+func (v *Issue1149_Array) Bar() string { return "foo" }
+
+func TestIssue1149(t *testing.T) {
+	i := interp.New(interp.Options{})
+	i.Use(interp.Exports{
+		"pkg/pkg": map[string]reflect.Value{
+			"Type": reflect.ValueOf((*Issue1149_Array)(nil)),
+		},
+	})
+	i.ImportUsed()
+
+	_, err := i.Eval(`
+		type Type = pkg.Type
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runTests(t, i, []testCase{
+		{src: "Type{1, 2, 3}.Foo()", res: "foo"},
+		{src: "Type{1, 2, 3}.Bar()", res: "foo"},
+	})
+}

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1512,16 +1512,16 @@ func TestIssue1142(t *testing.T) {
 	})
 }
 
-type Issue1149_Array [3]float32
+type Issue1149Array [3]float32
 
-func (v Issue1149_Array) Foo() string  { return "foo" }
-func (v *Issue1149_Array) Bar() string { return "foo" }
+func (v Issue1149Array) Foo() string  { return "foo" }
+func (v *Issue1149Array) Bar() string { return "foo" }
 
 func TestIssue1149(t *testing.T) {
 	i := interp.New(interp.Options{})
 	i.Use(interp.Exports{
 		"pkg/pkg": map[string]reflect.Value{
-			"Type": reflect.ValueOf((*Issue1149_Array)(nil)),
+			"Type": reflect.ValueOf((*Issue1149Array)(nil)),
 		},
 	})
 	i.ImportUsed()

--- a/interp/run.go
+++ b/interp/run.go
@@ -1965,14 +1965,28 @@ func getIndexSeqPtrMethod(n *node) {
 	next := getExec(n.tnext)
 
 	if n.child[0].typ.TypeOf().Kind() == reflect.Ptr {
-		n.exec = func(f *frame) bltn {
-			getFrame(f, l).data[i] = value(f).Elem().FieldByIndex(fi).Addr().Method(mi)
-			return next
+		if len(fi) == 0 {
+			n.exec = func(f *frame) bltn {
+				getFrame(f, l).data[i] = value(f).Method(mi)
+				return next
+			}
+		} else {
+			n.exec = func(f *frame) bltn {
+				getFrame(f, l).data[i] = value(f).Elem().FieldByIndex(fi).Addr().Method(mi)
+				return next
+			}
 		}
 	} else {
-		n.exec = func(f *frame) bltn {
-			getFrame(f, l).data[i] = value(f).FieldByIndex(fi).Addr().Method(mi)
-			return next
+		if len(fi) == 0 {
+			n.exec = func(f *frame) bltn {
+				getFrame(f, l).data[i] = value(f).Addr().Method(mi)
+				return next
+			}
+		} else {
+			n.exec = func(f *frame) bltn {
+				getFrame(f, l).data[i] = value(f).FieldByIndex(fi).Addr().Method(mi)
+				return next
+			}
 		}
 	}
 }
@@ -1987,14 +2001,28 @@ func getIndexSeqMethod(n *node) {
 	next := getExec(n.tnext)
 
 	if n.child[0].typ.TypeOf().Kind() == reflect.Ptr {
-		n.exec = func(f *frame) bltn {
-			getFrame(f, l).data[i] = value(f).Elem().FieldByIndex(fi).Method(mi)
-			return next
+		if len(fi) == 0 {
+			n.exec = func(f *frame) bltn {
+				getFrame(f, l).data[i] = value(f).Elem().Method(mi)
+				return next
+			}
+		} else {
+			n.exec = func(f *frame) bltn {
+				getFrame(f, l).data[i] = value(f).Elem().FieldByIndex(fi).Method(mi)
+				return next
+			}
 		}
 	} else {
-		n.exec = func(f *frame) bltn {
-			getFrame(f, l).data[i] = value(f).FieldByIndex(fi).Method(mi)
-			return next
+		if len(fi) == 0 {
+			n.exec = func(f *frame) bltn {
+				getFrame(f, l).data[i] = value(f).Method(mi)
+				return next
+			}
+		} else {
+			n.exec = func(f *frame) bltn {
+				getFrame(f, l).data[i] = value(f).FieldByIndex(fi).Method(mi)
+				return next
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1149

Because of how aliases are handled, `n.gen` is set to `getIndexSeqMethod` or `getIndexSeqPtrMethod` in cases like the one described in #1149. As a result, `FieldByIndex` can be called on a value that is not a struct, which causes a panic. This MR updates those two methods to avoid that call if the index array is empty.