### PR TITLE
Dev

### DIFF
--- a/cmd/yaegi/extract.go
+++ b/cmd/yaegi/extract.go
@@ -18,12 +18,14 @@ func extractCmd(arg []string) error {
 	var name string
 	var exclude string
 	var include string
+	var tag string
 
 	eflag := flag.NewFlagSet("run", flag.ContinueOnError)
 	eflag.StringVar(&licensePath, "license", "", "path to a LICENSE file")
 	eflag.StringVar(&name, "name", "", "the namespace for the extracted symbols")
 	eflag.StringVar(&exclude, "exclude", "", "comma separated list of regexp matching symbols to exclude")
 	eflag.StringVar(&include, "include", "", "comma separated list of regexp matching symbols to include")
+	eflag.StringVar(&tag, "tag", "", "build tag to be added to the created package")
 	eflag.Usage = func() {
 		fmt.Println("Usage: yaegi extract [options] packages...")
 		fmt.Println("Options:")
@@ -55,6 +57,7 @@ func extractCmd(arg []string) error {
 	ext := extract.Extractor{
 		Dest:    name,
 		License: license,
+		Tag:     tag,
 	}
 
 	if exclude != "" {

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -270,6 +270,14 @@ func (e *Extractor) genContent(importPath string, p *types.Package) ([]byte, err
 		}
 	}
 
+	if len(e.Tag) != 0 {
+		prefix := ""
+		if len(buildTags) != 0 {
+			prefix = ","
+		}
+		buildTags += prefix + e.Tag
+	}
+
 	b := new(bytes.Buffer)
 	data := map[string]interface{}{
 		"Dest":       e.Dest,
@@ -336,6 +344,7 @@ type Extractor struct {
 	License string   // License text to be included in the created package, optional.
 	Exclude []string // Comma separated list of regexp matching symbols to exclude.
 	Include []string // Comma separated list of regexp matching symbols to include.
+	Tag     string   // Build tag to be added to the created package.
 }
 
 // importPath checks whether pkgIdent is an existing directory relative to

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -181,6 +181,7 @@ type opt struct {
 	stdin        io.Reader     // standard input
 	stdout       io.Writer     // standard output
 	stderr       io.Writer     // standard error
+	args         []string      // cmdline args
 	filesystem   fs.FS
 }
 
@@ -303,6 +304,9 @@ type Options struct {
 	Stdin          io.Reader
 	Stdout, Stderr io.Writer
 
+	// Cmdline args, defaults to os.Args.
+	Args []string
+
 	// SourcecodeFilesystem is where the _sourcecode_ is loaded from and does
 	// NOT affect the filesystem of scripts when they run.
 	// It can be any fs.FS compliant filesystem (e.g. embed.FS, or fstest.MapFS for testing)
@@ -335,6 +339,10 @@ func New(options Options) *Interpreter {
 
 	if i.opt.stderr = options.Stderr; i.opt.stderr == nil {
 		i.opt.stderr = os.Stderr
+	}
+
+	if i.opt.args = options.Args; i.opt.args == nil {
+		i.opt.args = os.Args
 	}
 
 	if options.SourcecodeFilesystem != nil {
@@ -716,6 +724,7 @@ func fixStdlib(interp *Interpreter) {
 	}
 
 	if p = interp.binPkg["os"]; p != nil {
+		p["Args"] = reflect.ValueOf(&interp.args).Elem()
 		if interp.specialStdio {
 			// Inherit streams from interpreter even if they do not have a file descriptor.
 			p["Stdin"] = reflect.ValueOf(&stdin).Elem()


### PR DESCRIPTION
This PR includes 2 small features I am working on:
1. Add a tag option in the extract program to optionally give an opportunity to tailor some packages in for example the stdlib, for people who is interested in keeping the final binary size as smaller as possible.

Below `go generate`
```
//go:generate ../cmd/extract/extract -name stdlib -tag stdmime mime mime/multipart mime/quotedprintable
````
produces a header to `stdlib/mime-multipart.go`
```
// Code generated by 'yaegi extract mime/multipart'. DO NOT EDIT.

// +build go1.16,!go1.17,stdmime
```

2. In some cases, we use many yaegi instances in one process, each interpreter will expect its own os.Args. This is done in `interp.go` as an option in Options besides Stdin Stdout and Stderr.