### PR TITLE
interp: fix append of values to an array of interface objects

### DIFF
--- a/_test/issue-1185.go
+++ b/_test/issue-1185.go
@@ -1,0 +1,20 @@
+package main
+
+import "io"
+
+type B []byte
+
+func (b B) Write(p []byte) (n int, err error) {
+	b = p
+	return len(p), nil
+}
+
+func main() {
+	b := B{}
+	a := make([]io.Writer, 0)
+	a = append(a, b)
+	println(len(a))
+}
+
+// Output:
+// 1

--- a/interp/run.go
+++ b/interp/run.go
@@ -2984,6 +2984,8 @@ func _append(n *node) {
 				values[i] = genValue(arg)
 			case isInterfaceSrc(n.typ.val):
 				values[i] = genValueInterface(arg)
+			case isInterfaceBin(n.typ.val):
+				values[i] = genInterfaceWrapper(arg, n.typ.val.rtype)
 			case isRecursiveType(n.typ.val, n.typ.val.rtype):
 				values[i] = genValueRecursiveInterface(arg, n.typ.val.rtype)
 			case arg.typ.untyped:
@@ -3008,6 +3010,8 @@ func _append(n *node) {
 			value0 = genValue(n.child[2])
 		case isInterfaceSrc(elem):
 			value0 = genValueInterface(n.child[2])
+		case isInterfaceBin(elem):
+			value0 = genInterfaceWrapper(n.child[2], elem.rtype)
 		case isRecursiveType(elem, elem.rtype):
 			value0 = genValueRecursiveInterface(n.child[2], elem.rtype)
 		case n.child[2].typ.untyped:


### PR DESCRIPTION
Interface wrappers were not properly generated.

Fixes #1185