### PR TITLE
interp: improve handling of interface values

### DIFF
--- a/_test/issue-1156.go
+++ b/_test/issue-1156.go
@@ -1,0 +1,25 @@
+package main
+
+type myInterface interface {
+	myFunc() string
+}
+
+type V struct{}
+
+func (v *V) myFunc() string { return "hello" }
+
+type U struct {
+	v myInterface
+}
+
+func (u *U) myFunc() string { return u.v.myFunc() }
+
+func main() {
+	x := V{}
+	y := myInterface(&x)
+	y = &U{y}
+	println(y.myFunc())
+}
+
+// Output:
+// hello

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1535,7 +1535,8 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 						}
 					}
 					break
-				} else if s, lind, ok := n.typ.lookupBinField(n.child[1].ident); ok {
+				}
+				if s, lind, ok := n.typ.lookupBinField(n.child[1].ident); ok {
 					// Handle an embedded binary field into a struct field.
 					n.gen = getIndexSeqField
 					lind = append(lind, s.Index...)

--- a/interp/run.go
+++ b/interp/run.go
@@ -1230,6 +1230,14 @@ func call(n *node) {
 						src = def.recv.val
 					} else {
 						src = v(f)
+						for src.IsValid() {
+							// traverse interface indirections to find out concrete type
+							vi, ok := src.Interface().(valueInterface)
+							if !ok {
+								break
+							}
+							src = vi.value
+						}
 					}
 					if recvIndexLater && def.recv != nil && len(def.recv.index) > 0 {
 						if src.Kind() == reflect.Ptr {

--- a/interp/type.go
+++ b/interp/type.go
@@ -1253,25 +1253,25 @@ func (t *itype) fieldSeq(seq []int) *itype {
 }
 
 // lookupField returns a list of indices, i.e. a path to access a field in a struct object.
-func (typ *itype) lookupField(name string) []int {
+func (t *itype) lookupField(name string) []int {
 	seen := map[*itype]bool{}
 	var lookup func(*itype) []int
 
-	lookup = func(t *itype) []int {
-		if seen[t] {
+	lookup = func(typ *itype) []int {
+		if seen[typ] {
 			return nil
 		}
-		seen[t] = true
+		seen[typ] = true
 
-		switch t.cat {
+		switch typ.cat {
 		case aliasT, ptrT:
-			return lookup(t.val)
+			return lookup(typ.val)
 		}
-		if fi := t.fieldIndex(name); fi >= 0 {
+		if fi := typ.fieldIndex(name); fi >= 0 {
 			return []int{fi}
 		}
 
-		for i, f := range t.field {
+		for i, f := range typ.field {
 			switch f.typ.cat {
 			case ptrT, structT, interfaceT, aliasT:
 				if index2 := lookup(f.typ); len(index2) > 0 {
@@ -1283,7 +1283,7 @@ func (typ *itype) lookupField(name string) []int {
 		return nil
 	}
 
-	return lookup(typ)
+	return lookup(t)
 }
 
 // lookupBinField returns a structfield and a path to access an embedded binary field in a struct object.

--- a/interp/type.go
+++ b/interp/type.go
@@ -1295,7 +1295,7 @@ func (t *itype) lookupBinField(name string) (s reflect.StructField, index []int,
 		return
 	}
 	rt := t.TypeOf()
-	if t.cat == valueT && rt.Kind() == reflect.Ptr {
+	for t.cat == valueT && rt.Kind() == reflect.Ptr {
 		rt = rt.Elem()
 	}
 	if rt.Kind() != reflect.Struct {


### PR DESCRIPTION
In selector resolution, struct field matching now precedes
method matching. Before struct field matching could be skipped
in case of a matching method, which is incorrect, as demontrated
by _test/issue-1156.go.

Field lookup has been fixed to operate on recursive structures.

Concrete type values are derived when filling a receiver for
interface methods.

LookupBinField has been fixed to skip non struct values.

LookupMethod has been fixed to iterate on interface values as
well as concrete type values.

Fixes #1156.