### PR TITLE
interp: fix wrapping of returned closure passed to runtime

### DIFF
--- a/_test/issue-1333.go
+++ b/_test/issue-1333.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+)
+
+func mock(name string) http.HandlerFunc {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(rw, "Hello ", name)
+	}
+}
+
+func client(uri string) {
+	resp, err := http.Get(uri)
+	if err != nil {
+		panic(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(body))
+}
+
+func main() {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.Handle("/", mock("foo"))
+	client(server.URL)
+}
+
+// Output:
+// Hello foo

--- a/interp/run.go
+++ b/interp/run.go
@@ -2375,9 +2375,13 @@ func _return(n *node) {
 			}
 			values[i] = genValueInterface(c)
 		case valueT:
-			if t.rtype.Kind() == reflect.Interface {
+			switch t.rtype.Kind() {
+			case reflect.Interface:
 				values[i] = genInterfaceWrapper(c, t.rtype)
-				break
+				continue
+			case reflect.Func:
+				values[i] = genFunctionWrapper(c)
+				continue
 			}
 			fallthrough
 		default:


### PR DESCRIPTION
Fixes #1333.