### PR TITLE
interp: fix assign of multiple return function call

### DIFF
--- a/_test/issue-1311.go
+++ b/_test/issue-1311.go
@@ -1,0 +1,19 @@
+package main
+
+type T struct {
+	v interface{}
+}
+
+func f() (ret int64, err error) {
+	ret += 2
+	return
+}
+
+func main() {
+	t := &T{}
+	t.v, _ = f()
+	println(t.v.(int64))
+}
+
+// Output:
+// 2


### PR DESCRIPTION
A runtime builtin assignFromCall is added to handle multiple values returned at once. It is necessary if some of the values require to be set to interface values in the caller space, which is performed by reflect.Set in assignFromCall.
 
Fixes #1311.