### PR TITLE
interp: improve the behaviour of interface{} function parameters

### DIFF
--- a/_test/issue-435.go
+++ b/_test/issue-435.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type Foo int
+
+func (f Foo) String() string {
+	return "foo-" + strconv.Itoa(int(f))
+}
+
+func print1(arg interface{}) {
+	fmt.Println(arg)
+}
+
+func main() {
+	var arg Foo = 3
+	var f = print1
+	f(arg)
+}
+
+// Output:
+// foo-3

--- a/interp/run.go
+++ b/interp/run.go
@@ -1534,7 +1534,7 @@ func callBin(n *node) {
 				break
 			}
 
-			// defType is the target type for an eventual interface wrapper.
+			// defType is the target type for a potential interface wrapper.
 			var defType reflect.Type
 			if variadic >= 0 && i+rcvrOffset >= variadic {
 				defType = funcType.In(variadic)

--- a/interp/value.go
+++ b/interp/value.go
@@ -392,6 +392,21 @@ func genValueOutput(n *node, t reflect.Type) func(*frame) reflect.Value {
 	return value
 }
 
+func getBinValue(getMapType func(*itype) reflect.Type, value func(*frame) reflect.Value, f *frame) reflect.Value {
+	v := value(f)
+	if getMapType == nil {
+		return v
+	}
+	val, ok := v.Interface().(valueInterface)
+	if !ok || val.node == nil {
+		return v
+	}
+	if rt := getMapType(val.node.typ); rt != nil {
+		return genInterfaceWrapper(val.node, rt)(f)
+	}
+	return v
+}
+
 func valueInterfaceValue(v reflect.Value) reflect.Value {
 	for {
 		vv, ok := v.Interface().(valueInterface)

--- a/stdlib/maptypes.go
+++ b/stdlib/maptypes.go
@@ -1,0 +1,58 @@
+package stdlib
+
+import (
+	"encoding"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"log"
+	"reflect"
+)
+
+func init() {
+	mt := []reflect.Type{
+		reflect.TypeOf((*fmt.Formatter)(nil)).Elem(),
+		reflect.TypeOf((*fmt.Stringer)(nil)).Elem(),
+	}
+
+	MapTypes[reflect.ValueOf(fmt.Errorf)] = mt
+	MapTypes[reflect.ValueOf(fmt.Fprint)] = mt
+	MapTypes[reflect.ValueOf(fmt.Fprintf)] = mt
+	MapTypes[reflect.ValueOf(fmt.Fprintln)] = mt
+	MapTypes[reflect.ValueOf(fmt.Print)] = mt
+	MapTypes[reflect.ValueOf(fmt.Printf)] = mt
+	MapTypes[reflect.ValueOf(fmt.Println)] = mt
+	MapTypes[reflect.ValueOf(fmt.Sprint)] = mt
+	MapTypes[reflect.ValueOf(fmt.Sprintf)] = mt
+	MapTypes[reflect.ValueOf(fmt.Sprintln)] = mt
+
+	MapTypes[reflect.ValueOf(log.Fatal)] = mt
+	MapTypes[reflect.ValueOf(log.Fatalf)] = mt
+	MapTypes[reflect.ValueOf(log.Fatalln)] = mt
+	MapTypes[reflect.ValueOf(log.Panic)] = mt
+	MapTypes[reflect.ValueOf(log.Panicf)] = mt
+	MapTypes[reflect.ValueOf(log.Panicln)] = mt
+
+	mt = []reflect.Type{reflect.TypeOf((*fmt.Scanner)(nil)).Elem()}
+
+	MapTypes[reflect.ValueOf(fmt.Scan)] = mt
+	MapTypes[reflect.ValueOf(fmt.Scanf)] = mt
+	MapTypes[reflect.ValueOf(fmt.Scanln)] = mt
+
+	MapTypes[reflect.ValueOf(json.Marshal)] = []reflect.Type{
+		reflect.TypeOf((*json.Marshaler)(nil)).Elem(),
+		reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem(),
+	}
+	MapTypes[reflect.ValueOf(json.Unmarshal)] = []reflect.Type{
+		reflect.TypeOf((*json.Unmarshaler)(nil)).Elem(),
+		reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem(),
+	}
+	MapTypes[reflect.ValueOf(xml.Marshal)] = []reflect.Type{
+		reflect.TypeOf((*xml.Marshaler)(nil)).Elem(),
+		reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem(),
+	}
+	MapTypes[reflect.ValueOf(xml.Unmarshal)] = []reflect.Type{
+		reflect.TypeOf((*xml.Unmarshaler)(nil)).Elem(),
+		reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem(),
+	}
+}

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -9,9 +9,16 @@ import "reflect"
 // Symbols variable stores the map of stdlib symbols per package.
 var Symbols = map[string]map[string]reflect.Value{}
 
+// MapTypes variable contains a map of functions which have an interface{} as parameter but
+// do something special if the parameter implements a given interface.
+var MapTypes = map[reflect.Value][]reflect.Type{}
+
 func init() {
-	Symbols["github.com/traefik/yaegi/stdlib"] = map[string]reflect.Value{
+	Symbols["github.com/traefik/yaegi/stdlib/stdlib"] = map[string]reflect.Value{
 		"Symbols": reflect.ValueOf(Symbols),
+	}
+	Symbols["."] = map[string]reflect.Value{
+		"MapTypes": reflect.ValueOf(MapTypes),
 	}
 }
 


### PR DESCRIPTION
We finally address a long standing limitation of the interpreter:
the capacity to generate the correct interface wrapper for an
anonymous interface{} function parameter of a binary function.

It allows for example fmt.Printf to invoke the String method
of an object defined within the interpreter, or json.Marshal
to invoke a textMarshaler method if it exists and if there is
no Marshaler method already defined for the passed interpreter
object.

To achieve that, we add a new mapType part of the "Used" symbols
to describe what not empty interfaces are expected and in which
priority order. This information can not be guessed and is found
in the related package documentation, then captured in stdlib/maptypes.go.

Then, at compile time and/or during execution, a lookup on mapTypes
is performed to allow the correct wrapper to be generated.

This change adds a new MapType type to the stdlib package.

Fixes #435.