### PR TITLE
interp: fix method resolution on pointer to binary values

### DIFF
--- a/_test/issue-1167.go
+++ b/_test/issue-1167.go
@@ -17,6 +17,3 @@ func main() {
 
 // Output:
 // P-256
-
-// Output:
-// P-256

--- a/_test/issue-1167.go
+++ b/_test/issue-1167.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+)
+
+func main() {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	pub := key.Public().(*ecdsa.PublicKey)
+	println(pub.Params().Name)
+}
+
+// Output:
+// P-256
+
+// Output:
+// P-256

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1620,7 +1620,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 						n.val = method.Index
 						n.typ = &itype{cat: valueT, rtype: method.Type, recv: n.typ, isBinMethod: true}
 						n.recv = &receiver{node: n.child[0]}
-						n.gen = getIndexBinMethod
+						n.gen = getIndexBinElemMethod
 						n.action = aGetMethod
 					} else if method, ok := reflect.PtrTo(n.typ.val.rtype).MethodByName(n.child[1].ident); ok {
 						n.val = method.Index

--- a/interp/run.go
+++ b/interp/run.go
@@ -1510,6 +1510,20 @@ func getIndexBinMethod(n *node) {
 	}
 }
 
+func getIndexBinElemMethod(n *node) {
+	i := n.findex
+	l := n.level
+	m := n.val.(int)
+	value := genValue(n.child[0])
+	next := getExec(n.tnext)
+
+	n.exec = func(f *frame) bltn {
+		// Can not use .Set() because dest type contains the receiver and source not
+		getFrame(f, l).data[i] = value(f).Elem().Method(m)
+		return next
+	}
+}
+
 func getIndexBinPtrMethod(n *node) {
 	i := n.findex
 	l := n.level


### PR DESCRIPTION
In that case, the value must be derefenced before extracting
the method by index, otherwise an incorrect method is returned.

Fixes #1167.