### PR TITLE
feat: add partial support for Go modules to imports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/traefik/yaegi
 
 go 1.16
+
+require golang.org/x/tools v0.1.6

--- a/interp/doc.go
+++ b/interp/doc.go
@@ -9,8 +9,7 @@ Importing packages
 Packages can be imported in source or binary form, using the standard
 Go import statement. In source form, packages are searched first in the
 vendor directory, the preferred way to store source dependencies. If not
-found in vendor, sources modules will be searched in GOPATH. Go modules
-are not supported yet by yaegi.
+found in vendor, sources modules will be searched in GOPATH.
 
 Binary form packages are compiled and linked with the interpreter
 executable, and exposed to scripts with the Use method. The extract

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -182,6 +182,7 @@ type opt struct {
 	stdout       io.Writer     // standard output
 	stderr       io.Writer     // standard error
 	filesystem   fs.FS
+	goCache      string // GOCACHE
 }
 
 // Interpreter contains global resources and state.
@@ -295,6 +296,9 @@ type Options struct {
 	// GoPath sets GOPATH for the interpreter.
 	GoPath string
 
+	// GoCache sets GOCACHE for the interpreter.
+	GoCache string
+
 	// BuildTags sets build constraints for the interpreter.
 	BuildTags []string
 
@@ -313,7 +317,7 @@ type Options struct {
 // New returns a new interpreter.
 func New(options Options) *Interpreter {
 	i := Interpreter{
-		opt:      opt{context: build.Default, filesystem: &realFS{}},
+		opt:      opt{context: build.Default, filesystem: &realFS{}, goCache: options.GoCache},
 		frame:    newFrame(nil, 0, 0),
 		fset:     token.NewFileSet(),
 		universe: initUniverse(),

--- a/interp/src.go
+++ b/interp/src.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/tools/go/packages"
 )
 
 // importSrc calls gta on the source code for the package identified by
@@ -23,22 +25,14 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 		return name, nil
 	}
 
-	// For relative import paths in the form "./xxx" or "../xxx", the initial
-	// base path is the directory of the interpreter input file, or "." if no file
-	// was provided.
-	// In all other cases, absolute import paths are resolved from the GOPATH
-	// and the nested "vendor" directories.
+	// resolve relative and absolute import paths
 	if isPathRelative(importPath) {
 		if rPath == mainID {
 			rPath = "."
 		}
 		dir = filepath.Join(filepath.Dir(interp.name), rPath, importPath)
-	} else if dir, rPath, err = interp.pkgDir(interp.context.GOPATH, rPath, importPath); err != nil {
-		// Try again, assuming a root dir at the source location.
-		if rPath, err = interp.rootFromSourceLocation(); err != nil {
-			return "", err
-		}
-		if dir, rPath, err = interp.pkgDir(interp.context.GOPATH, rPath, importPath); err != nil {
+	} else {
+		if dir, err = interp.getPackageDir(importPath); err != nil {
 			return "", err
 		}
 	}
@@ -187,99 +181,35 @@ func (interp *Interpreter) rootFromSourceLocation() (string, error) {
 	return root, nil
 }
 
-// pkgDir returns the absolute path in filesystem for a package given its import path
-// and the root of the subtree dependencies.
-func (interp *Interpreter) pkgDir(goPath string, root, importPath string) (string, string, error) {
-	rPath := filepath.Join(root, "vendor")
-	dir := filepath.Join(goPath, "src", rPath, importPath)
-
-	if _, err := fs.Stat(interp.opt.filesystem, dir); err == nil {
-		return dir, rPath, nil // found!
-	}
-
-	dir = filepath.Join(goPath, "src", effectivePkg(root, importPath))
-
-	if _, err := fs.Stat(interp.opt.filesystem, dir); err == nil {
-		return dir, root, nil // found!
-	}
-
-	if len(root) == 0 {
-		if interp.context.GOPATH == "" {
-			return "", "", fmt.Errorf("unable to find source related to: %q. Either the GOPATH environment variable, or the Interpreter.Options.GoPath needs to be set", importPath)
-		}
-		return "", "", fmt.Errorf("unable to find source related to: %q", importPath)
-	}
-
-	rootPath := filepath.Join(goPath, "src", root)
-	prevRoot, err := previousRoot(interp.opt.filesystem, rootPath, root)
+// getPackageDir uses the GOPATH to find the absolute path of an import path
+func (interp *Interpreter) getPackageDir(importPath string) (string, error) {
+	// search the standard library and Go modules.
+	config := packages.Config{}
+	config.Env = append(config.Env, "GOPATH="+interp.context.GOPATH, "GOCACHE="+interp.opt.goCache)
+	pkgs, err := packages.Load(&config, importPath)
 	if err != nil {
-		return "", "", err
+		return "", fmt.Errorf("An error occurred retrieving a package from the GOPATH: %v\n%v", importPath, err)
 	}
 
-	return interp.pkgDir(goPath, prevRoot, importPath)
-}
-
-const vendor = "vendor"
-
-// Find the previous source root (vendor > vendor > ... > GOPATH).
-func previousRoot(filesystem fs.FS, rootPath, root string) (string, error) {
-	rootPath = filepath.Clean(rootPath)
-	parent, final := filepath.Split(rootPath)
-	parent = filepath.Clean(parent)
-
-	// TODO(mpl): maybe it works for the special case main, but can't be bothered for now.
-	if root != mainID && final != vendor {
-		root = strings.TrimSuffix(root, string(filepath.Separator))
-		prefix := strings.TrimSuffix(strings.TrimSuffix(rootPath, root), string(filepath.Separator))
-
-		// look for the closest vendor in one of our direct ancestors, as it takes priority.
-		var vendored string
-		for {
-			fi, err := fs.Stat(filesystem, filepath.Join(parent, vendor))
-			if err == nil && fi.IsDir() {
-				vendored = strings.TrimPrefix(strings.TrimPrefix(parent, prefix), string(filepath.Separator))
-				break
-			}
-			if !os.IsNotExist(err) {
-				return "", err
-			}
-
-			// stop when we reach GOPATH/src/blah
-			parent = filepath.Dir(parent)
-			if parent == prefix {
-				break
-			}
-
-			// just an additional failsafe, stop if we reach the filesystem root, or dot (if
-			// we are dealing with relative paths).
-			// TODO(mpl): It should probably be a critical error actually,
-			// as we shouldn't have gone that high up in the tree.
-			if parent == string(filepath.Separator) || parent == "." {
-				break
+	// confirm the import path is found.
+	for _, pkg := range pkgs {
+		for _, goFile := range pkg.GoFiles {
+			if strings.Contains(filepath.Dir(goFile), pkg.Name) {
+				return filepath.Dir(goFile), nil
 			}
 		}
-
-		if vendored != "" {
-			return vendored, nil
-		}
 	}
 
-	// TODO(mpl): the algorithm below might be redundant with the one above,
-	// but keeping it for now. Investigate/simplify/remove later.
-	splitRoot := strings.Split(root, string(filepath.Separator))
-	var index int
-	for i := len(splitRoot) - 1; i >= 0; i-- {
-		if splitRoot[i] == "vendor" {
-			index = i
-			break
-		}
+	// certain go tooldirs are in GOTOOLDIR.
+	// filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(toolDir))), "src", )
+	// linux android darwin dragonfly freebsd nacl netbsd openbsd plan9 solaris
+	switch interp.context.GOOS {
+	case "windows":
+		return filepath.Join("C:/Program Files/Go/src", "unsafe"), nil
+	default:
+		return "", fmt.Errorf("You must set the GOTOOLDIR for this operating system.")
 	}
-
-	if index == 0 {
-		return "", nil
-	}
-
-	return filepath.Join(splitRoot[:index]...), nil
+	return "", fmt.Errorf("An import source could not be found: %q. Set the GOPATH environment variable from Interpreter.Options.GoPath.", importPath)
 }
 
 func effectivePkg(root, path string) string {

--- a/interp/src_test.go
+++ b/interp/src_test.go
@@ -184,7 +184,7 @@ func Test_pkgDir(t *testing.T) {
 				}
 			}
 
-			dir, rPath, err := interp.pkgDir(goPath, test.root, test.path)
+			dir, err := interp.getPackageDir(test.path)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -193,71 +193,8 @@ func Test_pkgDir(t *testing.T) {
 				t.Errorf("[dir] got: %s, want: %s", dir, test.expected.dir)
 			}
 
-			if rPath != test.expected.rpath {
-				t.Errorf(" [rpath] got: %s, want: %s", rPath, test.expected.rpath)
-			}
-		})
-	}
-}
-
-func Test_previousRoot(t *testing.T) {
-	testCases := []struct {
-		desc           string
-		root           string
-		rootPathSuffix string
-		expected       string
-	}{
-		{
-			desc:     "GOPATH",
-			root:     "github.com/foo/pkg/",
-			expected: "",
-		},
-		{
-			desc:     "vendor level 1",
-			root:     "github.com/foo/pkg/vendor/guthib.com/traefik/fromage",
-			expected: "github.com/foo/pkg",
-		},
-		{
-			desc:     "vendor level 2",
-			root:     "github.com/foo/pkg/vendor/guthib.com/traefik/fromage/vendor/guthib.com/traefik/fuu",
-			expected: "github.com/foo/pkg/vendor/guthib.com/traefik/fromage",
-		},
-		{
-			desc:           "vendor is sibling",
-			root:           "github.com/foo/bar",
-			rootPathSuffix: "testdata/src/github.com/foo/bar",
-			expected:       "github.com/foo",
-		},
-		{
-			desc:           "vendor is uncle",
-			root:           "github.com/foo/bar/baz",
-			rootPathSuffix: "testdata/src/github.com/foo/bar/baz",
-			expected:       "github.com/foo",
-		},
-	}
-
-	for _, test := range testCases {
-		test := test
-		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
-			var rootPath string
-			if test.rootPathSuffix != "" {
-				wd, err := os.Getwd()
-				if err != nil {
-					t.Fatal(err)
-				}
-				rootPath = filepath.Join(wd, test.rootPathSuffix)
-			} else {
-				rootPath = vendor
-			}
-			p, err := previousRoot(&realFS{}, rootPath, test.root)
-			if err != nil {
-				t.Error(err)
-			}
-
-			if p != test.expected {
-				t.Errorf("got: %s, want: %s", p, test.expected)
+			if test.root != test.expected.rpath {
+				t.Errorf(" [rpath] got: %s, want: %s", test.root, test.expected.rpath)
 			}
 		})
 	}


### PR DESCRIPTION
# Support Go Modules in Imports
This pull request aims to solve these issues:
   - https://github.com/traefik/yaegi/issues/259
   - https://github.com/traefik/yaegi/issues/300
   - https://github.com/traefik/yaegi/issues/656
   - https://github.com/traefik/yaegi/issues/856
   - https://github.com/traefik/yaegi/issues/926
   - https://github.com/traefik/yaegi/issues/300

These give the error `error: unable to find source related to: "github.com/switchupcb/copygen/cli/models". Either the GOPATH environment variable, or the Interpreter.Options.GoPath needs to be set.`

## Problem
There were a few issues with the `pkgDir` method.
1. **The paths printed are all backwards.** 
2. The function runs three times for one call? Presumably to change the separator.
3. Setting goPath from options makes the program hang.
4. References GTA5.
5. Irrelevent variable root is returned.

**OUTPUT of PROBLEM CODE**
`pkgDir(), previousRoot(), effectivePkg()`
`RPATH` generator\vendor
`DIR` src\generator\vendor\github.com\switchupcb\copygen\cli\models
`goPath`
`importPath` github.com/switchupcb/copygen/cli/models
`effectivePkg()` generator\github.com\switchupcb\copygen\cli\models
`RPATH` vendor
`DIR` src\vendor\github.com\switchupcb\copygen\cli\models
`goPath`
`importPath` github.com/switchupcb/copygen/cli/models
`EFFECTIVE` github.com\switchupcb\copygen\cli\models
`RPATH` vendor
`DIR` src\vendor\github.com\switchupcb\copygen\cli\models
`goPath`
`importPath` github.com/switchupcb/copygen/cli/models
`effectivePkg()` github.com\switchupcb\copygen\cli\models
`prevRoot`
`interp.opt.filesystem` &{}
`FRAG` github.com\switchupcb\copygen\cli\models

**THE PROGRAM HANGS ON THIS FUNCTION WHEN GOPATH IS SET**
```go
// Find the previous source root (vendor > vendor > ... > GOPATH).
func previousRoot(filesystem fs.FS, rootPath, root string) (string, error) {
    rootPath = filepath.Clean(rootPath)
    parent, final := filepath.Split(rootPath)
    parent = filepath.Clean(parent)

    // TODO(mpl): maybe it works for the special case main, but can't be bothered for now.
...
```

## Fix
1. Remove the problem code.
2. Don't reverse the filepath.
3. Use cross-platform implementation via `filepath.Join`.

### Solution
Go modules are located in `$GOPATH/pkg/mod`. Vendor files are located somewhere in the project relative to the `go.mod` file. You state that "In all other cases, absolute import paths are resolved from the GOPATH and the nested "vendor" directories." Therefore, we only need to search in a few places.

1. The GOPATH src (for regular imports)
   - Installed during Go installation. 
2. The GOPATH pkg/mod (for Go modules and/or "vendor" dirs)
   - Installed during `go get` or placed.
3. The relative case.
   - Did not touch; however the new case may implement.
4. The vendor files are in the project.

For 1, 2, and 4: https://pkg.go.dev/golang.org/x/tools/go/packages#Package gives a list of files we can filter for the absolute import path. 3 is untouched, BUT should work with the given method. For #856 specifically, the `unsafe` issue is fixed by searching in the `GOTOOLDIR`.

The following code finds a relative path's absolute path from the current working directory. The other code regarding relative path wasn't commented, so I did not implement it.
```go
absgopath, err := filepath.Abs(rPath)
    if err != nil {
        return nil, fmt.Errorf("There was an error retrieving the absolute filepath for the relative path.". rPath)
    }
```

## Test
If GOCACHE is not set, you will get this error: `err: exit status 1: stderr: build cache is required, but could not be located: GOCACHE is not defined and %LocalAppData% is not defined`. During interpretation, you might recieve `stderr: go: creating work dir: mkdir C:\WINDOWS\go-build1065008415: Access is denied.` if an import can't be found and you aren't in administrator (from the command line).

```
go test ./_test 
_test\bad0.go:1:1: expected 'package', found println
package github.com/traefik/yaegi/_test
        imports github.com/traefik/yaegi/_test/c1
        imports github.com/traefik/yaegi/_test/c2
        imports github.com/traefik/yaegi/_test/c1: import cycle not allowed
_test\pkgname0.go:4:2: no required module provides package guthib.com/bar; to add it:
        go get guthib.com/bar
_test\pkgname0.go:5:2: no required module provides package guthib.com/baz; to add it:
        go get guthib.com/baz
_test\ipp_as_key.go:5:2: no required module provides package guthib.com/tata; to add it:
        go get guthib.com/tata
_test\ipp_as_key.go:4:2: no required module provides package guthib.com/toto; to add it:
        go get guthib.com/toto
```
_Note: Did not run install.sh cause its not supported._

## Disclaimer
These changes allow me to use yaegi imports without yaegi extract unless I access custom types (which fail with an out of range error from unsafe). This Pull Request is **NOT** ready to merge and must be modified.