### PR TITLE
interp: create real recursive types with unsafe type swapping

### DIFF
--- a/internal/unsafe2/unsafe.go
+++ b/internal/unsafe2/unsafe.go
@@ -1,0 +1,52 @@
+package unsafe2
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+type dummy struct{}
+
+// DummyType represents a stand-in for a recursive type.
+var DummyType = reflect.TypeOf(dummy{})
+
+type rtype struct {
+	_ [48]byte
+}
+
+type emptyInterface struct {
+	typ *rtype
+	_   unsafe.Pointer
+}
+
+type structField struct {
+	_   int64
+	typ *rtype
+	_   uintptr
+}
+
+type structType struct {
+	rtype
+	_      int64
+	fields []structField
+}
+
+// SwapFieldType swaps the type of the struct field with the given type.
+//
+// The struct type must have been created at runtime. This is very unsafe.
+func SwapFieldType(s reflect.Type, idx int, t reflect.Type) {
+	if s.Kind() != reflect.Struct || idx >= s.NumField() {
+		return
+	}
+
+	rtyp := unpackType(s)
+	styp := (*structType)(unsafe.Pointer(rtyp))
+	f := styp.fields[idx]
+	f.typ = unpackType(t)
+	styp.fields[idx] = f
+}
+
+func unpackType(t reflect.Type) *rtype {
+	v := reflect.New(t).Elem().Interface()
+	return (*emptyInterface)(unsafe.Pointer(&v)).typ
+}

--- a/internal/unsafe2/unsafe_test.go
+++ b/internal/unsafe2/unsafe_test.go
@@ -1,0 +1,33 @@
+package unsafe2_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/traefik/yaegi/internal/unsafe2"
+)
+
+func TestSwapFieldType(t *testing.T) {
+	f := []reflect.StructField{
+		{
+			Name: "A",
+			Type: reflect.TypeOf(int(0)),
+		},
+		{
+			Name: "B",
+			Type: reflect.PtrTo(unsafe2.DummyType),
+		},
+		{
+			Name: "C",
+			Type: reflect.TypeOf(int64(0)),
+		},
+	}
+	typ := reflect.StructOf(f)
+	ntyp := reflect.PtrTo(typ)
+
+	unsafe2.SwapFieldType(typ, 1, ntyp)
+
+	if typ.Field(1).Type != ntyp {
+		t.Fatalf("unexpected field type: want %s; got %s", ntyp, typ.Field(1).Type)
+	}
+}

--- a/interp/run.go
+++ b/interp/run.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"unsafe"
 )
 
 // bltn type defines functions which run at CFG execution.
@@ -568,18 +567,6 @@ func convert(n *node) {
 	}
 }
 
