### PR TITLE
interp: support type spec assign

### DIFF
--- a/_test/type27.go
+++ b/_test/type27.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+type Foo = int
+
+func (f Foo) Bar() int {
+	return f * f
+}
+
+func main() {
+	x := Foo(1)
+	fmt.Println(x.Bar())
+}
+
+// Error:
+// 7:1: cannot define new methods on non-local type int

--- a/_test/type28.go
+++ b/_test/type28.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+type Foo = int
+
+func (f *Foo) Bar() int {
+	return *f * *f
+}
+
+func main() {
+	x := Foo(1)
+	fmt.Println(x.Bar())
+}
+
+// Error:
+// 7:1: cannot define new methods on non-local type int

--- a/_test/type29.go
+++ b/_test/type29.go
@@ -1,0 +1,12 @@
+package main
+
+var Foo int
+
+func (f Foo) Bar() int {
+	return 1
+}
+
+func main() {}
+
+// Error:
+// 5:1: cannot define new methods on non-local type int

--- a/_test/type30.go
+++ b/_test/type30.go
@@ -1,0 +1,12 @@
+package main
+
+var Foo *int
+
+func (f Foo) Bar() int {
+	return 1
+}
+
+func main() {}
+
+// Error:
+// 5:1: cannot define new methods on non-local type int

--- a/_test/type31.go
+++ b/_test/type31.go
@@ -14,4 +14,4 @@ func main() {
 }
 
 // Error:
-// 9:6: cannot define new methods on non-local type int
+// 5:1: cannot define new methods on non-local type int

--- a/_test/type31.go
+++ b/_test/type31.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+func (f Foo) Bar() int {
+	return f * f
+}
+
+type Foo = int
+
+func main() {
+	x := Foo(1)
+	fmt.Println(x.Bar())
+}
+
+// Error:
+// 9:6: cannot define new methods on non-local type int

--- a/_test/type32.go
+++ b/_test/type32.go
@@ -14,4 +14,4 @@ func main() {
 }
 
 // Error:
-// 9:6: cannot define new methods on non-local type int
+// 5:1: cannot define new methods on non-local type int

--- a/_test/type32.go
+++ b/_test/type32.go
@@ -1,0 +1,17 @@
+package main
+
+import "fmt"
+
+func (f *Foo) Bar() int {
+	return *f * *f
+}
+
+type Foo = int
+
+func main() {
+	x := Foo(1)
+	fmt.Println(x.Bar())
+}
+
+// Error:
+// 9:6: cannot define new methods on non-local type int

--- a/_test/type33.go
+++ b/_test/type33.go
@@ -1,0 +1,11 @@
+package main
+
+func (f *Foo) Bar() int {
+	return *f * *f
+}
+
+func main() {
+}
+
+// Error:
+// 3:1: undefined: Foo

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -93,7 +93,8 @@ const (
 	switchIfStmt
 	typeAssertExpr
 	typeDecl
-	typeSpec
+	typeSpec       // type A int
+	typeSpecAssign // type A = int
 	typeSwitch
 	unaryExpr
 	valueSpec
@@ -176,6 +177,7 @@ var kinds = [...]string{
 	typeAssertExpr:    "typeAssertExpr",
 	typeDecl:          "typeDecl",
 	typeSpec:          "typeSpec",
+	typeSpecAssign:    "typeSpecAssign",
 	typeSwitch:        "typeSwitch",
 	unaryExpr:         "unaryExpr",
 	valueSpec:         "valueSpec",
@@ -826,6 +828,10 @@ func (interp *Interpreter) ast(src, name string, inc bool) (string, *node, error
 			st.push(addChild(&root, anc, pos, typeAssertExpr, aTypeAssert), nod)
 
 		case *ast.TypeSpec:
+			if a.Assign.IsValid() {
+				st.push(addChild(&root, anc, pos, typeSpecAssign, aNop), nod)
+				break
+			}
 			st.push(addChild(&root, anc, pos, typeSpec, aNop), nod)
 
 		case *ast.TypeSwitchStmt:

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -107,7 +107,8 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "type29.go" || // expect error
 			file.Name() == "type30.go" || // expect error
 			file.Name() == "type31.go" || // expect error
-			file.Name() == "type32.go" { // expect error
+			file.Name() == "type32.go" || // expect error
+			file.Name() == "type33.go" { // expect error
 			continue
 		}
 

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -101,7 +101,13 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "server.go" || // syntax parsing
 			file.Name() == "range9.go" || // expect error
 			file.Name() == "unsafe6.go" || // needs go.mod to be 1.17
-			file.Name() == "unsafe7.go" { // needs go.mod to be 1.17
+			file.Name() == "unsafe7.go" || // needs go.mod to be 1.17
+			file.Name() == "type27.go" || // expect error
+			file.Name() == "type28.go" || // expect error
+			file.Name() == "type29.go" || // expect error
+			file.Name() == "type30.go" || // expect error
+			file.Name() == "type31.go" || // expect error
+			file.Name() == "type32.go" { // expect error
 			continue
 		}
 


### PR DESCRIPTION
This supports type spec assign types which disallows the attachment of methods onto the alias type as per the Go spec.

Fixes #1154