### PR TITLE
interp: improve method resolution on embedded fields

### DIFF
--- a/_test/issue-1330.go
+++ b/_test/issue-1330.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+)
+
+type wrappedConn struct {
+	net.Conn
+}
+
+func main() {
+	listener, err := net.Listen("tcp", "127.0.0.1:49153")
+	if err != nil {
+		panic(err)
+	}
+	go func() {
+		_, err := listener.Accept()
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	dialer := &net.Dialer{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: 0,
+		},
+	}
+
+	conn, err := dialer.Dial("tcp", "127.0.0.1:49153")
+	if err != nil {
+		panic(err)
+	}
+
+	t := &wrappedConn{conn}
+	var w io.Writer = t
+	fmt.Println(w.Write != nil)
+}
+
+// Output:
+// true

--- a/_test/issue-1330.go
+++ b/_test/issue-1330.go
@@ -11,16 +11,10 @@ type wrappedConn struct {
 }
 
 func main() {
-	listener, err := net.Listen("tcp", "127.0.0.1:49153")
+	_, err := net.Listen("tcp", "127.0.0.1:49153")
 	if err != nil {
 		panic(err)
 	}
-	go func() {
-		_, err := listener.Accept()
-		if err != nil {
-			panic(err)
-		}
-	}()
 
 	dialer := &net.Dialer{
 		LocalAddr: &net.TCPAddr{
@@ -33,11 +27,16 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	defer conn.Close()
 
 	t := &wrappedConn{conn}
 	var w io.Writer = t
-	fmt.Println(w.Write != nil)
+	if n, err := w.Write([]byte("hello")); err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(n)
+	}
 }
 
 // Output:
-// true
+// 5

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -52,6 +52,7 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "io0.go" || // use random number
 			file.Name() == "issue-1093.go" || // expect error
 			file.Name() == "issue-1276.go" || // expect error
+			file.Name() == "issue-1330.go" || // expect error
 			file.Name() == "op1.go" || // expect error
 			file.Name() == "op7.go" || // expect error
 			file.Name() == "op9.go" || // expect error

--- a/interp/run.go
+++ b/interp/run.go
@@ -1126,12 +1126,35 @@ func methodByName(value reflect.Value, name string, index []int) (v reflect.Valu
 	}
 	for value.Kind() == reflect.Ptr {
 		value = value.Elem()
-		o := value.FieldByIndex(index)
-		if v = o.MethodByName(name); v.IsValid() {
+		if checkFieldIndex(value.Type(), index) {
+			value = value.FieldByIndex(index)
+		}
+		if v = value.MethodByName(name); v.IsValid() {
 			return
 		}
 	}
 	return
+}
+
+func checkFieldIndex(typ reflect.Type, index []int) bool {
+	if len(index) == 0 {
+		return false
+	}
+	t := typ
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return false
+	}
+	i := index[0]
+	if i >= t.NumField() {
+		return false
+	}
+	if len(index) > 1 {
+		return checkFieldIndex(t.Field(i).Type, index[1:])
+	}
+	return true
 }
 
 func call(n *node) {

--- a/interp/run.go
+++ b/interp/run.go
@@ -1086,7 +1086,7 @@ func genInterfaceWrapper(n *node, typ reflect.Type) func(*frame) reflect.Value {
 		for i, m := range methods {
 			if m == nil {
 				// First direct method lookup on field.
-				if r := methodByName(v, names[i]); r.IsValid() {
+				if r := methodByName(v, names[i], indexes[i]); r.IsValid() {
 					w.Field(i + 1).Set(r)
 					continue
 				}
@@ -1115,7 +1115,7 @@ func genInterfaceWrapper(n *node, typ reflect.Type) func(*frame) reflect.Value {
 // The search is extended on valueInterface wrapper if present.
 // If valid, the returned value is a method function with the receiver already set
 // (no need to pass it at call).
-func methodByName(value reflect.Value, name string) (v reflect.Value) {
+func methodByName(value reflect.Value, name string, index []int) (v reflect.Value) {
 	if vi, ok := value.Interface().(valueInterface); ok {
 		if v = getConcreteValue(vi.value).MethodByName(name); v.IsValid() {
 			return
@@ -1126,7 +1126,8 @@ func methodByName(value reflect.Value, name string) (v reflect.Value) {
 	}
 	for value.Kind() == reflect.Ptr {
 		value = value.Elem()
-		if v = value.MethodByName(name); v.IsValid() {
+		o := value.FieldByIndex(index)
+		if v = o.MethodByName(name); v.IsValid() {
 			return
 		}
 	}


### PR DESCRIPTION
The capability to dereference pointers has been added to
methodByName(), improving method lookup on binary values.

Wrapping to valueInterface is performed in a missing use case at
return of function calls. It was done in the nested call, but not
at assign.

Fixes #1330.