### PR TITLE
interp: fix the behaviour of goto, continue and break

### DIFF
--- a/_test/break0.go
+++ b/_test/break0.go
@@ -1,0 +1,24 @@
+package main
+
+func main() {
+	n := 2
+	m := 2
+	foo := true
+OuterLoop:
+	println("Boo")
+	for i := 0; i < n; i++ {
+		println("I: ", i)
+		for j := 0; j < m; j++ {
+			switch foo {
+			case true:
+				println(foo)
+				break OuterLoop
+			case false:
+				println(foo)
+			}
+		}
+	}
+}
+
+// Error:
+// 15:5: invalid break label OuterLoop

--- a/_test/break1.go
+++ b/_test/break1.go
@@ -1,0 +1,24 @@
+package main
+
+func main() {
+	n := 2
+	m := 2
+	foo := true
+OuterLoop:
+	for i := 0; i < n; i++ {
+		println("I: ", i)
+		for j := 0; j < m; j++ {
+			switch foo {
+			case true:
+				println(foo)
+				break OuterLoop
+			case false:
+				println(foo)
+			}
+		}
+	}
+}
+
+// Output:
+// I:  0
+// true

--- a/_test/break2.go
+++ b/_test/break2.go
@@ -1,0 +1,25 @@
+package main
+
+func main() {
+	n := 2
+	m := 2
+	foo := true
+OuterLoop:
+	for i := 0; i < n; i++ {
+		println("I: ", i)
+		for j := 0; j < m; j++ {
+			switch foo {
+			case true:
+				println(foo)
+				break OuterLoop
+			case false:
+				println(foo)
+				continue OuterLoop
+			}
+		}
+	}
+}
+
+// Output:
+// I:  0
+// true

--- a/_test/break3.go
+++ b/_test/break3.go
@@ -1,0 +1,27 @@
+package main
+
+func main() {
+	n := 2
+	m := 2
+	foo := true
+	goto OuterLoop
+	println("Boo")
+OuterLoop:
+	for i := 0; i < n; i++ {
+		println("I: ", i)
+		for j := 0; j < m; j++ {
+			switch foo {
+			case true:
+				println(foo)
+				break OuterLoop
+			case false:
+				println(foo)
+				goto OuterLoop
+			}
+		}
+	}
+}
+
+// Output:
+// I:  0
+// true

--- a/_test/cont2.go
+++ b/_test/cont2.go
@@ -1,0 +1,26 @@
+package main
+
+func main() {
+	n := 2
+	m := 2
+	foo := true
+OuterLoop:
+	for i := 0; i < n; i++ {
+		println("I: ", i)
+		for j := 0; j < m; j++ {
+			switch foo {
+			case true:
+				println(foo)
+				continue OuterLoop
+			case false:
+				println(foo)
+			}
+		}
+	}
+}
+
+// Output:
+// I:  0
+// true
+// I:  1
+// true

--- a/_test/cont3.go
+++ b/_test/cont3.go
@@ -1,0 +1,24 @@
+package main
+
+func main() {
+	n := 2
+	m := 2
+	foo := true
+OuterLoop:
+	println("boo")
+	for i := 0; i < n; i++ {
+		println("I: ", i)
+		for j := 0; j < m; j++ {
+			switch foo {
+			case true:
+				println(foo)
+				continue OuterLoop
+			case false:
+				println(foo)
+			}
+		}
+	}
+}
+
+// Error:
+// 15:5: invalid continue label OuterLoop

--- a/_test/issue-1354.go
+++ b/_test/issue-1354.go
@@ -1,0 +1,21 @@
+package main
+
+func main() {
+	println(test()) // Go prints true, Yaegi false
+}
+
+func test() bool {
+	if true {
+		goto label
+	}
+	goto label
+label:
+	println("Go continues here")
+	return true
+	println("Yaegi goes straight to this return (this line is never printed)")
+	return false
+}
+
+// Output:
+// Go continues here
+// true

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2598,9 +2598,6 @@ func typeSwichAssign(n *node) bool {
 }
 
 func breakLabel(s *symbol) {
-	if s.node == nil {
-		return
-	}
 	for _, c := range s.from {
 		c.tnext = s.node
 	}

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -37,6 +37,8 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "assign12.go" || // expect error
 			file.Name() == "assign15.go" || // expect error
 			file.Name() == "bad0.go" || // expect error
+			file.Name() == "break0.go" || // expect error
+			file.Name() == "cont3.go" || // expect error
 			file.Name() == "const9.go" || // expect error
 			file.Name() == "export1.go" || // non-main package
 			file.Name() == "export0.go" || // non-main package
@@ -197,6 +199,16 @@ func TestInterpErrorConsistency(t *testing.T) {
 			fileName:       "bad0.go",
 			expectedInterp: "1:1: expected 'package', found println",
 			expectedExec:   "1:1: expected 'package', found println",
+		},
+		{
+			fileName:       "break0.go",
+			expectedInterp: "15:5: invalid break label OuterLoop",
+			expectedExec:   "15:11: invalid break label OuterLoop",
+		},
+		{
+			fileName:       "cont3.go",
+			expectedInterp: "15:5: invalid continue label OuterLoop",
+			expectedExec:   "15:14: invalid continue label OuterLoop",
 		},
 		{
 			fileName:       "const9.go",

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -144,20 +144,6 @@ func (s *scope) lookup(ident string) (*symbol, int, bool) {
 	return nil, 0, false
 }
 
-// lookdown searches for a symbol in the current scope and included ones, recursively.
-// It returns the first found symbol and true, or nil and false.
-func (s *scope) lookdown(ident string) (*symbol, bool) {
-	if sym, ok := s.sym[ident]; ok {
-		return sym, true
-	}
-	for _, c := range s.child {
-		if sym, ok := c.lookdown(ident); ok {
-			return sym, true
-		}
-	}
-	return nil, false
-}
-
 func (s *scope) rangeChanType(n *node) *itype {
 	if sym, _, found := s.lookup(n.child[1].ident); found {
 		if t := sym.typ; len(n.child) == 3 && t != nil && (t.cat == chanT || t.cat == chanRecvT) {

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -47,7 +47,7 @@ type symbol struct {
 	kind    sKind
 	typ     *itype        // Type of value
 	node    *node         // Node value if index is negative
-	from    []*node       // list of nodes jumping to node if kind is label, or nil
+	from    []*node       // list of goto nodes jumping to this label node, or nil
 	recv    *receiver     // receiver node value, if sym refers to a method
 	index   int           // index of value in frame or -1
 	rval    reflect.Value // default value (used for constants)


### PR DESCRIPTION
The logic of goto was false due to mixing break label and goto
label, despite being opposite. In case of break, jump to node (the
exit point) instead of node.start. Also always define label symbols
before their use is parsed.

Fixes #1354.