### PR TITLE
interp: support wrapping of nested interfaces

### DIFF
--- a/_test/issue-1128.go
+++ b/_test/issue-1128.go
@@ -7,4 +7,5 @@ func main() {
 	println(len(c))
 }
 
-// Output: 1
+// Output:
+// 1

--- a/_test/issue-1187.go
+++ b/_test/issue-1187.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+type sink interface {
+	io.Writer
+	io.Closer
+}
+
+func newSink() sink {
+	// return os.Stdout	// Stdout is special in yaegi tests
+	file, err := ioutil.TempFile("", "yaegi-test.*")
+	if err != nil {
+		panic(err)
+	}
+	return file
+}
+
+func main() {
+	s := newSink()
+	n, err := s.Write([]byte("Hello\n"))
+	if err != nil {
+		panic(err)
+	}
+	var writer io.Writer = s
+	m, err := writer.Write([]byte("Hello\n"))
+	if err != nil {
+		panic(err)
+	}
+	var closer io.Closer = s
+	err = closer.Close()
+	if err != nil {
+		panic(err)
+	}
+	err = os.Remove(s.(*os.File).Name())
+	if err != nil {
+		panic(err)
+	}
+	println(m, n)
+}
+
+// Output:
+// 6 6

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1655,9 +1655,12 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					}
 				} else if m, lind, isPtr, ok := n.typ.lookupBinMethod(n.child[1].ident); ok {
 					n.action = aGetMethod
-					if isPtr && n.typ.fieldSeq(lind).cat != ptrT {
+					switch {
+					case isPtr && n.typ.fieldSeq(lind).cat != ptrT:
 						n.gen = getIndexSeqPtrMethod
-					} else {
+					case isInterfaceSrc(n.typ):
+						n.gen = getMethodByName
+					default:
 						n.gen = getIndexSeqMethod
 					}
 					n.recv = &receiver{node: n.child[0], index: lind}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -304,7 +304,8 @@ func New(options Options) *Interpreter {
 	// fastChan disables the cancellable version of channel operations in evalWithContext
 	i.opt.fastChan, _ = strconv.ParseBool(os.Getenv("YAEGI_FAST_CHAN"))
 
-	// specialStdio allows to assign directly io.Writer and io.Reader to os.Stdxxx, even if they are not file descriptors.
+	// specialStdio allows to assign directly io.Writer and io.Reader to os.Stdxxx,
+	// even if they are not file descriptors.
 	i.opt.specialStdio, _ = strconv.ParseBool(os.Getenv("YAEGI_SPECIAL_STDIO"))
 
 	return &i


### PR DESCRIPTION
Add getConcreteType to retrieve the concrete type of a nested interface
value implementing a specific interface for which a wrapper exists.

If method resolution fails at runtime, a panic is now issued instead
of an error message and continue.

Fixes #1187.