### PR TITLE
interp: catch mismatched types for other comparisons

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -440,7 +440,7 @@ func TestEvalComparison(t *testing.T) {
 		{src: `a, b, c := 1, 1, false; if a == b { c = true }; c`, res: "true"},
 		{src: `a, b, c := 1, 2, false; if a != b { c = true }; c`, res: "true"},
 		{
-			desc: "mismatched types",
+			desc: "mismatched types equality",
 			src: `
 				type Foo string
 				type Bar string
@@ -448,6 +448,18 @@ func TestEvalComparison(t *testing.T) {
 				var a = Foo("test")
 				var b = Bar("test")
 				var c = a == b
+			`,
+			err: "7:13: invalid operation: mismatched types main.Foo and main.Bar",
+		},
+		{
+			desc: "mismatched types less than",
+			src: `
+				type Foo string
+				type Bar string
+
+				var a = Foo("test")
+				var b = Bar("test")
+				var c = a < b
 			`,
 			err: "7:13: invalid operation: mismatched types main.Foo and main.Bar",
 		},

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -73,6 +73,7 @@ func TestEvalArithmetic(t *testing.T) {
 	})
 }
 
+// TestEvalShift fake commit
 func TestEvalShift(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -73,7 +73,6 @@ func TestEvalArithmetic(t *testing.T) {
 	})
 }
 
-// TestEvalShift fake commit
 func TestEvalShift(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -191,12 +191,14 @@ func (check typecheck) comparison(n *node) error {
 	}
 
 	ok := false
+
+	if !isInterface(t0) && !isInterface(t1) && !t0.isNil() && !t1.isNil() && t0.untyped == t1.untyped && t0.id() != t1.id() {
+		// Non interface types must be really equals.
+		return n.cfgErrorf("invalid operation: mismatched types %s and %s", t0.id(), t1.id())
+	}
+
 	switch n.action {
 	case aEqual, aNotEqual:
-		if !isInterface(t0) && !isInterface(t1) && !t0.isNil() && !t1.isNil() && t0.untyped == t1.untyped && t0.id() != t1.id() {
-			// Non interface types must be really equals.
-			return n.cfgErrorf("invalid operation: mismatched types %s and %s", t0.id(), t1.id())
-		}
 		ok = t0.comparable() && t1.comparable() || t0.isNil() && t1.hasNil() || t1.isNil() && t0.hasNil()
 	case aLower, aLowerEqual, aGreater, aGreaterEqual:
 		ok = t0.ordered() && t1.ordered()


### PR DESCRIPTION
The check for mismatched types was already added recently for ==  and != comparisons.
This PR now adds it for other comparisons ( < , <=, > , >=).
