### PR TITLE
interp: fix handling map of interfaces

### DIFF
--- a/_test/issue-1189.go
+++ b/_test/issue-1189.go
@@ -1,0 +1,30 @@
+package main
+
+type I interface {
+	Foo() int
+}
+
+type S1 struct {
+	i int
+}
+
+func (s S1) Foo() int { return s.i }
+
+type S2 struct{}
+
+func (s *S2) Foo() int { return 42 }
+
+func main() {
+	Is := map[string]I{
+		"foo": S1{21},
+		"bar": &S2{},
+	}
+	n := 0
+	for _, s := range Is {
+		n += s.Foo()
+	}
+	println(n, Is["foo"].Foo())
+}
+
+// Output:
+// 63 21

--- a/_test/issue-1189.go
+++ b/_test/issue-1189.go
@@ -23,8 +23,9 @@ func main() {
 	for _, s := range Is {
 		n += s.Foo()
 	}
-	println(n, Is["foo"].Foo())
+	bar := "bar"
+	println(n, Is["foo"].Foo(), Is[bar].Foo())
 }
 
 // Output:
-// 63 21
+// 63 21 42


### PR DESCRIPTION
Map handling builtins getIndexMap and rangeMap had some leftover
code of previous way of emulating interfaces, which was modified
following changes in #1017.

Specific code for interfaceT is removed, as not necessary anymore.
Map builtins are now simplified and more robust.

Fixes #1189.