### PR TITLE
interp: fix handling interface values in assign operators

### DIFF
--- a/_test/issue-1311.go
+++ b/_test/issue-1311.go
@@ -1,0 +1,19 @@
+package main
+
+type T struct {
+	v interface{}
+}
+
+func f() (ret int64, err error) {
+	ret += 2
+	return
+}
+
+func main() {
+	t := &T{}
+	t.v, _ = f()
+	println(t.v.(int64))
+}
+
+// Output:
+// 2

--- a/internal/cmd/genop/genop.go
+++ b/internal/cmd/genop/genop.go
@@ -305,7 +305,11 @@ func {{$name}}Assign(n *node) {
 			v1 := vString(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, s := v0(f)
-				v.SetString(s {{$op.Name}} v1)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(s {{$op.Name}} v1).Convert(typ))
+				} else {
+					v.SetString(s {{$op.Name}} v1)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -321,7 +325,11 @@ func {{$name}}Assign(n *node) {
 			{{end -}}
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i {{$op.Name}} j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i {{$op.Name}} j).Convert(typ))
+				} else {
+					v.SetInt(i {{$op.Name}} j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -332,7 +340,11 @@ func {{$name}}Assign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i {{$op.Name}} j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i {{$op.Name}} j).Convert(typ))
+				} else {
+					v.SetUint(i {{$op.Name}} j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -344,7 +356,11 @@ func {{$name}}Assign(n *node) {
 			j := vFloat(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetFloat(i {{$op.Name}} j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i {{$op.Name}} j).Convert(typ))
+				} else {
+					v.SetFloat(i {{$op.Name}} j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -355,7 +371,11 @@ func {{$name}}Assign(n *node) {
 			v1 := vComplex(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v := v0(f)
-				v.SetComplex(v.Complex() {{$op.Name}} v1)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(v.Complex() {{$op.Name}} v1).Convert(typ))
+				} else {
+					v.SetComplex(v.Complex() {{$op.Name}} v1)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -371,7 +391,11 @@ func {{$name}}Assign(n *node) {
 			v1 := genValue(c1)
 			n.exec = func(f *frame) bltn {
 				v, s := v0(f)
-				v.SetString(s {{$op.Name}} v1(f).String())
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(s {{$op.Name}} v1(f).String()).Convert(typ))
+				} else {
+					v.SetString(s {{$op.Name}} v1(f).String())
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -388,7 +412,11 @@ func {{$name}}Assign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i {{$op.Name}} j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i {{$op.Name}} j).Convert(typ))
+				} else {
+					v.SetInt(i {{$op.Name}} j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -400,7 +428,11 @@ func {{$name}}Assign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i {{$op.Name}} j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i {{$op.Name}} j).Convert(typ))
+				} else {
+					v.SetUint(i {{$op.Name}} j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -413,7 +445,11 @@ func {{$name}}Assign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetFloat(i {{$op.Name}} j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i {{$op.Name}} j).Convert(typ))
+				} else {
+					v.SetFloat(i {{$op.Name}} j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -424,7 +460,11 @@ func {{$name}}Assign(n *node) {
 			v1 := genValue(c1)
 			n.exec = func(f *frame) bltn {
 				v := v0(f)
-				v.SetComplex(v.Complex() {{$op.Name}} v1(f).Complex())
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(v.Complex() {{$op.Name}} v1(f).Complex()).Convert(typ))
+				} else {
+					v.SetComplex(v.Complex() {{$op.Name}} v1(f).Complex())
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -453,7 +493,11 @@ func {{$name}}(n *node) {
 		v0 := genValueInt(c0)
 		n.exec = func(f *frame) bltn {
 			v, i := v0(f)
-			v.SetInt(i {{$op.Name}} 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(i {{$op.Name}} 1).Convert(typ))
+			} else {
+				v.SetInt(i {{$op.Name}} 1)
+			}
 			if setMap {
                 mapValue(f).SetMapIndex(indexValue(f), v)
             }
@@ -463,7 +507,11 @@ func {{$name}}(n *node) {
 		v0 := genValueUint(c0)
 		n.exec = func(f *frame) bltn {
 			v, i := v0(f)
-			v.SetUint(i {{$op.Name}} 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(i {{$op.Name}} 1).Convert(typ))
+			} else {
+				v.SetUint(i {{$op.Name}} 1)
+			}
 			if setMap {
                 mapValue(f).SetMapIndex(indexValue(f), v)
             }
@@ -473,7 +521,11 @@ func {{$name}}(n *node) {
 		v0 := genValueFloat(c0)
 		n.exec = func(f *frame) bltn {
 			v, i := v0(f)
-			v.SetFloat(i {{$op.Name}} 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(i {{$op.Name}} 1).Convert(typ))
+			} else {
+				v.SetFloat(i {{$op.Name}} 1)
+			}
 			if setMap {
                 mapValue(f).SetMapIndex(indexValue(f), v)
             }
@@ -483,7 +535,11 @@ func {{$name}}(n *node) {
 		v0 := genValue(c0)
 		n.exec = func(f *frame) bltn {
 			v := v0(f)
-			v.SetComplex(v.Complex() {{$op.Name}} 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(v.Complex() {{$op.Name}} 1).Convert(typ))
+			} else {
+				v.SetComplex(v.Complex() {{$op.Name}} 1)
+			}
 			if setMap {
                 mapValue(f).SetMapIndex(indexValue(f), v)
             }

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -128,6 +128,7 @@ func TestEvalAssign(t *testing.T) {
 		{src: "i := 1; j := &i; (*j) = 2", res: "2"},
 		{src: "i64 := testpkg.val; i64 == 11", res: "true"},
 		{pre: func() { eval(t, i, "k := 1") }, src: `k := "Hello world"`, res: "Hello world"}, // allow reassignment in subsequent evaluations
+		{src: "f1 := func() (r int) { r++; return }; var t interface{}; t = f1()", res: "1"},
 	})
 }
 

--- a/interp/op.go
+++ b/interp/op.go
@@ -1505,7 +1505,11 @@ func addAssign(n *node) {
 			v1 := vString(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, s := v0(f)
-				v.SetString(s + v1)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(s + v1).Convert(typ))
+				} else {
+					v.SetString(s + v1)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1516,7 +1520,11 @@ func addAssign(n *node) {
 			j := vInt(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i + j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i + j).Convert(typ))
+				} else {
+					v.SetInt(i + j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1527,7 +1535,11 @@ func addAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i + j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i + j).Convert(typ))
+				} else {
+					v.SetUint(i + j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1538,7 +1550,11 @@ func addAssign(n *node) {
 			j := vFloat(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetFloat(i + j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i + j).Convert(typ))
+				} else {
+					v.SetFloat(i + j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1549,7 +1565,11 @@ func addAssign(n *node) {
 			v1 := vComplex(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v := v0(f)
-				v.SetComplex(v.Complex() + v1)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(v.Complex() + v1).Convert(typ))
+				} else {
+					v.SetComplex(v.Complex() + v1)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1563,7 +1583,11 @@ func addAssign(n *node) {
 			v1 := genValue(c1)
 			n.exec = func(f *frame) bltn {
 				v, s := v0(f)
-				v.SetString(s + v1(f).String())
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(s + v1(f).String()).Convert(typ))
+				} else {
+					v.SetString(s + v1(f).String())
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1575,7 +1599,11 @@ func addAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i + j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i + j).Convert(typ))
+				} else {
+					v.SetInt(i + j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1587,7 +1615,11 @@ func addAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i + j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i + j).Convert(typ))
+				} else {
+					v.SetUint(i + j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1599,7 +1631,11 @@ func addAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetFloat(i + j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i + j).Convert(typ))
+				} else {
+					v.SetFloat(i + j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1610,7 +1646,11 @@ func addAssign(n *node) {
 			v1 := genValue(c1)
 			n.exec = func(f *frame) bltn {
 				v := v0(f)
-				v.SetComplex(v.Complex() + v1(f).Complex())
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(v.Complex() + v1(f).Complex()).Convert(typ))
+				} else {
+					v.SetComplex(v.Complex() + v1(f).Complex())
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1639,7 +1679,11 @@ func andAssign(n *node) {
 			j := vInt(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i & j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i & j).Convert(typ))
+				} else {
+					v.SetInt(i & j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1650,7 +1694,11 @@ func andAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i & j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i & j).Convert(typ))
+				} else {
+					v.SetUint(i & j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1665,7 +1713,11 @@ func andAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i & j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i & j).Convert(typ))
+				} else {
+					v.SetInt(i & j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1677,7 +1729,11 @@ func andAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i & j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i & j).Convert(typ))
+				} else {
+					v.SetUint(i & j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1706,7 +1762,11 @@ func andNotAssign(n *node) {
 			j := vInt(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i &^ j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i &^ j).Convert(typ))
+				} else {
+					v.SetInt(i &^ j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1717,7 +1777,11 @@ func andNotAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i &^ j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i &^ j).Convert(typ))
+				} else {
+					v.SetUint(i &^ j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1732,7 +1796,11 @@ func andNotAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i &^ j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i &^ j).Convert(typ))
+				} else {
+					v.SetInt(i &^ j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1744,7 +1812,11 @@ func andNotAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i &^ j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i &^ j).Convert(typ))
+				} else {
+					v.SetUint(i &^ j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1773,7 +1845,11 @@ func mulAssign(n *node) {
 			j := vInt(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i * j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i * j).Convert(typ))
+				} else {
+					v.SetInt(i * j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1784,7 +1860,11 @@ func mulAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i * j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i * j).Convert(typ))
+				} else {
+					v.SetUint(i * j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1795,7 +1875,11 @@ func mulAssign(n *node) {
 			j := vFloat(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetFloat(i * j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i * j).Convert(typ))
+				} else {
+					v.SetFloat(i * j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1806,7 +1890,11 @@ func mulAssign(n *node) {
 			v1 := vComplex(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v := v0(f)
-				v.SetComplex(v.Complex() * v1)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(v.Complex() * v1).Convert(typ))
+				} else {
+					v.SetComplex(v.Complex() * v1)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1821,7 +1909,11 @@ func mulAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i * j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i * j).Convert(typ))
+				} else {
+					v.SetInt(i * j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1833,7 +1925,11 @@ func mulAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i * j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i * j).Convert(typ))
+				} else {
+					v.SetUint(i * j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1845,7 +1941,11 @@ func mulAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetFloat(i * j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i * j).Convert(typ))
+				} else {
+					v.SetFloat(i * j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1856,7 +1956,11 @@ func mulAssign(n *node) {
 			v1 := genValue(c1)
 			n.exec = func(f *frame) bltn {
 				v := v0(f)
-				v.SetComplex(v.Complex() * v1(f).Complex())
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(v.Complex() * v1(f).Complex()).Convert(typ))
+				} else {
+					v.SetComplex(v.Complex() * v1(f).Complex())
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1885,7 +1989,11 @@ func orAssign(n *node) {
 			j := vInt(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i | j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i | j).Convert(typ))
+				} else {
+					v.SetInt(i | j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1896,7 +2004,11 @@ func orAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i | j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i | j).Convert(typ))
+				} else {
+					v.SetUint(i | j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1911,7 +2023,11 @@ func orAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i | j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i | j).Convert(typ))
+				} else {
+					v.SetInt(i | j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1923,7 +2039,11 @@ func orAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i | j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i | j).Convert(typ))
+				} else {
+					v.SetUint(i | j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1952,7 +2072,11 @@ func quoAssign(n *node) {
 			j := vInt(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i / j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i / j).Convert(typ))
+				} else {
+					v.SetInt(i / j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1963,7 +2087,11 @@ func quoAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i / j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i / j).Convert(typ))
+				} else {
+					v.SetUint(i / j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1974,7 +2102,11 @@ func quoAssign(n *node) {
 			j := vFloat(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetFloat(i / j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i / j).Convert(typ))
+				} else {
+					v.SetFloat(i / j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -1985,7 +2117,11 @@ func quoAssign(n *node) {
 			v1 := vComplex(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v := v0(f)
-				v.SetComplex(v.Complex() / v1)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(v.Complex() / v1).Convert(typ))
+				} else {
+					v.SetComplex(v.Complex() / v1)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2000,7 +2136,11 @@ func quoAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i / j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i / j).Convert(typ))
+				} else {
+					v.SetInt(i / j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2012,7 +2152,11 @@ func quoAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i / j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i / j).Convert(typ))
+				} else {
+					v.SetUint(i / j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2024,7 +2168,11 @@ func quoAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetFloat(i / j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i / j).Convert(typ))
+				} else {
+					v.SetFloat(i / j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2035,7 +2183,11 @@ func quoAssign(n *node) {
 			v1 := genValue(c1)
 			n.exec = func(f *frame) bltn {
 				v := v0(f)
-				v.SetComplex(v.Complex() / v1(f).Complex())
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(v.Complex() / v1(f).Complex()).Convert(typ))
+				} else {
+					v.SetComplex(v.Complex() / v1(f).Complex())
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2064,7 +2216,11 @@ func remAssign(n *node) {
 			j := vInt(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i % j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i % j).Convert(typ))
+				} else {
+					v.SetInt(i % j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2075,7 +2231,11 @@ func remAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i % j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i % j).Convert(typ))
+				} else {
+					v.SetUint(i % j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2090,7 +2250,11 @@ func remAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i % j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i % j).Convert(typ))
+				} else {
+					v.SetInt(i % j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2102,7 +2266,11 @@ func remAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i % j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i % j).Convert(typ))
+				} else {
+					v.SetUint(i % j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2131,7 +2299,11 @@ func shlAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i << j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i << j).Convert(typ))
+				} else {
+					v.SetInt(i << j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2142,7 +2314,11 @@ func shlAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i << j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i << j).Convert(typ))
+				} else {
+					v.SetUint(i << j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2157,7 +2333,11 @@ func shlAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i << j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i << j).Convert(typ))
+				} else {
+					v.SetInt(i << j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2169,7 +2349,11 @@ func shlAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i << j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i << j).Convert(typ))
+				} else {
+					v.SetUint(i << j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2198,7 +2382,11 @@ func shrAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i >> j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i >> j).Convert(typ))
+				} else {
+					v.SetInt(i >> j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2209,7 +2397,11 @@ func shrAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i >> j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i >> j).Convert(typ))
+				} else {
+					v.SetUint(i >> j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2224,7 +2416,11 @@ func shrAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i >> j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i >> j).Convert(typ))
+				} else {
+					v.SetInt(i >> j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2236,7 +2432,11 @@ func shrAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i >> j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i >> j).Convert(typ))
+				} else {
+					v.SetUint(i >> j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2265,7 +2465,11 @@ func subAssign(n *node) {
 			j := vInt(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i - j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i - j).Convert(typ))
+				} else {
+					v.SetInt(i - j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2276,7 +2480,11 @@ func subAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i - j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i - j).Convert(typ))
+				} else {
+					v.SetUint(i - j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2287,7 +2495,11 @@ func subAssign(n *node) {
 			j := vFloat(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetFloat(i - j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i - j).Convert(typ))
+				} else {
+					v.SetFloat(i - j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2298,7 +2510,11 @@ func subAssign(n *node) {
 			v1 := vComplex(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v := v0(f)
-				v.SetComplex(v.Complex() - v1)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(v.Complex() - v1).Convert(typ))
+				} else {
+					v.SetComplex(v.Complex() - v1)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2313,7 +2529,11 @@ func subAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i - j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i - j).Convert(typ))
+				} else {
+					v.SetInt(i - j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2325,7 +2545,11 @@ func subAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i - j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i - j).Convert(typ))
+				} else {
+					v.SetUint(i - j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2337,7 +2561,11 @@ func subAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetFloat(i - j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i - j).Convert(typ))
+				} else {
+					v.SetFloat(i - j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2348,7 +2576,11 @@ func subAssign(n *node) {
 			v1 := genValue(c1)
 			n.exec = func(f *frame) bltn {
 				v := v0(f)
-				v.SetComplex(v.Complex() - v1(f).Complex())
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(v.Complex() - v1(f).Complex()).Convert(typ))
+				} else {
+					v.SetComplex(v.Complex() - v1(f).Complex())
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2377,7 +2609,11 @@ func xorAssign(n *node) {
 			j := vInt(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetInt(i ^ j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i ^ j).Convert(typ))
+				} else {
+					v.SetInt(i ^ j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2388,7 +2624,11 @@ func xorAssign(n *node) {
 			j := vUint(c1.rval)
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
-				v.SetUint(i ^ j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i ^ j).Convert(typ))
+				} else {
+					v.SetUint(i ^ j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2403,7 +2643,11 @@ func xorAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetInt(i ^ j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i ^ j).Convert(typ))
+				} else {
+					v.SetInt(i ^ j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2415,7 +2659,11 @@ func xorAssign(n *node) {
 			n.exec = func(f *frame) bltn {
 				v, i := v0(f)
 				_, j := v1(f)
-				v.SetUint(i ^ j)
+				if v.Type().Kind() == reflect.Interface {
+					v.Set(reflect.ValueOf(i ^ j).Convert(typ))
+				} else {
+					v.SetUint(i ^ j)
+				}
 				if setMap {
 					mapValue(f).SetMapIndex(indexValue(f), v)
 				}
@@ -2442,7 +2690,11 @@ func dec(n *node) {
 		v0 := genValueInt(c0)
 		n.exec = func(f *frame) bltn {
 			v, i := v0(f)
-			v.SetInt(i - 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(i - 1).Convert(typ))
+			} else {
+				v.SetInt(i - 1)
+			}
 			if setMap {
 				mapValue(f).SetMapIndex(indexValue(f), v)
 			}
@@ -2452,7 +2704,11 @@ func dec(n *node) {
 		v0 := genValueUint(c0)
 		n.exec = func(f *frame) bltn {
 			v, i := v0(f)
-			v.SetUint(i - 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(i - 1).Convert(typ))
+			} else {
+				v.SetUint(i - 1)
+			}
 			if setMap {
 				mapValue(f).SetMapIndex(indexValue(f), v)
 			}
@@ -2462,7 +2718,11 @@ func dec(n *node) {
 		v0 := genValueFloat(c0)
 		n.exec = func(f *frame) bltn {
 			v, i := v0(f)
-			v.SetFloat(i - 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(i - 1).Convert(typ))
+			} else {
+				v.SetFloat(i - 1)
+			}
 			if setMap {
 				mapValue(f).SetMapIndex(indexValue(f), v)
 			}
@@ -2472,7 +2732,11 @@ func dec(n *node) {
 		v0 := genValue(c0)
 		n.exec = func(f *frame) bltn {
 			v := v0(f)
-			v.SetComplex(v.Complex() - 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(v.Complex() - 1).Convert(typ))
+			} else {
+				v.SetComplex(v.Complex() - 1)
+			}
 			if setMap {
 				mapValue(f).SetMapIndex(indexValue(f), v)
 			}
@@ -2498,7 +2762,11 @@ func inc(n *node) {
 		v0 := genValueInt(c0)
 		n.exec = func(f *frame) bltn {
 			v, i := v0(f)
-			v.SetInt(i + 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(i + 1).Convert(typ))
+			} else {
+				v.SetInt(i + 1)
+			}
 			if setMap {
 				mapValue(f).SetMapIndex(indexValue(f), v)
 			}
@@ -2508,7 +2776,11 @@ func inc(n *node) {
 		v0 := genValueUint(c0)
 		n.exec = func(f *frame) bltn {
 			v, i := v0(f)
-			v.SetUint(i + 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(i + 1).Convert(typ))
+			} else {
+				v.SetUint(i + 1)
+			}
 			if setMap {
 				mapValue(f).SetMapIndex(indexValue(f), v)
 			}
@@ -2518,7 +2790,11 @@ func inc(n *node) {
 		v0 := genValueFloat(c0)
 		n.exec = func(f *frame) bltn {
 			v, i := v0(f)
-			v.SetFloat(i + 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(i + 1).Convert(typ))
+			} else {
+				v.SetFloat(i + 1)
+			}
 			if setMap {
 				mapValue(f).SetMapIndex(indexValue(f), v)
 			}
@@ -2528,7 +2804,11 @@ func inc(n *node) {
 		v0 := genValue(c0)
 		n.exec = func(f *frame) bltn {
 			v := v0(f)
-			v.SetComplex(v.Complex() + 1)
+			if v.Type().Kind() == reflect.Interface {
+				v.Set(reflect.ValueOf(v.Complex() + 1).Convert(typ))
+			} else {
+				v.SetComplex(v.Complex() + 1)
+			}
 			if setMap {
 				mapValue(f).SetMapIndex(indexValue(f), v)
 			}

--- a/interp/run.go
+++ b/interp/run.go
@@ -957,7 +957,7 @@ func genFunctionWrapper(n *node) func(*frame) reflect.Value {
 			} else {
 				// Copy method receiver as first argument.
 				src, dest := rcvr(f), d[numRet]
-				sk, dk := src.Type().Kind(), dest.Type().Kind()
+				sk, dk := src.Kind(), dest.Kind()
 				switch {
 				case sk == reflect.Ptr && dk != reflect.Ptr:
 					dest.Set(src.Elem())
@@ -1328,7 +1328,7 @@ func call(n *node) {
 					// The !val.IsZero is to work around a recursive struct zero interface
 					// issue. Once there is a better way to handle this case, the dest
 					// can just be set.
-					if !val.IsZero() || dest[i].Type().Kind() == reflect.Interface {
+					if !val.IsZero() || dest[i].Kind() == reflect.Interface {
 						dest[i].Set(val)
 					}
 				}
@@ -1566,7 +1566,7 @@ func callBin(n *node) {
 				}
 				out := callFn(value(f), in)
 				for i := 0; i < len(out); i++ {
-					if out[i].Type().Kind() == reflect.Func {
+					if out[i].Kind() == reflect.Func {
 						getFrame(f, n.level).data[n.findex+i] = out[i]
 					} else {
 						getFrame(f, n.level).data[n.findex+i].Set(out[i])
@@ -2533,7 +2533,7 @@ func doCompositeBinStruct(n *node, hasType bool) {
 		}
 		d := value(f)
 		switch {
-		case d.Type().Kind() == reflect.Ptr:
+		case d.Kind() == reflect.Ptr:
 			d.Set(s.Addr())
 		default:
 			d.Set(s)
@@ -2611,7 +2611,7 @@ func doComposite(n *node, hasType bool, keyed bool) {
 		}
 		d := value(f)
 		switch {
-		case d.Type().Kind() == reflect.Ptr:
+		case d.Kind() == reflect.Ptr:
 			d.Set(a.Addr())
 		case destInterface:
 			if len(destType(n).field) > 0 {
@@ -3169,7 +3169,7 @@ func _len(n *node) {
 		val := value
 		value = func(f *frame) reflect.Value {
 			v := val(f).Elem()
-			for v.Type().Kind() == reflect.Ptr {
+			for v.Kind() == reflect.Ptr {
 				v = v.Elem()
 			}
 			return v

--- a/interp/value.go
+++ b/interp/value.go
@@ -521,47 +521,47 @@ func genValueInt(n *node) func(*frame) (reflect.Value, int64) {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return func(f *frame) (reflect.Value, int64) {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return v, 0
-				}
-				return v, v.Elem().Int()
+			if v.Kind() != reflect.Interface {
+				return v, v.Int()
 			}
-			return v, v.Int()
+			if v.IsNil() {
+				return v, 0
+			}
+			return v, v.Elem().Int()
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return func(f *frame) (reflect.Value, int64) {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return v, 0
-				}
-				return v, int64(v.Elem().Uint())
+			if v.Kind() != reflect.Interface {
+				return v, int64(v.Uint())
 			}
-			return v, int64(v.Uint())
+			if v.IsNil() {
+				return v, 0
+			}
+			return v, int64(v.Elem().Uint())
 		}
 	case reflect.Float32, reflect.Float64:
 		return func(f *frame) (reflect.Value, int64) {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return v, 0
-				}
-				return v, int64(v.Elem().Float())
+			if v.Kind() != reflect.Interface {
+				return v, int64(v.Float())
 			}
-			return v, int64(v.Float())
+			if v.IsNil() {
+				return v, 0
+			}
+			return v, int64(v.Elem().Float())
 		}
 	case reflect.Complex64, reflect.Complex128:
 		if n.typ.untyped && n.rval.IsValid() && imag(n.rval.Complex()) == 0 {
 			return func(f *frame) (reflect.Value, int64) {
 				v := value(f)
-				if v.Kind() == reflect.Interface {
-					if v.IsNil() {
-						return v, 0
-					}
-					return v, int64(real(v.Elem().Complex()))
+				if v.Kind() != reflect.Interface {
+					return v, int64(real(v.Complex()))
 				}
-				return v, int64(real(v.Complex()))
+				if v.IsNil() {
+					return v, 0
+				}
+				return v, int64(real(v.Elem().Complex()))
 			}
 		}
 	}
@@ -575,47 +575,47 @@ func genValueUint(n *node) func(*frame) (reflect.Value, uint64) {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return func(f *frame) (reflect.Value, uint64) {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return v, 0
-				}
-				return v, uint64(v.Elem().Int())
+			if v.Kind() != reflect.Interface {
+				return v, uint64(v.Int())
 			}
-			return v, uint64(v.Int())
+			if v.IsNil() {
+				return v, 0
+			}
+			return v, uint64(v.Elem().Int())
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return func(f *frame) (reflect.Value, uint64) {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return v, 0
-				}
-				return v, v.Elem().Uint()
+			if v.Kind() != reflect.Interface {
+				return v, v.Uint()
 			}
-			return v, v.Uint()
+			if v.IsNil() {
+				return v, 0
+			}
+			return v, v.Elem().Uint()
 		}
 	case reflect.Float32, reflect.Float64:
 		return func(f *frame) (reflect.Value, uint64) {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return v, 0
-				}
-				return v, uint64(v.Elem().Float())
+			if v.Kind() != reflect.Interface {
+				return v, uint64(v.Float())
 			}
-			return v, uint64(v.Float())
+			if v.IsNil() {
+				return v, 0
+			}
+			return v, uint64(v.Elem().Float())
 		}
 	case reflect.Complex64, reflect.Complex128:
 		if n.typ.untyped && n.rval.IsValid() && imag(n.rval.Complex()) == 0 {
 			return func(f *frame) (reflect.Value, uint64) {
 				v := value(f)
-				if v.Kind() == reflect.Interface {
-					if v.IsNil() {
-						return v, 0
-					}
-					return v, uint64(real(v.Elem().Complex()))
+				if v.Kind() != reflect.Interface {
+					return v, uint64(real(v.Complex()))
 				}
-				return v, uint64(real(v.Complex()))
+				if v.IsNil() {
+					return v, 0
+				}
+				return v, uint64(real(v.Elem().Complex()))
 			}
 		}
 	}
@@ -629,47 +629,47 @@ func genValueFloat(n *node) func(*frame) (reflect.Value, float64) {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return func(f *frame) (reflect.Value, float64) {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return v, 0
-				}
-				return v, float64(v.Elem().Int())
+			if v.Kind() != reflect.Interface {
+				return v, float64(v.Int())
 			}
-			return v, float64(v.Int())
+			if v.IsNil() {
+				return v, 0
+			}
+			return v, float64(v.Elem().Int())
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return func(f *frame) (reflect.Value, float64) {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return v, 0
-				}
-				return v, float64(v.Elem().Uint())
+			if v.Kind() != reflect.Interface {
+				return v, float64(v.Uint())
 			}
-			return v, float64(v.Uint())
+			if v.IsNil() {
+				return v, 0
+			}
+			return v, float64(v.Elem().Uint())
 		}
 	case reflect.Float32, reflect.Float64:
 		return func(f *frame) (reflect.Value, float64) {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return v, 0
-				}
-				return v, v.Elem().Float()
+			if v.Kind() != reflect.Interface {
+				return v, v.Float()
 			}
-			return v, v.Float()
+			if v.IsNil() {
+				return v, 0
+			}
+			return v, v.Elem().Float()
 		}
 	case reflect.Complex64, reflect.Complex128:
 		if n.typ.untyped && n.rval.IsValid() && imag(n.rval.Complex()) == 0 {
 			return func(f *frame) (reflect.Value, float64) {
 				v := value(f)
-				if v.Kind() == reflect.Interface {
-					if v.IsNil() {
-						return v, 0
-					}
-					return v, real(v.Elem().Complex())
+				if v.Kind() != reflect.Interface {
+					return v, real(v.Complex())
 				}
-				return v, real(v.Complex())
+				if v.IsNil() {
+					return v, 0
+				}
+				return v, real(v.Elem().Complex())
 			}
 		}
 	}
@@ -688,46 +688,46 @@ func genComplex(n *node) func(*frame) complex128 {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return func(f *frame) complex128 {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return 0
-				}
-				return complex(float64(v.Elem().Int()), 0)
+			if v.Kind() != reflect.Interface {
+				return complex(float64(v.Int()), 0)
 			}
-			return complex(float64(v.Int()), 0)
+			if v.IsNil() {
+				return 0
+			}
+			return complex(float64(v.Elem().Int()), 0)
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return func(f *frame) complex128 {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return 0
-				}
-				return complex(float64(v.Elem().Uint()), 0)
+			if v.Kind() != reflect.Interface {
+				return complex(float64(v.Uint()), 0)
 			}
-			return complex(float64(v.Uint()), 0)
+			if v.IsNil() {
+				return 0
+			}
+			return complex(float64(v.Elem().Uint()), 0)
 		}
 	case reflect.Float32, reflect.Float64:
 		return func(f *frame) complex128 {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return 0
-				}
-				return complex(v.Elem().Float(), 0)
+			if v.Kind() != reflect.Interface {
+				return complex(v.Float(), 0)
 			}
-			return complex(v.Float(), 0)
+			if v.IsNil() {
+				return 0
+			}
+			return complex(v.Elem().Float(), 0)
 		}
 	case reflect.Complex64, reflect.Complex128:
 		return func(f *frame) complex128 {
 			v := value(f)
-			if v.Kind() == reflect.Interface {
-				if v.IsNil() {
-					return 0
-				}
-				return v.Elem().Complex()
+			if v.Kind() != reflect.Interface {
+				return v.Complex()
 			}
-			return v.Complex()
+			if v.IsNil() {
+				return 0
+			}
+			return v.Elem().Complex()
 		}
 	}
 	return nil
@@ -737,12 +737,12 @@ func genValueString(n *node) func(*frame) (reflect.Value, string) {
 	value := genValue(n)
 	return func(f *frame) (reflect.Value, string) {
 		v := value(f)
-		if v.Kind() == reflect.Interface {
-			if v.IsNil() {
-				return v, ""
-			}
-			return v, v.Elem().String()
+		if v.Kind() != reflect.Interface {
+			return v, v.String()
 		}
-		return v, v.String()
+		if v.IsNil() {
+			return v, ""
+		}
+		return v, v.Elem().String()
 	}
 }

--- a/stdlib/unsafe/unsafe_go1.17.go
+++ b/stdlib/unsafe/unsafe_go1.17.go
@@ -31,7 +31,7 @@ func slice(i interface{}, l int) interface{} {
 	}
 
 	v := reflect.ValueOf(i)
-	if v.Type().Kind() != reflect.Ptr {
+	if v.Kind() != reflect.Ptr {
 		panic(errors.New("first argument to unsafe.Slice must be pointer"))
 	}
 	if v.IsNil() {


### PR DESCRIPTION
As assign operators may indirectly set interface values, through
conversions or function returns, they must be able to retrieve and
set the value (through Elem() method).

Also for reflect values v, use v.Kind() instead of v.Type().Kind(),
which is cumbersome and less efficient.

Fixes #1311.