### PR TITLE
interp: fix default types for runes

### DIFF
--- a/_test/rune2.go
+++ b/_test/rune2.go
@@ -1,0 +1,22 @@
+package main
+
+import "fmt"
+
+const majorVersion = '2'
+
+type hashed struct {
+	major byte
+}
+
+func main() {
+	fmt.Println(majorVersion)
+
+	p := new(hashed)
+	p.major = majorVersion
+
+	fmt.Println(p)
+}
+
+// Output:
+// 50
+// &{50}

--- a/interp/type.go
+++ b/interp/type.go
@@ -1773,15 +1773,19 @@ func (t *itype) defaultType(v reflect.Value, sc *scope) *itype {
 
 	typ := t
 	// The default type can also be derived from a constant value.
-	if v.IsValid() && t.TypeOf().Implements(constVal) {
-		// TODO: find a way to get actual types here
+	if v.IsValid() && v.Type().Implements(constVal) {
 		switch v.Interface().(constant.Value).Kind() {
 		case constant.String:
 			typ = sc.getType("string")
 		case constant.Bool:
 			typ = sc.getType("bool")
 		case constant.Int:
-			typ = sc.getType("int")
+			switch t.cat {
+			case int32T:
+				typ = sc.getType("int32")
+			default:
+				typ = sc.getType("int")
+			}
 		case constant.Float:
 			typ = sc.getType("float64")
 		case constant.Complex:


### PR DESCRIPTION
When using an untyped rune in an interface, the default type was blindly untyping it. This fixes this issue.

Fixes #1238