### PR TITLE
interp: fix passing binary function as parameter

### DIFF
--- a/_test/issue-1361.go
+++ b/_test/issue-1361.go
@@ -9,16 +9,16 @@ type obj struct {
 	num float64
 }
 
-type Func func(o *obj) (r *obj, err error)
+type Fun func(o *obj) (r *obj, err error)
 
-func numFunc(fn func(f float64) float64) Func {
+func numFun(fn func(f float64) float64) Fun {
 	return func(o *obj) (*obj, error) {
 		return &obj{fn(o.num)}, nil
 	}
 }
 
 func main() {
-	f := numFunc(math.Cos)
+	f := numFun(math.Cos)
 	r, err := f(&obj{})
 	fmt.Println(r, err)
 }

--- a/_test/issue-1361.go
+++ b/_test/issue-1361.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+type obj struct {
+	num float64
+}
+
+type Func func(o *obj) (r *obj, err error)
+
+func numFunc(fn func(f float64) float64) Func {
+	return func(o *obj) (*obj, error) {
+		return &obj{fn(o.num)}, nil
+	}
+}
+
+func main() {
+	f := numFunc(math.Cos)
+	r, err := f(&obj{})
+	fmt.Println(r, err)
+}
+
+// Output:
+// &{1} <nil>

--- a/interp/run.go
+++ b/interp/run.go
@@ -1235,6 +1235,8 @@ func call(n *node) {
 				values = append(values, genValueInterface(c))
 			case isInterfaceBin(arg):
 				values = append(values, genInterfaceWrapper(c, arg.rtype))
+			case isFuncSrc(arg):
+				values = append(values, genValueNode(c))
 			default:
 				values = append(values, genValue(c))
 			}

--- a/interp/value.go
+++ b/interp/value.go
@@ -421,7 +421,11 @@ func genValueNode(n *node) func(*frame) reflect.Value {
 	value := genValue(n)
 
 	return func(f *frame) reflect.Value {
-		return reflect.ValueOf(&node{rval: value(f)})
+		v := value(f)
+		if _, ok := v.Interface().(*node); ok {
+			return v
+		}
+		return reflect.ValueOf(&node{rval: v})
 	}
 }
 


### PR DESCRIPTION
Wrap binary function values in a node if passing it
as a parameter to an interperter defined function.

Fixes #1361.