### PR TITLE
interp: avoid panic when defining a label in incremental parsing mode

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1375,7 +1375,7 @@ func testConcurrentComposite(t *testing.T, filePath string) {
 	}
 }
 
-func TestEvalScanner(t *testing.T) {
+func TestEvalREPL(t *testing.T) {
 	if testing.Short() {
 		return
 	}
@@ -1460,6 +1460,13 @@ func TestEvalScanner(t *testing.T) {
 			src: []string{
 				`type bar string`,
 				`func (b bar) foo() { println(3) }`,
+			},
+			errorLine: -1,
+		},
+		{
+			desc: "define a label",
+			src: []string{
+				`a:`,
 			},
 			errorLine: -1,
 		},

--- a/interp/value.go
+++ b/interp/value.go
@@ -34,10 +34,10 @@ func valueGenerator(n *node, i int) func(*frame) reflect.Value {
 // because a cancellation prior to any evaluation result may leave
 // the frame's data empty.
 func valueOf(data []reflect.Value, i int) reflect.Value {
-	if i < len(data) {
-		return data[i]
+	if i < 0 || i >= len(data) {
+		return reflect.Value{}
 	}
-	return reflect.Value{}
+	return data[i]
 }
 
 func genValueBinMethodOnInterface(n *node, defaultGen func(*frame) reflect.Value) func(*frame) reflect.Value {
@@ -195,7 +195,7 @@ func genValue(n *node) func(*frame) reflect.Value {
 		}
 		if n.sym != nil {
 			i := n.sym.index
-			if i < 0 {
+			if i < 0 && n != n.sym.node {
 				return genValue(n.sym.node)
 			}
 			if n.sym.global {


### PR DESCRIPTION
In REPL mode, a panic (stack overflow) could be triggered by:

	$ yaegi
	> a:
	runtime: goroutine stack exceeds 1000000000-byte limit
	runtime: sp=0x14020760330 stack=[0x14020760000, 0x14040760000]
	fatal error: stack overflow
	[...]

This issue occurs in incremental parsing mode only, and not when the parser
is in file mode. We avoid it by being more defensive when generating
values.

Fixes #982.