### PR TITLE
interp: fix parsing of late binding consts

### DIFF
--- a/_test/const26.go
+++ b/_test/const26.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+)
+
+func init() {
+	fmt.Println(constString)
+	fmt.Println(const2)
+	fmt.Println(varString)
+}
+
+const constString string = "hello"
+
+const (
+	const1 = iota + 10
+	const2
+	const3
+)
+
+var varString string = "test"
+
+func main() {}
+
+// Output:
+// hello
+// 11
+// test

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -3,7 +3,6 @@ package interp
 import (
 	"path"
 	"path/filepath"
-	"reflect"
 )
 
 // gta performs a global types analysis on the AST, registering types,
@@ -53,7 +52,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 
 			for i := 0; i < n.nleft; i++ {
 				dest, src := n.child[i], n.child[sbase+i]
-				val := reflect.ValueOf(sc.iota)
+				val := src.rval
 				if n.anc.kind == constDecl {
 					if _, err2 := interp.cfg(n, importPath, pkgName); err2 != nil {
 						// Constant value can not be computed yet.


### PR DESCRIPTION
When a const is late binding and specified with a type, the GTA defineStmt was creating the symbol with the current scopes `iota` which is incorrect. The symbol should be created with the source nodes `rval`.

Related to #1158