### PR TITLE
interp: fix switch expression

### DIFF
--- a/_test/issue-1368.go
+++ b/_test/issue-1368.go
@@ -1,0 +1,16 @@
+package main
+
+const dollar byte = 36
+
+func main() {
+	var c byte = 36
+	switch true {
+	case c == dollar:
+		println("ok")
+	default:
+		println("not ok")
+	}
+}
+
+// Output:
+// ok

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1832,6 +1832,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 					setFNext(c, clauses[i+1])
 				}
 			}
+			sbn.start = clauses[0].start
 			n.start = n.child[0].start
 			n.child[0].tnext = sbn.start
 


### PR DESCRIPTION
The control flow graph was incorrect for the initial clause.

Fixes #1368.