### PR TITLE
interp: fix handling of redeclaration in multi-assign expression

### DIFF
--- a/_test/issue-1365.go
+++ b/_test/issue-1365.go
@@ -1,0 +1,18 @@
+package main
+
+func genInt() (int, error) { return 3, nil }
+
+func getInt() (value int) {
+	value, err := genInt()
+	if err != nil {
+		panic(err)
+	}
+	return
+}
+
+func main() {
+	println(getInt())
+}
+
+// Output:
+// 3

--- a/_test/var16.go
+++ b/_test/var16.go
@@ -12,3 +12,8 @@ func main() {
 	}
 	println("#3")
 }
+
+// Output:
+// getNum
+// getArray
+// #3

--- a/_test/var16.go
+++ b/_test/var16.go
@@ -1,0 +1,14 @@
+package main
+
+func getArray() ([]int, error) { println("getArray"); return []int{1, 2}, nil }
+
+func getNum() (int, error) { println("getNum"); return 3, nil }
+
+func main() {
+	if a, err := getNum(); err != nil {
+		println("#1", a)
+	} else if a, err := getArray(); err != nil {
+		println("#2", a)
+	}
+	println("#3")
+}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2062,8 +2062,8 @@ func compDefineX(sc *scope, n *node) error {
 	for i, t := range types {
 		var index int
 		id := n.child[i].ident
-		if sym, _, ok := sc.lookup(id); ok && sym.kind == varSym {
-			// Reuse symbol in case of a variable redeclaration
+		if sym, _, ok := sc.lookup(id); ok && sym.kind == varSym && sym.typ.equals(t) {
+			// Reuse symbol in case of a variable redeclaration with the same type.
 			index = sym.index
 		} else {
 			index = sc.add(t)

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2060,12 +2060,18 @@ func compDefineX(sc *scope, n *node) error {
 	}
 
 	for i, t := range types {
-		index := sc.add(t)
-		sc.sym[n.child[i].ident] = &symbol{index: index, kind: varSym, typ: t}
+		var index int
+		id := n.child[i].ident
+		if sym, _, ok := sc.lookup(id); ok && sym.kind == varSym {
+			// Reuse symbol in case of a variable redeclaration
+			index = sym.index
+		} else {
+			index = sc.add(t)
+			sc.sym[id] = &symbol{index: index, kind: varSym, typ: t}
+		}
 		n.child[i].typ = t
 		n.child[i].findex = index
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
In a statement like `a, b := f()` if `a` was previously declared,
and has the same type, its symbol must be reused, a new symbol must not override its
previous value. This is now fixed.

Fixes #1365.