### PR TITLE
interp: fix comparison operators in if statement

### DIFF
--- a/internal/cmd/genop/genop.go
+++ b/internal/cmd/genop/genop.go
@@ -557,7 +557,7 @@ func {{$name}}(n *node) {
 				fnext := getExec(n.fnext)
 				n.exec = func(f *frame) bltn {
 					i1 := v1(f).Interface()
-					if i0 != i1 {
+					if i0 {{$op.Name}} i1 {
 						dest(f).SetBool(true)
 						return tnext
 					}
@@ -579,7 +579,7 @@ func {{$name}}(n *node) {
 				fnext := getExec(n.fnext)
 				n.exec = func(f *frame) bltn {
 					i0 := v0(f).Interface()
-					if i0 != i1 {
+					if i0 {{$op.Name}} i1 {
 						dest(f).SetBool(true)
 						return tnext
 					}
@@ -602,7 +602,7 @@ func {{$name}}(n *node) {
 				n.exec = func(f *frame) bltn {
 					i0 := v0(f).Interface()
 					i1 := v1(f).Interface()
-					if i0 != i1 {
+					if i0 {{$op.Name}} i1 {
 						dest(f).SetBool(true)
 						return tnext
 					}

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -418,6 +418,8 @@ func TestEvalComparison(t *testing.T) {
 		{src: `2 > 1`, res: "true"},
 		{src: `1.2 > 1.1`, res: "true"},
 		{src: `"hhh" > "ggg"`, res: "true"},
+		{src: `a, b, c := 1, 1, false; if a == b { c = true }; c`, res: "true"},
+		{src: `a, b, c := 1, 2, false; if a != b { c = true }; c`, res: "true"},
 		{
 			desc: "mismatched types",
 			src: `

--- a/interp/op.go
+++ b/interp/op.go
@@ -2644,7 +2644,7 @@ func equal(n *node) {
 				fnext := getExec(n.fnext)
 				n.exec = func(f *frame) bltn {
 					i1 := v1(f).Interface()
-					if i0 != i1 {
+					if i0 == i1 {
 						dest(f).SetBool(true)
 						return tnext
 					}
@@ -2666,7 +2666,7 @@ func equal(n *node) {
 				fnext := getExec(n.fnext)
 				n.exec = func(f *frame) bltn {
 					i0 := v0(f).Interface()
-					if i0 != i1 {
+					if i0 == i1 {
 						dest(f).SetBool(true)
 						return tnext
 					}
@@ -2689,7 +2689,7 @@ func equal(n *node) {
 				n.exec = func(f *frame) bltn {
 					i0 := v0(f).Interface()
 					i1 := v1(f).Interface()
-					if i0 != i1 {
+					if i0 == i1 {
 						dest(f).SetBool(true)
 						return tnext
 					}


### PR DESCRIPTION
At generation of operator closures, the comparison expression
was hard-coded instead of being derived from the operator name,
leading to a wrong result.

Fixes #1297.