### PR TITLE
interp: improve handling of interface struct field

### DIFF
--- a/_test/issue-1208.go
+++ b/_test/issue-1208.go
@@ -1,0 +1,23 @@
+package main
+
+type Enabler interface {
+	Enabled() bool
+}
+
+type Logger struct {
+	core Enabler
+}
+
+func (log *Logger) GetCore() Enabler { return log.core }
+
+type T struct{}
+
+func (t *T) Enabled() bool { return true }
+
+func main() {
+	base := &Logger{&T{}}
+	println(base.GetCore().Enabled())
+}
+
+// Output:
+// true

--- a/interp/run.go
+++ b/interp/run.go
@@ -2544,6 +2544,8 @@ func doComposite(n *node, hasType bool, keyed bool) {
 			values[fieldIndex] = genValueInterfaceArray(val)
 		case isRecursiveType(ft, rft):
 			values[fieldIndex] = genValueRecursiveInterface(val, rft)
+		case isInterfaceSrc(ft) && !isEmptyInterface(ft):
+			values[fieldIndex] = genValueInterface(val)
 		case isInterface(ft):
 			values[fieldIndex] = genInterfaceWrapper(val, rft)
 		default:


### PR DESCRIPTION
Wrap non empty interface value  in struct field, to allow method
lookup.

Fixes #1208.