### PR TITLE
interp: add a function to directly compile Go AST

### DIFF
--- a/interp/compile_test.go
+++ b/interp/compile_test.go
@@ -1,0 +1,84 @@
+package interp
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/traefik/yaegi/stdlib"
+)
+
+func TestCompileAST(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "_.go", `
+		package main
+
+		import "fmt"
+
+		type Foo struct{}
+
+		var foo Foo
+		const bar = "asdf"
+
+		func main() {
+			fmt.Println(1)
+		}
+	`, 0)
+	if err != nil {
+		panic(err)
+	}
+	if len(file.Imports) != 1 || len(file.Decls) != 5 {
+		panic("wrong number of imports or decls")
+	}
+
+	dType := file.Decls[1].(*ast.GenDecl)
+	dVar := file.Decls[2].(*ast.GenDecl)
+	dConst := file.Decls[3].(*ast.GenDecl)
+	dFunc := file.Decls[4].(*ast.FuncDecl)
+
+	if dType.Tok != token.TYPE {
+		panic("decl[1] is not a type")
+	}
+	if dVar.Tok != token.VAR {
+		panic("decl[2] is not a var")
+	}
+	if dConst.Tok != token.CONST {
+		panic("decl[3] is not a const")
+	}
+
+	cases := []struct {
+		desc string
+		node ast.Node
+		skip string
+	}{
+		{desc: "file", node: file},
+		{desc: "import", node: file.Imports[0]},
+		{desc: "type", node: dType},
+		{desc: "var", node: dVar, skip: "not supported"},
+		{desc: "const", node: dConst},
+		{desc: "func", node: dFunc},
+		{desc: "block", node: dFunc.Body},
+		{desc: "expr", node: dFunc.Body.List[0]},
+	}
+
+	i := New(Options{})
+	_ = i.Use(stdlib.Symbols)
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			if c.skip != "" {
+				t.Skip(c.skip)
+			}
+
+			i := i
+			if _, ok := c.node.(*ast.File); ok {
+				i = New(Options{})
+				_ = i.Use(stdlib.Symbols)
+			}
+			_, err := i.CompileAST(c.node)
+			if err != nil {
+				t.Fatalf("Failed to compile %s: %v", c.desc, err)
+			}
+		})
+	}
+}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -573,7 +573,7 @@ func isFile(filesystem fs.FS, path string) bool {
 }
 
 func (interp *Interpreter) eval(src, name string, inc bool) (res reflect.Value, err error) {
-	prog, err := interp.compile(src, name, inc)
+	prog, err := interp.compileSrc(src, name, inc)
 	if err != nil {
 		return res, err
 	}

--- a/interp/src.go
+++ b/interp/src.go
@@ -73,8 +73,16 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 			return "", err
 		}
 
+		n, err := interp.parse(string(buf), name, false)
+		if err != nil {
+			return "", err
+		}
+		if n == nil {
+			continue
+		}
+
 		var pname string
-		if pname, root, err = interp.ast(string(buf), name, false); err != nil {
+		if pname, root, err = interp.ast(n); err != nil {
 			return "", err
 		}
 		if root == nil {


### PR DESCRIPTION
Adds CompileAST, which can be used to compile Go AST directly. This
allows users to delegate parsing of source to their own code instead of
relying on the interpreter.

CLoses #1251