### PR TITLE
interp: fix type switch when the case type is an interpreted interface

### DIFF
--- a/_test/issue-1315.go
+++ b/_test/issue-1315.go
@@ -1,0 +1,32 @@
+package main
+
+type Intf interface {
+	M()
+}
+
+type T struct {
+	s string
+}
+
+func (t *T) M() { println("in M") }
+
+func f(i interface{}) {
+	switch j := i.(type) {
+	case Intf:
+		j.M()
+	default:
+		println("default")
+	}
+}
+
+func main() {
+	var i Intf
+	var k interface{} = 1
+	i = &T{"hello"}
+	f(i)
+	f(k)
+}
+
+// Output:
+// in M
+// default


### PR DESCRIPTION
Fixes #1315.

With this PR, the package gopkg.in/yaml.v3 works in yaegi (fixes #1296).