### PR TITLE
interp: fix nil funcs in composite literals

### DIFF
--- a/_test/composite18.go
+++ b/_test/composite18.go
@@ -1,0 +1,32 @@
+package main
+
+import "fmt"
+
+type fn func(string, string) bool
+
+var funcs = []fn{
+	cmpLessFn,
+	cmpGreaterFn,
+	nil,
+}
+
+func cmpLessFn(a string, b string) bool {
+	return a < b
+}
+
+func cmpGreaterFn(a string, b string) bool {
+	return a > b
+}
+
+func main() {
+	for _, f := range funcs {
+		if f == nil {
+			continue
+		}
+		fmt.Println(f("a", "b"))
+	}
+}
+
+// Output:
+// true
+// false

--- a/_test/composite19.go
+++ b/_test/composite19.go
@@ -1,0 +1,33 @@
+package main
+
+import "fmt"
+
+type fn func(string, string) bool
+
+var funcs = map[string]fn{
+	"less":    cmpLessFn,
+	"greater": cmpGreaterFn,
+	"none":     nil,
+}
+
+func cmpLessFn(a string, b string) bool {
+	return a < b
+}
+
+func cmpGreaterFn(a string, b string) bool {
+	return a > b
+}
+
+func main() {
+	for _, n := range []string{"less", "greater", "none"} {
+		f := funcs[n]
+		if f == nil {
+			continue
+		}
+		fmt.Println(f("a", "b"))
+	}
+}
+
+// Output:
+// true
+// false

--- a/interp/value.go
+++ b/interp/value.go
@@ -215,7 +215,7 @@ func genDestValue(typ *itype, n *node) func(*frame) reflect.Value {
 	switch {
 	case isInterfaceSrc(typ) && !isEmptyInterface(typ):
 		return genValueInterface(n)
-	case isFuncSrc(typ) && n.typ.cat == valueT:
+	case isFuncSrc(typ) && (n.typ.cat == valueT || n.typ.cat == nilT):
 		return genValueNode(n)
 	case typ.cat == valueT && isFuncSrc(n.typ):
 		return genFunctionWrapper(n)


### PR DESCRIPTION
When a nil are used in a func composite literal, the nil type is a `func` not a `*node`. This handles this case.

Fixes #1249