### PR TITLE
interp: improve support of alias types

### DIFF
--- a/_test/alias3/alias3.go
+++ b/_test/alias3/alias3.go
@@ -1,9 +1,31 @@
 package alias3
 
+import (
+	"fmt"
+	"net/http"
+)
+
 type T struct {
 	A string
 }
 
 func (t *T) Print() {
 	println(t.A)
+}
+
+type A http.Header
+
+func (a A) ForeachKey() error {
+	for k, vals := range a {
+		for _, v := range vals {
+			fmt.Println(k, v)
+		}
+
+	}
+
+	return nil
+}
+
+func (a A) Set(k string, v []string) {
+	a[k] = v
 }

--- a/_test/alias4.go
+++ b/_test/alias4.go
@@ -17,11 +17,23 @@ func (b B) Test2() {
 	fmt.Println("test2")
 }
 
+func (b B) Test3() {
+	for k, vals := range b {
+		for _, v := range vals {
+			fmt.Println(k, v)
+		}
+	}
+}
+
 func main() {
 	b := B{}
 
 	b.Test2()
+	b["test"] = []string{"a", "b"}
+	b.Test3()
 }
 
 // Output:
 // test2
+// test a
+// test b

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -145,8 +145,11 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 					}
 
 					switch o.typ.cat {
-					case valueT:
+					case valueT, aliasT:
 						typ := o.typ.rtype
+						if o.typ.cat == aliasT {
+							typ = o.typ.val.rtype
+						}
 						switch typ.Kind() {
 						case reflect.Map:
 							n.anc.gen = rangeMap

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -148,7 +148,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 					case valueT, aliasT:
 						typ := o.typ.rtype
 						if o.typ.cat == aliasT {
-							typ = o.typ.val.rtype
+							typ = o.typ.val.TypeOf()
 						}
 						switch typ.Kind() {
 						case reflect.Map:
@@ -793,13 +793,10 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 			}
 			wireChild(n)
 			t := n.child[0].typ
+			for t.cat == aliasT {
+				t = t.val
+			}
 			switch t.cat {
-			case aliasT:
-				if isString(t.val.TypeOf()) {
-					n.typ = sc.getType("byte")
-					break
-				}
-				fallthrough
 			case ptrT:
 				n.typ = t.val
 				if t.val.cat == valueT {


### PR DESCRIPTION
I expect the following code to be supported.
```go
type TT http.Header

func (t TT) Set(key, val string) {

}

func (t TT) Get(key string) string {

}
```
So, I pushed this PR. 
Do I need to add some test cases?  I don't see the relevant test files ....