### PR TITLE
interp: allow GTA revisit for unresolved define statements

### DIFF
--- a/_test/method38.go
+++ b/_test/method38.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/traefik/yaegi/_test/method38"
+)
+
+func main() {
+	fmt.Println(method38.Get())
+}
+
+// Output:
+// &{[] {<nil>}}

--- a/_test/method38/a.go
+++ b/_test/method38/a.go
@@ -1,0 +1,19 @@
+package method38
+
+import "sync"
+
+func NewPool() Pool { return Pool{} }
+
+type Buffer struct {
+	bs   []byte
+	pool Pool
+}
+
+type Pool struct {
+	p *sync.Pool
+}
+
+var (
+	_pool = NewPool()
+	Get   = _pool.Get
+)

--- a/_test/method38/b.go
+++ b/_test/method38/b.go
@@ -1,0 +1,3 @@
+package method38
+
+func (p Pool) Get() *Buffer { return &Buffer{} }

--- a/_test/method39.go
+++ b/_test/method39.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/traefik/yaegi/_test/method38"
+)
+
+func NewPool() Pool { return Pool{} }
+
+type Buffer struct {
+	bs   []byte
+	pool Pool
+}
+
+type Pool struct {
+	p *sync.Pool
+}
+
+var (
+	_pool = NewPool()
+	Get   = _pool.Get
+)
+
+
+func main() {
+	fmt.Println(Get())
+}
+
+// Error:
+// 17:11: undefined selector Get

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -53,6 +53,7 @@ type node struct {
 	val    interface{}    // static generic value (CFG execution)
 	rval   reflect.Value  // reflection value to let runtime access interpreter (CFG)
 	ident  string         // set if node is a var or func
+	meta   interface{}    // meta stores meta information between gta runs, like errors
 }
 
 func (n *node) shouldBreak() bool {

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -56,6 +56,7 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "op9.go" || // expect error
 			file.Name() == "bltn0.go" || // expect error
 			file.Name() == "method16.go" || // private struct field
+			file.Name() == "method39.go" || // expect error
 			file.Name() == "switch8.go" || // expect error
 			file.Name() == "switch9.go" || // expect error
 			file.Name() == "switch13.go" || // expect error


### PR DESCRIPTION
When a define statement relies on a selector or type that may exist in another file it should revisit once GTA is complete. This allows that revisit.

**Note:** In order to keep the original GTA error for the define statement, so the error received is correct and meaningful, I have added a node `meta` property. I decided to make it generic as it may be useful in future. There may be a better way to stash errors across the GTA runs and am open to suggestion here.

Fixes #1253