### PR TITLE
interp: fix array declaration with a typed constant size

### DIFF
--- a/_test/issue-1175.go
+++ b/_test/issue-1175.go
@@ -1,0 +1,18 @@
+package main
+
+type Level int
+
+const (
+	a Level = -1
+	b Level = 5
+	d       = b - a + 1
+)
+
+type counters [d]int
+
+func main() {
+	println(len(counters{}))
+}
+
+// Output:
+// 7

--- a/_test/issue-1175.go
+++ b/_test/issue-1175.go
@@ -1,6 +1,6 @@
 package main
 
-type Level int
+type Level int8
 
 const (
 	a Level = -1

--- a/interp/type.go
+++ b/interp/type.go
@@ -205,15 +205,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 				t.incomplete = true
 				break
 			}
-			if v, ok := sym.rval.Interface().(int); ok {
-				t.length = v
-				break
-			}
-			if c, ok := sym.rval.Interface().(constant.Value); ok {
-				t.length = constToInt(c)
-				break
-			}
-			t.incomplete = true
+			t.length = int(vInt(sym.rval))
 		default:
 			// Size is defined by a numeric constant expression.
 			if _, err = interp.cfg(c0, sc.pkgID); err != nil {

--- a/interp/type.go
+++ b/interp/type.go
@@ -201,7 +201,7 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			if sym.kind != constSym {
 				return nil, c0.cfgErrorf("non-constant array bound %q", c0.ident)
 			}
-			if sym.typ == nil || sym.typ.cat != intT || !sym.rval.IsValid() {
+			if sym.typ == nil || !isInt(sym.typ.TypeOf()) || !sym.rval.IsValid() {
 				t.incomplete = true
 				break
 			}


### PR DESCRIPTION
In parsing array type declaration, The type check of array size was
restricted to `int`. Broaden the test to accept any valid integer
kind.

Fixes #1175.