### PR TITLE
interp: improve processing of recursive types

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -572,7 +572,7 @@ func (interp *Interpreter) cfg(root *node, importPath, pkgName string) ([]*node,
 					dest.gen = nop
 				case isFuncField(dest):
 					// Setting a struct field of function type requires an extra step. Do not optimize.
-				case isCall(src) && !isInterfaceSrc(dest.typ) && !isRecursiveField(dest) && n.kind != defineStmt:
+				case isCall(src) && !isInterfaceSrc(dest.typ) && n.kind != defineStmt:
 					// Call action may perform the assignment directly.
 					if dest.typ.id() != src.typ.id() {
 						// Skip optimitization if returned type doesn't match assigned one.
@@ -2401,20 +2401,6 @@ func isKey(n *node) bool {
 
 func isField(n *node) bool {
 	return n.kind == selectorExpr && len(n.child) > 0 && n.child[0].typ != nil && isStruct(n.child[0].typ)
-}
-
-func isRecursiveField(n *node) bool {
-	if !isField(n) {
-		return false
-	}
-	t := n.typ
-	for t != nil {
-		if t.recursive {
-			return true
-		}
-		t = t.val
-	}
-	return false
 }
 
 func isInConstOrTypeDecl(n *node) bool {

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -63,7 +63,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 				}
 				typ := atyp
 				if typ == nil {
-					if typ, err = nodeType(interp, sc, src); err != nil {
+					if typ, err = nodeType(interp, sc, src); err != nil || typ == nil {
 						return false
 					}
 					val = src.rval
@@ -150,7 +150,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 					}
 					rcvrtype = ptrOf(elementType, withNode(rtn), withScope(sc))
 					rcvrtype.incomplete = elementType.incomplete
-					elementType.method = append(elementType.method, n)
+					elementType.addMethod(n)
 				} else {
 					rcvrtype = sc.getType(typeName)
 					if rcvrtype == nil {
@@ -159,7 +159,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 						rcvrtype = sc.sym[typeName].typ
 					}
 				}
-				rcvrtype.method = append(rcvrtype.method, n)
+				rcvrtype.addMethod(n)
 				n.child[0].child[0].lastChild().typ = rcvrtype
 			case ident == "init":
 				// init functions do not get declared as per the Go spec.
@@ -288,7 +288,9 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 			} else {
 				if sym.typ != nil && (len(sym.typ.method) > 0) {
 					// Type has already been seen as a receiver in a method function
-					n.typ.method = append(n.typ.method, sym.typ.method...)
+					for _, m := range sym.typ.method {
+						n.typ.addMethod(m)
+					}
 				} else {
 					// TODO(mpl): figure out how to detect redeclarations without breaking type aliases.
 					// Allow redeclarations for now.

--- a/interp/type.go
+++ b/interp/type.go
@@ -377,6 +377,7 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen map[*node]bool) (t 
 				return sym.typ, nil
 			}
 			if seen[n] {
+				// TODO (marc): find a better way to distinguish recursive vs incomplete types.
 				sym.typ.incomplete = false
 				return sym.typ, nil
 			}

--- a/interp/type.go
+++ b/interp/type.go
@@ -1633,7 +1633,6 @@ func (t *itype) refType(ctx *refTypeContext) reflect.Type {
 			panic(err)
 		}
 	}
-	recursive := false
 	name := t.path + "/" + t.name
 
 	if t.rtype != nil && !ctx.rebuilding {
@@ -1693,7 +1692,7 @@ func (t *itype) refType(ctx *refTypeContext) reflect.Type {
 			fctx := ctx.Clone()
 			field := reflect.StructField{
 				Name: exportName(f.name), Type: f.typ.refType(fctx),
-				Tag: reflect.StructTag(f.tag), Anonymous: (f.embed && !recursive),
+				Tag: reflect.StructTag(f.tag), Anonymous: f.embed,
 			}
 			fields = append(fields, field)
 			// Find any nil type refs that indicates a rebuild is needed on this field.

--- a/interp/type.go
+++ b/interp/type.go
@@ -1023,42 +1023,6 @@ func (t *itype) addMethod(n *node) {
 	t.method = append(t.method, n)
 }
 
-// ReferTo returns true if the type contains a reference to a
-// full type name. It allows to assess a type recursive status.
-func (t *itype) referTo(name string, seen map[*itype]bool) bool {
-	if t.path+"/"+t.name == name {
-		return true
-	}
-	if seen[t] {
-		return false
-	}
-	seen[t] = true
-	switch t.cat {
-	case aliasT, arrayT, chanT, chanRecvT, chanSendT, ptrT, sliceT, variadicT:
-		return t.val.referTo(name, seen)
-	case funcT:
-		for _, a := range t.arg {
-			if a.referTo(name, seen) {
-				return true
-			}
-		}
-		for _, a := range t.ret {
-			if a.referTo(name, seen) {
-				return true
-			}
-		}
-	case mapT:
-		return t.key.referTo(name, seen) || t.val.referTo(name, seen)
-	case structT, interfaceT:
-		for _, f := range t.field {
-			if f.typ.referTo(name, seen) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func (t *itype) numIn() int {
 	switch t.cat {
 	case funcT:

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -53,10 +53,6 @@ func (check typecheck) assignment(n *node, typ *itype, context string) error {
 		return nil
 	}
 
-	if typ.isIndirectRecursive() || n.typ.isIndirectRecursive() {
-		return nil
-	}
-
 	if !n.typ.assignableTo(typ) {
 		if context == "" {
 			return n.cfgErrorf("cannot use type %s as type %s", n.typ.id(), typ.id())


### PR DESCRIPTION
Make sure to keep always a single copy of incomplete type structures.
Remove remnants of recursive types processing.

Now `import "go.uber.org/zap"` works again (see #1172), fixing regressions
introduced since #1236.