### PR TITLE
interp: fix handling of interface value in forwarding return calls

### DIFF
--- a/_test/issue-1179.go
+++ b/_test/issue-1179.go
@@ -1,0 +1,23 @@
+package main
+
+type I interface {
+	F()
+}
+
+type T struct {
+	Name string
+}
+
+func (t *T) F() { println("in F", t.Name) }
+
+func NewI(s string) I { return newT(s) }
+
+func newT(s string) *T { return &T{s} }
+
+func main() {
+	i := NewI("test")
+	i.F()
+}
+
+// Output:
+// in F test

--- a/interp/run.go
+++ b/interp/run.go
@@ -1112,20 +1112,8 @@ func call(n *node) {
 		// Function call from a return statement: forward return values (always at frame start).
 		for i := range rtypes {
 			j := n.findex + i
-			ret := n.child[0].typ.ret[i]
-			callret := n.anc.val.(*node).typ.ret[i]
-
-			if isInterfaceSrc(callret) && !isEmptyInterface(callret) && !isInterfaceSrc(ret) {
-				// Wrap the returned value in a valueInterface in caller frame.
-				rvalues[i] = func(f *frame) reflect.Value {
-					v := reflect.New(ret.rtype).Elem()
-					f.data[j].Set(reflect.ValueOf(valueInterface{n, v}))
-					return v
-				}
-			} else {
-				// Set the return value location in return value of caller frame.
-				rvalues[i] = func(f *frame) reflect.Value { return f.data[j] }
-			}
+			// Set the return value location in return value of caller frame.
+			rvalues[i] = func(f *frame) reflect.Value { return f.data[j] }
 		}
 	default:
 		// Multiple return values frame index are indexed from the node frame index.


### PR DESCRIPTION
Special wrapping of interface value at return is no longer necessary and
must be avoided now.

Fixes #1179.