### PR TITLE
interp: make use of type constructors

### DIFF
--- a/interp/gta.go
+++ b/interp/gta.go
@@ -11,7 +11,7 @@ import (
 // All function bodies are skipped. GTA is necessary to handle out of
 // order declarations and multiple source files packages.
 // rpath is the relative path to the directory containing the source for the package.
-func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, error) {
+func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([]*node, error) {
 	sc := interp.initScopePkg(importPath)
 	var err error
 	var revisit []*node
@@ -266,14 +266,14 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 
 			switch n.child[1].kind {
 			case identExpr, selectorExpr:
-				n.typ = namedOf(typ, importPath, typeName, withNode(n.child[0]), withScope(sc))
+				n.typ = namedOf(typ, pkgName, typeName, withNode(n.child[0]), withScope(sc))
 				n.typ.incomplete = typ.incomplete
 				n.typ.field = typ.field
 				copy(n.typ.method, typ.method)
 			default:
 				n.typ = typ
 				n.typ.name = typeName
-				n.typ.path = importPath
+				n.typ.path = pkgName
 			}
 			n.typ.str = n.typ.path + "." + n.typ.name
 
@@ -312,11 +312,11 @@ func (interp *Interpreter) gta(root *node, rpath, importPath string) ([]*node, e
 }
 
 // gtaRetry (re)applies gta until all global constants and types are defined.
-func (interp *Interpreter) gtaRetry(nodes []*node, importPath string) error {
+func (interp *Interpreter) gtaRetry(nodes []*node, importPath, pkgName string) error {
 	revisit := []*node{}
 	for {
 		for _, n := range nodes {
-			list, err := interp.gta(n, importPath, importPath)
+			list, err := interp.gta(n, importPath, importPath, pkgName)
 			if err != nil {
 				return err
 			}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -537,7 +537,7 @@ func (interp *Interpreter) eval(src, name string, inc bool) (res reflect.Value, 
 	}
 
 	// Perform global types analysis.
-	if err = interp.gtaRetry([]*node{root}, pkgName); err != nil {
+	if err = interp.gtaRetry([]*node{root}, pkgName, pkgName); err != nil {
 		return res, err
 	}
 

--- a/interp/src.go
+++ b/interp/src.go
@@ -97,7 +97,7 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 
 		subRPath := effectivePkg(rPath, importPath)
 		var list []*node
-		list, err = interp.gta(root, subRPath, importPath)
+		list, err = interp.gta(root, subRPath, importPath, pkgName)
 		if err != nil {
 			return "", err
 		}
@@ -106,7 +106,7 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 
 	// Revisit incomplete nodes where GTA could not complete.
 	for _, nodes := range revisit {
-		if err = interp.gtaRetry(nodes, importPath); err != nil {
+		if err = interp.gtaRetry(nodes, importPath, pkgName); err != nil {
 			return "", err
 		}
 	}

--- a/interp/type.go
+++ b/interp/type.go
@@ -246,16 +246,16 @@ const (
 // chanOf returns a channel of the underlying type val.
 func chanOf(val *itype, dir chanDir, opts ...itypeOption) *itype {
 	cat := chanT
-	str := "chan"
+	str := "chan "
 	switch dir {
 	case chanSend:
 		cat = chanSendT
-		str = "chan<-"
+		str = "chan<- "
 	case chanRecv:
 		cat = chanRecvT
-		str = "<-chan"
+		str = "<-chan "
 	}
-	t := &itype{cat: cat, val: val, str: str}
+	t := &itype{cat: cat, val: val, str: str + val.str}
 	for _, opt := range opts {
 		opt(t)
 	}
@@ -678,7 +678,6 @@ func nodeType(interp *Interpreter, sc *scope, n *node) (*itype, error) {
 				return nil, err
 			}
 			t.field = append(t.field, structField{name: f0.ident, typ: typ})
-			repr.WriteString(" " + f0.ident + typ.str[4:])
 			incomplete = incomplete || typ.incomplete
 		}
 		methStr := methodsTypeString(t.field)

--- a/interp/type.go
+++ b/interp/type.go
@@ -118,6 +118,7 @@ type itype struct {
 	recv        *itype        // Receiver type for funcT or nil
 	arg         []*itype      // Argument types if funcT or nil
 	ret         []*itype      // Return types if funcT or nil
+	ptr         *itype        // Pointer to this type. Might be nil
 	method      []*node       // Associated methods or nil
 	name        string        // name of type within its package for a defined type
 	path        string        // for a defined type, the package import path
@@ -215,10 +216,14 @@ func wrapperValueTOf(rtype reflect.Type, val *itype, opts ...itypeOption) *itype
 
 // ptrOf returns a pointer to t.
 func ptrOf(val *itype, opts ...itypeOption) *itype {
+	if val.ptr != nil {
+		return val.ptr
+	}
 	t := &itype{cat: ptrT, val: val, str: "*" + val.str}
 	for _, opt := range opts {
 		opt(t)
 	}
+	val.ptr = t
 	return t
 }
 


### PR DESCRIPTION
It was initially assumed that `nodeType` needed to rebuild the type from scratch, but this is not the case anymore. The existing type constructors are now used in `nodeType` to make it more readable. In doing this some bugs in type strings were found and fixed, along with adding the real package name to the type.

As `ptrOf` is now the only place that pointer types are constructed, it is feasible to cache the pointer type on the value type. To ensures that we have a consistent pointer type for any value type.