-func isRecursiveType(t *itype, rtype reflect.Type) bool {
-	if t.cat == structT && rtype.Kind() == reflect.Interface {
-		return true
-	}
-	switch t.cat {
-	case aliasT, arrayT, mapT, ptrT, sliceT:
-		return isRecursiveType(t.val, t.val.rtype)
-	default:
-		return false
-	}
-}
-
 func assign(n *node) {
 	next := getExec(n.tnext)
 	dvalue := make([]func(*frame) reflect.Value, n.nleft)
@@ -1038,11 +1025,7 @@ func call(n *node) {
 	switch {
 	case n.child[0].recv != nil:
 		// Compute method receiver value.
-		if isRecursiveType(n.child[0].recv.node.typ, n.child[0].recv.node.typ.rtype) {
-			values = append(values, genValueRecvInterfacePtr(n.child[0]))
-		} else {
-			values = append(values, genValueRecv(n.child[0]))
-		}
+		values = append(values, genValueRecv(n.child[0]))
 		method = true
 	case len(n.child[0].child) > 0 && n.child[0].child[0].typ != nil && isInterfaceSrc(n.child[0].child[0].typ):
 		recvIndexLater = true
@@ -1096,8 +1079,6 @@ func call(n *node) {
 				values = append(values, genValueInterface(c))
 			case isInterfaceBin(arg):
 				values = append(values, genInterfaceWrapper(c, arg.rtype))
-			case isRecursiveType(c.typ, c.typ.rtype):
-				values = append(values, genValueRecursiveInterfacePtrValue(c))
 			default:
 				values = append(values, genValue(c))
 			}
@@ -1852,9 +1833,6 @@ func getIndexSeq(n *node) {
 		fnext := getExec(n.fnext)
 		n.exec = func(f *frame) bltn {
 			v := value(f)
-			if v.Type().Kind() == reflect.Interface && n.child[0].typ.recursive {
-				v = writableDeref(v)
-			}
 			r := v.FieldByIndex(index)
 			getFrame(f, l).data[i] = r
 			if r.Bool() {
@@ -1865,34 +1843,16 @@ func getIndexSeq(n *node) {
 	} else {
 		n.exec = func(f *frame) bltn {
 			v := value(f)
-			if v.Type().Kind() == reflect.Interface && n.child[0].typ.recursive {
-				v = writableDeref(v)
-			}
 			getFrame(f, l).data[i] = v.FieldByIndex(index)
 			return tnext
 		}
 	}
 }
 
-//go:nocheckptr
-func writableDeref(v reflect.Value) reflect.Value {
-	// Here we have an interface to a struct. Any attempt to dereference it will
-	// make a copy of the struct. We need to get a Value to the actual struct.
-	// TODO: using unsafe is a temporary measure. Rethink this.
-	// TODO: InterfaceData has been depreciated, this is even less of a good idea now.
-	return reflect.NewAt(v.Elem().Type(), unsafe.Pointer(v.InterfaceData()[1])).Elem() //nolint:govet,staticcheck
-}
-
 func getPtrIndexSeq(n *node) {
 	index := n.val.([]int)
 	tnext := getExec(n.tnext)
-	var value func(*frame) reflect.Value
-	if isRecursiveType(n.child[0].typ, n.child[0].typ.rtype) {
-		v := genValue(n.child[0])
-		value = func(f *frame) reflect.Value { return v(f).Elem().Elem() }
-	} else {
-		value = genValue(n.child[0])
-	}
+	value := genValue(n.child[0])
 	i := n.findex
 	l := n.level
 
@@ -2546,8 +2506,6 @@ func doComposite(n *node, hasType bool, keyed bool) {
 			values[fieldIndex] = genValueAsFunctionWrapper(val)
 		case isArray(val.typ) && val.typ.val != nil && isInterfaceSrc(val.typ.val):
 			values[fieldIndex] = genValueInterfaceArray(val)
-		case isRecursiveType(ft, rft):
-			values[fieldIndex] = genValueRecursiveInterface(val, rft)
 		case isInterfaceSrc(ft) && !isEmptyInterface(ft):
 			values[fieldIndex] = genValueInterface(val)
 		case isInterface(ft):
@@ -2946,8 +2904,6 @@ func _append(n *node) {
 				values[i] = genValueInterface(arg)
 			case isInterfaceBin(n.typ.val):
 				values[i] = genInterfaceWrapper(arg, n.typ.val.rtype)
-			case isRecursiveType(n.typ.val, n.typ.val.rtype):
-				values[i] = genValueRecursiveInterface(arg, n.typ.val.rtype)
 			case arg.typ.untyped:
 				values[i] = genValueAs(arg, n.child[1].typ.TypeOf().Elem())
 			default:
@@ -2972,8 +2928,6 @@ func _append(n *node) {
 			value0 = genValueInterface(n.child[2])
 		case isInterfaceBin(elem):
 			value0 = genInterfaceWrapper(n.child[2], elem.rtype)
-		case isRecursiveType(elem, elem.rtype):
-			value0 = genValueRecursiveInterface(n.child[2], elem.rtype)
 		case n.child[2].typ.untyped:
 			value0 = genValueAs(n.child[2], n.child[1].typ.TypeOf().Elem())
 		default:

--- a/interp/type.go
+++ b/interp/type.go
@@ -1613,7 +1613,7 @@ func (c *refTypeContext) Clone() *refTypeContext {
 // For recursive named struct or interfaces, as reflect does not permit to
 // create a recursive named struct, a nil type is set temporarily for each recursive
 // field. When done, the nil type fields are updated with the original reflect type
-// pointer using unsafe. We thus obtain a usable recursive type definition, except 
+// pointer using unsafe. We thus obtain a usable recursive type definition, except
 // for string representation, as created reflect types are still unnamed.
 func (t *itype) refType(ctx *refTypeContext) reflect.Type {
 	if ctx == nil {

--- a/interp/type.go
+++ b/interp/type.go
@@ -612,6 +612,8 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 			ident := filepath.Join(n.ident, baseName)
 			sym, _, found = sc.lookup(ident)
 			if !found {
+				t.name = n.ident
+				t.path = sc.pkgID
 				t.incomplete = true
 				sc.sym[n.ident] = &symbol{kind: typeSym, typ: t}
 				break
@@ -855,12 +857,12 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 
 	switch {
 	case t == nil:
-	case t.cat == nilT:
-		t.str = "nil"
 	case t.name != "" && t.path != "":
 		t.str = t.path + "." + t.name
 	case repr.Len() > 0:
 		t.str = repr.String()
+	case t.cat == nilT:
+		t.str = "nil"
 	}
 
 	return t, err

--- a/interp/type.go
+++ b/interp/type.go
@@ -1611,8 +1611,10 @@ func (c *refTypeContext) Clone() *refTypeContext {
 // In simple cases, reflect types are directly mapped from the interpreter
 // counterpart.
 // For recursive named struct or interfaces, as reflect does not permit to
-// create a recursive named struct, an interface{} is returned in place to
-// avoid infinitely nested structs.
+// create a recursive named struct, a nil type is set temporarily for each recursive
+// field. When done, the nil type fields are updated with the original reflect type
+// pointer using unsafe. We thus obtain a usable recursive type definition, except 
+// for string representation, as created reflect types are still unnamed.
 func (t *itype) refType(ctx *refTypeContext) reflect.Type {
 	if ctx == nil {
 		ctx = &refTypeContext{

--- a/interp/type.go
+++ b/interp/type.go
@@ -276,6 +276,11 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 	if n.typ != nil && !n.typ.incomplete {
 		return n.typ, nil
 	}
+	if sname := typeName(n); sname != "" {
+		if sym, _, found := sc.lookup(sname); found && sym.kind == typeSym && sym.typ != nil && sym.typ.isComplete() {
+			return sym.typ, nil
+		}
+	}
 
 	repr := strings.Builder{}
 	t := &itype{node: n, scope: sc}

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -752,10 +752,6 @@ func (check typecheck) builtin(name string, n *node, child []*node, ellipsis boo
 			}
 			return nil
 		}
-		// We cannot check a recursive type.
-		if isRecursiveType(typ, typ.TypeOf()) {
-			return nil
-		}
 
 		fun := &node{
 			typ: &itype{


### PR DESCRIPTION
As the unsafe and pointer methods in `reflect` are to be depreciated, and seeing no replacement functions, it is now forced that some unsafe is needed to replace this as when and interface is dereferenced it is made unsettable by reflect.

With this in mind, this adds real recursive types by hot swapping the struct field type on the fly. This removes a lot of compensation code, simplifying all previous cases.

**Note:** While the struct field type is swapped for the real type, the type string is not changed. Due to this, unsafe will recreate the same type.