### PR TITLE
interp: virtualize environment in restricted mode

### DIFF
--- a/cmd/yaegi/run.go
+++ b/cmd/yaegi/run.go
@@ -47,7 +47,12 @@ func run(arg []string) error {
 	}
 	args := rflag.Args()
 
-	i := interp.New(interp.Options{GoPath: build.Default.GOPATH, BuildTags: strings.Split(tags, ","), Env: os.Environ()})
+	i := interp.New(interp.Options{
+		GoPath:       build.Default.GOPATH,
+		BuildTags:    strings.Split(tags, ","),
+		Env:          os.Environ(),
+		Unrestricted: useUnrestricted,
+	})
 	if err := i.Use(stdlib.Symbols); err != nil {
 		return err
 	}

--- a/cmd/yaegi/run.go
+++ b/cmd/yaegi/run.go
@@ -47,7 +47,7 @@ func run(arg []string) error {
 	}
 	args := rflag.Args()
 
-	i := interp.New(interp.Options{GoPath: build.Default.GOPATH, BuildTags: strings.Split(tags, ",")})
+	i := interp.New(interp.Options{GoPath: build.Default.GOPATH, BuildTags: strings.Split(tags, ","), Env: os.Environ()})
 	if err := i.Use(stdlib.Symbols); err != nil {
 		return err
 	}

--- a/cmd/yaegi/test.go
+++ b/cmd/yaegi/test.go
@@ -116,7 +116,12 @@ func test(arg []string) (err error) {
 		return err
 	}
 
-	i := interp.New(interp.Options{GoPath: build.Default.GOPATH, BuildTags: strings.Split(tags, ",")})
+	i := interp.New(interp.Options{
+		GoPath:       build.Default.GOPATH,
+		BuildTags:    strings.Split(tags, ","),
+		Env:          os.Environ(),
+		Unrestricted: useUnrestricted,
+	})
 	if err := i.Use(stdlib.Symbols); err != nil {
 		return err
 	}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -169,20 +169,22 @@ type imports map[string]map[string]*symbol
 
 // opt stores interpreter options.
 type opt struct {
-	astDot bool // display AST graph (debug)
-	cfgDot bool // display CFG graph (debug)
 	// dotCmd is the command to process the dot graph produced when astDot and/or
 	// cfgDot is enabled. It defaults to 'dot -Tdot -o <filename>.dot'.
 	dotCmd       string
-	noRun        bool          // compile, but do not run
-	fastChan     bool          // disable cancellable chan operations
-	context      build.Context // build context: GOPATH, build constraints
-	specialStdio bool          // Allows os.Stdin, os.Stdout, os.Stderr to not be file descriptors
-	stdin        io.Reader     // standard input
-	stdout       io.Writer     // standard output
-	stderr       io.Writer     // standard error
-	args         []string      // cmdline args
-	filesystem   fs.FS
+	context      build.Context     // build context: GOPATH, build constraints
+	stdin        io.Reader         // standard input
+	stdout       io.Writer         // standard output
+	stderr       io.Writer         // standard error
+	args         []string          // cmdline args
+	env          map[string]string // environment of interpreter, entries in form of "key=value"
+	filesystem   fs.FS             // filesystem containing sources
+	astDot       bool              // display AST graph (debug)
+	cfgDot       bool              // display CFG graph (debug)
+	noRun        bool              // compile, but do not run
+	fastChan     bool              // disable cancellable chan operations
+	specialStdio bool              // allows os.Stdin, os.Stdout, os.Stderr to not be file descriptors
+	unrestricted bool              // allow use of non sandboxed symbols
 }
 
 // Interpreter contains global resources and state.
