### PR TITLE
interp: fix swap assign with extra operation

### DIFF
--- a/_test/issue-1181.go
+++ b/_test/issue-1181.go
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	a, b := 1, 2
+	a, b = b, -a
+	println(a, b)
+}
+
+// Output:
+// 2 -1

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1927,7 +1927,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 			case n.rval.IsValid():
 				n.gen = nop
 				n.findex = notInFrame
-			case n.anc.kind == assignStmt && n.anc.action == aAssign:
+			case n.anc.kind == assignStmt && n.anc.action == aAssign && n.anc.nright == 1:
 				dest := n.anc.child[childPos(n)-n.anc.nright]
 				n.typ = dest.typ
 				n.findex = dest.findex


### PR DESCRIPTION
The optimization in unary operaror bypasses the necessary temporary
variable in that case and must be disabled.

Fixes #1181.