### PR TITLE
interp: handle alias of an alias

### DIFF
--- a/_test/alias4.go
+++ b/_test/alias4.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type A http.Header
+
+func (a A) Test1() {
+	fmt.Println("test1")
+}
+
+type B A
+
+func (b B) Test2() {
+	fmt.Println("test2")
+}
+
+func main() {
+	b := B{}
+
+	b.Test2()
+}
+
+// Output:
+// test2

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2560,7 +2560,7 @@ func gotoLabel(s *symbol) {
 func compositeGenerator(n *node, typ *itype, rtyp reflect.Type) (gen bltnGenerator) {
 	switch typ.cat {
 	case aliasT, ptrT:
-		gen = compositeGenerator(n, n.typ.val, rtyp)
+		gen = compositeGenerator(n, typ.val, rtyp)
 	case arrayT, sliceT:
 		gen = arrayLit
 	case mapT:

--- a/interp/type.go
+++ b/interp/type.go
@@ -239,6 +239,9 @@ func namedOf(val *itype, path, name string, opts ...itypeOption) *itype {
 	if path != "" {
 		str = path + "." + name
 	}
+	for val.cat == aliasT {
+		val = val.val
+	}
 	t := &itype{cat: aliasT, val: val, path: path, name: name, str: str}
 	for _, opt := range opts {
 		opt(t)


### PR DESCRIPTION
When dealing with an alias of an alias, the actual underlying type of the source alias should be used.