### PR TITLE
interp: implements detection of packages with no Go files

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"go/build"
 	"go/parser"
 	"io"
 	"log"
@@ -1649,6 +1650,16 @@ func TestStdio(t *testing.T) {
 	if _, ok := v.Interface().(*os.File); !ok {
 		t.Fatalf("%v not *os.file", v.Interface())
 	}
+}
+
+func TestNoGoFiles(t *testing.T) {
+	i := interp.New(interp.Options{GoPath: build.Default.GOPATH})
+	_, err := i.Eval(`import "github.com/traefik/yaegi/_test/p3"`)
+	if strings.Contains(err.Error(), "no Go files in") {
+		return
+	}
+
+	t.Fatalf("failed to detect no Go files: %v", err)
 }
 
 func TestIssue1142(t *testing.T) {

--- a/interp/src.go
+++ b/interp/src.go
@@ -132,6 +132,10 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 	// the global symbols in the package scope.
 	interp.mutex.Lock()
 	gs := interp.scopes[importPath]
+	if gs == nil {
+		// A nil scope means that no even an empty package is created from source.
+		return "", fmt.Errorf("no Go files in %s", dir)
+	}
 	interp.srcPkg[importPath] = gs.sym
 	interp.pkgNames[importPath] = pkgName
 


### PR DESCRIPTION
This avoids panic during import, and print a proper diagnostic
instead.

Fixes #1394.