### PR TITLE
feat: fix zero instance issue

### DIFF
--- a/_test/struct60.go
+++ b/_test/struct60.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+)
+
+type data struct {
+	S string
+}
+
+func render(v interface{}) {
+	fmt.Println(v)
+}
+
+func main() {
+	render(data{})
+}
+
+// Output:
+// {}

--- a/interp/run.go
+++ b/interp/run.go
@@ -1265,7 +1265,10 @@ func call(n *node) {
 					}
 				default:
 					val := v(f)
-					if !val.IsZero() {
+					// The !val.IsZero is to work around a recursive struct zero interface
+					// issue. Once there is a better way to handle this case, the dest
+					// can just be set.
+					if !val.IsZero() || dest[i].Type().Kind() == reflect.Interface {
 						dest[i].Set(val)
 					}
 				}


### PR DESCRIPTION
When calling a function, if the input param is a "zero" instance, it is not set on the input. This is an issue where the param is an `interface{}` as a `nil` value is set instead of the zero value.

The actual solution for this is to remove the `if !val.IsZero()`, this however runs into an issue on `_test/struct48.go` where we have a zero recursive struct instance (`*interface{}`) and we have no way to get its real type. Should a way be figured out to keep tabs on the original type, the `if` can go away, and in the zero case of `genValueRecursiveInterfacePtrValue`, the actual zero type can be returned. 

Fixes #1215