### PR TITLE
interp: fix a regression in type checks

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -540,6 +540,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					sym, level, _ = sc.lookup(dest.ident)
 				}
 
+				log.Println(n.cfgErrorf("assign"))
 				err = check.assignExpr(n, dest, src)
 				if err != nil {
 					break
@@ -1450,7 +1451,7 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 				}
 				// TODO(mpl): move any of that code to typecheck?
 				c.typ.node = c
-				if !c.typ.assignableTo(typ) {
+				if !c.typ.assignableTo(typ, c) {
 					err = c.cfgErrorf("cannot use %v (type %v) as type %v in return argument", c.ident, c.typ.cat, typ.cat)
 					return
 				}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -540,7 +540,6 @@ func (interp *Interpreter) cfg(root *node, importPath string) ([]*node, error) {
 					sym, level, _ = sc.lookup(dest.ident)
 				}
 
-				log.Println(n.cfgErrorf("assign"))
 				err = check.assignExpr(n, dest, src)
 				if err != nil {
 					break

--- a/interp/type.go
+++ b/interp/type.go
@@ -1154,7 +1154,7 @@ func (t *itype) comparable() bool {
 	return t.cat == nilT || typ != nil && typ.Comparable()
 }
 
-func (t *itype) assignableTo(o *itype) bool {
+func (t *itype) assignableTo(o *itype, n *node) bool {
 	if t.equals(o) {
 		return true
 	}
@@ -1179,7 +1179,6 @@ func (t *itype) assignableTo(o *itype) bool {
 		return true
 	}
 
-	n := t.node
 	if n == nil || !n.rval.IsValid() {
 		return false
 	}
@@ -1195,7 +1194,7 @@ func (t *itype) assignableTo(o *itype) bool {
 
 // convertibleTo returns true if t is convertible to o.
 func (t *itype) convertibleTo(o *itype) bool {
-	if t.assignableTo(o) {
+	if t.assignableTo(o, nil) {
 		return true
 	}
 


### PR DESCRIPTION
When type checking assignments or conversions, we may have to check
if a constant value, known at compile time, is representable in a given type.
It involves retrieving the value from the node, which is not always
populated in type object. Before #1231, the node value was populated
correctly in the case of #1238, but not since. Anyway, there is no guarantee that this value is
always set, depending on how the type is built.

The assignableTo type method now requires the node
value to be passed explicitely, not relying on how the type was
obtained.

Fixes #1238.