### PR TITLE
interp: improve field and method resolution in presence of collisions.

### DIFF
--- a/_test/issue-1163.go
+++ b/_test/issue-1163.go
@@ -27,7 +27,7 @@ func (w *Window) HandleEvent(e *WindowEvent) {
 }
 
 func main() {
-	window := Window{
+	window := &Window{
 		Widget: &Button{},
 	}
 	windowevent := &WindowEvent{}

--- a/_test/issue-1163.go
+++ b/_test/issue-1163.go
@@ -1,0 +1,41 @@
+package main
+
+import "fmt"
+
+type WidgetEvent struct {
+	Nothing string
+}
+
+type WidgetControl interface {
+	HandleEvent(e *WidgetEvent)
+}
+
+type Button struct{}
+
+func (b *Button) HandleEvent(e *WidgetEvent) {
+}
+
+type WindowEvent struct {
+	Something int
+}
+
+type Window struct {
+	Widget WidgetControl
+}
+
+func (w *Window) HandleEvent(e *WindowEvent) {
+}
+
+func main() {
+	window := Window{
+		Widget: &Button{},
+	}
+	windowevent := &WindowEvent{}
+	// The next line uses the signature from the wrong method, resulting in an error.
+	// Renaming one of the clashing method names fixes the problem.
+	window.HandleEvent(windowevent)
+	fmt.Println("OK!")
+}
+
+// Output:
+// OK!

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1553,7 +1553,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					n.gen = getIndexSeqField
 					lind = append(lind, s.Index...)
 					if isStruct(n.typ) {
-						// If a method of the same name exists, use it if it is less shallowed.
+						// If a method of the same name exists, use it if it is shallower than the struct field.
 						// if method's depth is the same as field's, this is an error.
 						d := n.typ.methodDepth(n.child[1].ident)
 						if d >= 0 && d < len(lind) {

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1512,7 +1512,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				// Find a matching field.
 				if ti := n.typ.lookupField(n.child[1].ident); len(ti) > 0 {
 					if isStruct(n.typ) {
-						// If a method of the same name exists, use it if it is less shallowed.
+						// If a method of the same name exists, use it if it is shallower than the struct field.
 						// if method's depth is the same as field's, this is an error.
 						d := n.typ.methodDepth(n.child[1].ident)
 						if d >= 0 && d < len(ti) {

--- a/interp/type.go
+++ b/interp/type.go
@@ -1372,6 +1372,17 @@ func (t *itype) lookupMethod(name string) (*node, []int) {
 	return m, index
 }
 
+// methodDepth returns a depth greater or equal to 0, or -1 if no match.
+func (t *itype) methodDepth(name string) int {
+	if m, lint := t.lookupMethod(name); m != nil {
+		return len(lint)
+	}
+	if _, lint, _, ok := t.lookupBinMethod(name); ok {
+		return len(lint)
+	}
+	return -1
+}
+
 // LookupBinMethod returns a method and a path to access a field in a struct object (the receiver).
 func (t *itype) lookupBinMethod(name string) (m reflect.Method, index []int, isPtr, ok bool) {
 	if t.cat == ptrT {


### PR DESCRIPTION
The resolution method was not compliant with the Go specification which
requires to retain the object where the field or method is the most
shallowed.

The detection of ambiguous fields or methods (same depth in different
objects) has also been added.

Fixes #1163.