### PR TITLE
Ignore private methods for binary types during type assertion

### DIFF
--- a/_test/issue-1373.go
+++ b/_test/issue-1373.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+)
+
+func NewBadExpr() ast.Expr {
+	return &ast.BadExpr{}
+}
+
+func main() {
+	fmt.Printf("%T\n", NewBadExpr().(*ast.BadExpr))
+}
+
+// Output:
+// *ast.BadExpr

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -3,6 +3,7 @@ package interp
 import (
 	"errors"
 	"go/constant"
+	"go/token"
 	"math"
 	"reflect"
 )
@@ -591,6 +592,12 @@ func (check typecheck) typeAssertionExpr(n *node, typ *itype) error {
 			continue
 		}
 		if tm == nil {
+			// Lookup for non-exported methods is impossible
+			// for bin types, ignore them as they can't be used
+			// directly by the interpreted programs.
+			if !token.IsExported(name) && isBin(typ) {
+				continue
+			}
 			return n.cfgErrorf("impossible type assertion: %s does not implement %s (missing %v method)", typ.id(), n.typ.id(), name)
 		}
 		if tm.recv != nil && tm.recv.TypeOf().Kind() == reflect.Ptr && typ.TypeOf().Kind() != reflect.Ptr {


### PR DESCRIPTION
Fixes #1373 