### PR TITLE
interp: fix handling of forward function declaration

### DIFF
--- a/_test/fun27.go
+++ b/_test/fun27.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func main() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		print("test")
+	}()
+
+	wg.Wait()
+}
+
+func print(state string) {
+	fmt.Println(state)
+}
+
+// Output:
+// test

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -680,6 +680,7 @@ func (interp *Interpreter) ast(src, name string, inc bool) (string, *node, error
 
 		case *ast.FuncDecl:
 			n := addChild(&root, anc, pos, funcDecl, aNop)
+			n.val = n
 			if a.Recv == nil {
 				// function is not a method, create an empty receiver list
 				addChild(&root, astNode{n, nod}, pos, fieldList, aNop)

--- a/interp/value.go
+++ b/interp/value.go
@@ -197,7 +197,19 @@ func genValue(n *node) func(*frame) reflect.Value {
 		} else {
 			v = reflect.ValueOf(n.val)
 		}
-		return func(f *frame) reflect.Value { return v }
+		return func(f *frame) reflect.Value {
+			// It is possible that the nodes val had not been set
+			// when getting the value. In this case, recheck it
+			// at runtime.
+			if !v.IsValid() {
+				return v
+			}
+
+			if w, ok := n.val.(reflect.Value); ok {
+				return w
+			}
+			return reflect.ValueOf(n.val)
+		}
 	default:
 		if n.rval.IsValid() {
 			convertConstantValue(n)

--- a/interp/value.go
+++ b/interp/value.go
@@ -197,19 +197,17 @@ func genValue(n *node) func(*frame) reflect.Value {
 		} else {
 			v = reflect.ValueOf(n.val)
 		}
-		return func(f *frame) reflect.Value {
-			// It is possible that the nodes val had not been set
-			// when getting the value. In this case, recheck it
-			// at runtime.
-			if !v.IsValid() {
-				return v
-			}
-
-			if w, ok := n.val.(reflect.Value); ok {
-				return w
-			}
-			return reflect.ValueOf(n.val)
-		}
+	  // If node value is not yet resolved due to forward function declaration,
+        // then we have to perform node resolution at runtime.
+        if _, ok := v.Interface().(*node); ok {
+            return func(f *frame) reflect.Value { return v }
+        }
+        return func(f *frame) reflect.Value {
+            if w, ok := n.val.(reflect.Value); ok {
+                return w
+            }
+            return reflect.ValueOf(n.val)
+        }
 	default:
 		if n.rval.IsValid() {
 			convertConstantValue(n)

--- a/interp/value.go
+++ b/interp/value.go
@@ -197,17 +197,7 @@ func genValue(n *node) func(*frame) reflect.Value {
 		} else {
 			v = reflect.ValueOf(n.val)
 		}
-		// If node value is not yet resolved due to forward function declaration,
-		// then we have to perform node resolution at runtime.
-		if _, ok := v.Interface().(*node); ok {
-			return func(f *frame) reflect.Value { return v }
-		}
-		return func(f *frame) reflect.Value {
-			if w, ok := n.val.(reflect.Value); ok {
-				return w
-			}
-			return reflect.ValueOf(n.val)
-		}
+		return func(f *frame) reflect.Value { return v }
 	default:
 		if n.rval.IsValid() {
 			convertConstantValue(n)

--- a/interp/value.go
+++ b/interp/value.go
@@ -197,17 +197,17 @@ func genValue(n *node) func(*frame) reflect.Value {
 		} else {
 			v = reflect.ValueOf(n.val)
 		}
-	  // If node value is not yet resolved due to forward function declaration,
-        // then we have to perform node resolution at runtime.
-        if _, ok := v.Interface().(*node); ok {
-            return func(f *frame) reflect.Value { return v }
-        }
-        return func(f *frame) reflect.Value {
-            if w, ok := n.val.(reflect.Value); ok {
-                return w
-            }
-            return reflect.ValueOf(n.val)
-        }
+		// If node value is not yet resolved due to forward function declaration,
+		// then we have to perform node resolution at runtime.
+		if _, ok := v.Interface().(*node); ok {
+			return func(f *frame) reflect.Value { return v }
+		}
+		return func(f *frame) reflect.Value {
+			if w, ok := n.val.(reflect.Value); ok {
+				return w
+			}
+			return reflect.ValueOf(n.val)
+		}
 	default:
 		if n.rval.IsValid() {
 			convertConstantValue(n)


### PR DESCRIPTION
Set node address in `val` field at creation of `funcDecl` node so it can be used correctly at closure generation, even in the case of forward function declarations, where the value was zero.

Fixes #1214