@@ -307,6 +309,9 @@ type Options struct {
 	// Cmdline args, defaults to os.Args.
 	Args []string
 
+	// Environment of interpreter. Entries are in the form "key=values".
+	Env []string
+
 	// SourcecodeFilesystem is where the _sourcecode_ is loaded from and does
 	// NOT affect the filesystem of scripts when they run.
 	// It can be any fs.FS compliant filesystem (e.g. embed.FS, or fstest.MapFS for testing)
@@ -317,7 +322,7 @@ type Options struct {
 // New returns a new interpreter.
 func New(options Options) *Interpreter {
 	i := Interpreter{
-		opt:      opt{context: build.Default, filesystem: &realFS{}},
+		opt:      opt{context: build.Default, filesystem: &realFS{}, env: map[string]string{}},
 		frame:    newFrame(nil, 0, 0),
 		fset:     token.NewFileSet(),
 		universe: initUniverse(),
@@ -343,6 +348,15 @@ func New(options Options) *Interpreter {
 
 	if i.opt.args = options.Args; i.opt.args == nil {
 		i.opt.args = os.Args
+	}
+
+	for _, e := range options.Env {
+		a := strings.SplitN(e, "=", 2)
+		if len(a) == 2 {
+			i.opt.env[a[0]] = a[1]
+		} else {
+			i.opt.env[a[0]] = ""
+		}
 	}
 
 	if options.SourcecodeFilesystem != nil {
@@ -374,6 +388,9 @@ func New(options Options) *Interpreter {
 	// specialStdio allows to assign directly io.Writer and io.Reader to os.Stdxxx,
 	// even if they are not file descriptors.
 	i.opt.specialStdio, _ = strconv.ParseBool(os.Getenv("YAEGI_SPECIAL_STDIO"))
+
+	// unrestricted allows to use non sandboxed stdlib symbols.
+	i.opt.unrestricted, _ = strconv.ParseBool(os.Getenv("YAEGI_UNRESTRICTED"))
 
 	return &i
 }
@@ -741,6 +758,22 @@ func fixStdlib(interp *Interpreter) {
 			if s, ok := stderr.(*os.File); ok {
 				p["Stderr"] = reflect.ValueOf(&s).Elem()
 			}
+		}
+		if !interp.unrestricted {
+			// In restricted mode, scripts can only access to a passed virtualized env, and can not write the real one.
+			getenv := func(key string) string { return interp.env[key] }
+			p["Clearenv"] = reflect.ValueOf(func() { interp.env = map[string]string{} })
+			p["ExpandEnv"] = reflect.ValueOf(func(s string) string { return os.Expand(s, getenv) })
+			p["Getenv"] = reflect.ValueOf(getenv)
+			p["LookupEnv"] = reflect.ValueOf(func(key string) (s string, ok bool) { s, ok = interp.env[key]; return })
+			p["Setenv"] = reflect.ValueOf(func(key, value string) error { interp.env[key] = value; return nil })
+			p["Unsetenv"] = reflect.ValueOf(func(key string) error { delete(interp.env, key); return nil })
+			p["Environ"] = reflect.ValueOf(func() (a []string) {
+				for k, v := range interp.env {
+					a = append(a, k+"="+v)
+				}
+				return
+			})
 		}
 	}
 

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1728,12 +1728,6 @@ func TestPassArgs(t *testing.T) {
 }
 
 func TestRestrictedEnv(t *testing.T) {
-	if err := os.Unsetenv("YAEGI_UNRESTRICTED"); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Unsetenv("foo"); err != nil {
-		t.Fatal(err)
-	}
 	i := interp.New(interp.Options{Env: []string{"foo=bar"}})
 	if err := i.Use(stdlib.Symbols); err != nil {
 		t.Fatal(err)

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1728,8 +1728,12 @@ func TestPassArgs(t *testing.T) {
 }
 
 func TestRestrictedEnv(t *testing.T) {
-	os.Unsetenv("YAEGI_UNRESTRICTED")
-	os.Unsetenv("foo")
+	if err := os.Unsetenv("YAEGI_UNRESTRICTED"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Unsetenv("foo"); err != nil {
+		t.Fatal(err)
+	}
 	i := interp.New(interp.Options{Env: []string{"foo=bar"}})
 	if err := i.Use(stdlib.Symbols); err != nil {
 		t.Fatal(err)
@@ -1742,6 +1746,7 @@ func TestRestrictedEnv(t *testing.T) {
 		{src: `s, ok := os.LookupEnv("PATH"); s`, res: ""},
 		{src: `s, ok := os.LookupEnv("PATH"); ok`, res: "false"},
 		{src: `os.Setenv("foo", "baz"); os.Environ()`, res: "[foo=baz]"},
+		{src: `os.ExpandEnv("foo is ${foo}")`, res: "foo is baz"},
 		{src: `os.Unsetenv("foo"); os.Environ()`, res: "[]"},
 		{src: `os.Setenv("foo", "baz"); os.Environ()`, res: "[foo=baz]"},
 		{src: `os.Clearenv(); os.Environ()`, res: "[]"},


### PR DESCRIPTION
In restricted mode, replace environment related symbols in
stdlib os package by a version which operates on a private copy
per interpreter context.

It allows to have concurrent interpreters in the same process
operating each in their own environment without affecting each
other or the host.

If unrestricted opt is set, this behaviour is disabled, and the
default symbols from stdlib are used.

Note also that no modification is done for syscall package, as it
should be not used in restricted mode.