### PR TITLE
interp: avoid collision between type and variable names in assign

### DIFF
--- a/_test/issue-1306.go
+++ b/_test/issue-1306.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func check() (result bool, err error) {
+	return true, nil
+}
+
+func main() {
+	result, error := check()
+	fmt.Println(result, error)
+}
+
+// Output:
+// true <nil>

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2013,7 +2013,7 @@ func compDefineX(sc *scope, n *node) error {
 		} else {
 			types = funtype.ret
 		}
-		if n.child[l-1].isType(sc) {
+		if n.anc.kind == varDecl && n.child[l-1].isType(sc) {
 			l--
 		}
 		if len(types) != l {


### PR DESCRIPTION
Fixes #1306