### PR TITLE
interp: delete incomplete type on pkg import

### DIFF
--- a/interp/gta.go
+++ b/interp/gta.go
@@ -217,6 +217,12 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 					if name == "" {
 						name = interp.pkgNames[ipath]
 					}
+
+					// If an incomplete type exists, delete it
+					if sym, exists := sc.sym[name]; exists && sym.kind == typeSym && sym.typ.incomplete {
+						delete(sc.sym, name)
+					}
+
 					// Imports of a same package are all mapped in the same scope, so we cannot just
 					// map them by their names, otherwise we could have collisions from same-name
 					// imports in different source files of the same package. Therefore, we suffix

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1769,7 +1769,7 @@ func TestIssue1388(t *testing.T) {
 	}
 
 	_, err = i.Eval(`x := errors.New("")`)
-  	if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 }

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1749,3 +1749,26 @@ func TestRestrictedEnv(t *testing.T) {
 		t.Fatal("expected \"\", got " + s)
 	}
 }
+
+func TestIssue1388(t *testing.T) {
+	i := interp.New(interp.Options{Env: []string{"foo=bar"}})
+	err := i.Use(stdlib.Symbols)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = i.Eval(`x := errors.New("")`)
+	if err == nil {
+		t.Fatal("Expected an error")
+	}
+
+	_, err = i.Eval(`import "errors"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = i.Eval(`x := errors.New("")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Closes #1388. When a package is imported, it creates a symbol with a name like `"errors/_.go"`. If a statement such as `x := errors.New(...)` is executed before `import "errors"`, it creates an incomplete type symbol with a name like `"errors"`. Importing the package after the incomplete type symbol has been created does not fix the compile issue because the incomplete type still exists.

To fix this, this PR deletes the incomplete type symbol, if one exists.