### PR TITLE
interp: fix assignment to a dereferenced struct pointer

### DIFF
--- a/_test/issue-1300.go
+++ b/_test/issue-1300.go
@@ -1,0 +1,20 @@
+package main
+
+const buflen = 512
+
+type T struct {
+	buf []byte
+}
+
+func f(t *T) { *t = T{buf: make([]byte, 0, buflen)} }
+
+func main() {
+	s := T{}
+	println(cap(s.buf))
+	f(&s)
+	println(cap(s.buf))
+}
+
+// Output:
+// 0
+// 512

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -597,7 +597,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 						break
 					}
 					if dest.action == aGetIndex || dest.action == aStar {
-						// Skip optimization, as it does not work when assigning to a struct field or a pointer.
+						// Skip optimization, as it does not work when assigning to a struct field or a dereferenced pointer.
 						break
 					}
 					n.gen = nop

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -596,8 +596,8 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 						// Skip optimisation for assigned interface.
 						break
 					}
-					if dest.action == aGetIndex {
-						// Skip optimization, as it does not work when assigning to a struct field.
+					if dest.action == aGetIndex || dest.action == aStar {
+						// Skip optimization, as it does not work when assigning to a struct field or a pointer.
 						break
 					}
 					n.gen = nop


### PR DESCRIPTION
disable the optimization of skipping assign operation in that case,
as this step is necessary in case of writing to a pointer.

Fixes #1300.