### PR TITLE
interp: fix creation of binary composite types

### DIFF
--- a/_test/issue-1381.go
+++ b/_test/issue-1381.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func main() {
+	var bufPtrOne *bytes.Buffer
+	var bufPtrTwo *bytes.Buffer
+
+	for i := 0; i < 2; i++ {
+		bufOne := bytes.Buffer{}
+		bufTwo := &bytes.Buffer{}
+
+		if bufPtrOne == nil {
+			bufPtrOne = &bufOne
+		} else if bufPtrOne == &bufOne {
+			fmt.Println("KO")
+		}
+		if bufPtrTwo == nil {
+			bufPtrTwo = bufTwo
+		} else if bufPtrTwo == bufTwo {
+			fmt.Println("KO")
+		}
+	}
+
+	bufPtrOne = nil
+	bufPtrTwo = nil
+
+	for i := 0; i < 2; i++ {
+		var bufOne bytes.Buffer
+		bufTwo := new(bytes.Buffer)
+
+		if bufPtrOne == nil {
+			bufPtrOne = &bufOne
+		} else if bufPtrOne != &bufOne {
+			fmt.Println("OK")
+		}
+		if bufPtrTwo == nil {
+			bufPtrTwo = bufTwo
+		} else if bufPtrTwo != bufTwo {
+			fmt.Println("OK")
+		}
+	}
+}
+
+// Output:
+// OK
+// OK

--- a/_test/issue-1381.go
+++ b/_test/issue-1381.go
@@ -8,43 +8,51 @@ import (
 func main() {
 	var bufPtrOne *bytes.Buffer
 	var bufPtrTwo *bytes.Buffer
+	var bufPtrThree *bytes.Buffer
+	var bufPtrFour *bytes.Buffer
 
 	for i := 0; i < 2; i++ {
 		bufOne := bytes.Buffer{}
 		bufTwo := &bytes.Buffer{}
+		var bufThree bytes.Buffer
+		bufFour := new(bytes.Buffer)
 
 		if bufPtrOne == nil {
 			bufPtrOne = &bufOne
 		} else if bufPtrOne == &bufOne {
-			fmt.Println("KO")
+			fmt.Println("bufOne was not properly redeclared")
+		} else {
+			fmt.Println("bufOne is properly redeclared")
 		}
+
 		if bufPtrTwo == nil {
 			bufPtrTwo = bufTwo
 		} else if bufPtrTwo == bufTwo {
-			fmt.Println("KO")
+			fmt.Println("bufTwo was not properly redeclared")
+		} else {
+			fmt.Println("bufTwo is properly redeclared")
 		}
-	}
 
-	bufPtrOne = nil
-	bufPtrTwo = nil
-
-	for i := 0; i < 2; i++ {
-		var bufOne bytes.Buffer
-		bufTwo := new(bytes.Buffer)
-
-		if bufPtrOne == nil {
-			bufPtrOne = &bufOne
-		} else if bufPtrOne != &bufOne {
-			fmt.Println("OK")
+		if bufPtrThree == nil {
+			bufPtrThree = &bufThree
+		} else if bufPtrThree == &bufThree {
+			fmt.Println("bufThree was not properly redeclared")
+		} else {
+			fmt.Println("bufThree is properly redeclared")
 		}
-		if bufPtrTwo == nil {
-			bufPtrTwo = bufTwo
-		} else if bufPtrTwo != bufTwo {
-			fmt.Println("OK")
+
+		if bufPtrFour == nil {
+			bufPtrFour = bufFour
+		} else if bufPtrFour == bufFour {
+			fmt.Println("bufFour was not properly redeclared")
+		} else {
+			fmt.Println("bufFour is properly redeclared")
 		}
 	}
 }
 
 // Output:
-// OK
-// OK
+// bufOne is properly redeclared
+// bufTwo is properly redeclared
+// bufThree is properly redeclared
+// bufFour is properly redeclared

--- a/interp/type.go
+++ b/interp/type.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/traefik/yaegi/internal/unsafe2"
 )
@@ -110,7 +109,6 @@ type structField struct {
 
 // itype defines the internal representation of types in the interpreter.
 type itype struct {
-	mu          *sync.Mutex
 	cat         tcat          // Type category
 	field       []structField // Array of struct fields if structT or interfaceT
 	key         *itype        // Type of key element if MapT or nil


### PR DESCRIPTION
Use direct assignment instead of reflect.Value Set method to
initialize a binary composite type, as for non binary types.
It ensures that a new reflect.Value is stored in the frame
instead of modifying a possibly existing one, which can defeat
the purpose of initializing variables in a body loop.

While there, remove the need to have and use a mutex on types.

Fixes #1381.