### PR TITLE
interp: add support of Go generics in interpreter

### DIFF
--- a/_test/gen1.go
+++ b/_test/gen1.go
@@ -1,0 +1,39 @@
+package main
+
+import "fmt"
+
+// SumInts adds together the values of m.
+func SumInts(m map[string]int64) int64 {
+	var s int64
+	for _, v := range m {
+		s += v
+	}
+	return s
+}
+
+// SumFloats adds together the values of m.
+func SumFloats(m map[string]float64) float64 {
+	var s float64
+	for _, v := range m {
+		s += v
+	}
+	return s
+}
+
+func main() {
+	// Initialize a map for the integer values
+	ints := map[string]int64{
+		"first":  34,
+		"second": 12,
+	}
+
+	// Initialize a map for the float values
+	floats := map[string]float64{
+		"first":  35.98,
+		"second": 26.99,
+	}
+
+	fmt.Printf("Non-Generic Sums: %v and %v\n",
+		SumInts(ints),
+		SumFloats(floats))
+}

--- a/_test/gen2.go
+++ b/_test/gen2.go
@@ -1,0 +1,31 @@
+package main
+
+import "fmt"
+
+// SumIntsOrFloats sums the values of map m. It supports both int64 and float64
+// as types for map values.
+func SumIntsOrFloats[K comparable, V int64 | float64](m map[K]V) V {
+    var s V
+    for _, v := range m {
+        s += v
+    }
+    return s
+}
+
+func main() {
+	// Initialize a map for the integer values
+	ints := map[string]int64{
+		"first":  34,
+		"second": 12,
+	}
+
+	// Initialize a map for the float values
+	floats := map[string]float64{
+		"first":  35.98,
+		"second": 26.99,
+	}
+
+	fmt.Printf("Generic Sums: %v and %v\n",
+		SumIntsOrFloats[string, int64](ints),
+    	SumIntsOrFloats[string, float64](floats))
+}

--- a/_test/gen2.go
+++ b/_test/gen2.go
@@ -5,11 +5,11 @@ import "fmt"
 // SumIntsOrFloats sums the values of map m. It supports both int64 and float64
 // as types for map values.
 func SumIntsOrFloats[K comparable, V int64 | float64](m map[K]V) V {
-    var s V
-    for _, v := range m {
-        s += v
-    }
-    return s
+	var s V
+	for _, v := range m {
+		s += v
+	}
+	return s
 }
 
 func main() {
@@ -27,5 +27,5 @@ func main() {
 
 	fmt.Printf("Generic Sums: %v and %v\n",
 		SumIntsOrFloats[string, int64](ints),
-    	SumIntsOrFloats[string, float64](floats))
+		SumIntsOrFloats[string, float64](floats))
 }

--- a/_test/gen2.go
+++ b/_test/gen2.go
@@ -29,3 +29,6 @@ func main() {
 		SumIntsOrFloats[string, int64](ints),
 		SumIntsOrFloats[string, float64](floats))
 }
+
+// Output:
+// Generic Sums: 46 and 62.97

--- a/_test/gen3.go
+++ b/_test/gen3.go
@@ -1,7 +1,7 @@
 package main
 
 type Number interface {
-	int | int64 | float64
+	int8 | int | int64 | ~float64
 }
 
 func Sum[T Number](numbers []T) T {

--- a/_test/gen3.go
+++ b/_test/gen3.go
@@ -1,0 +1,19 @@
+package main
+
+type Number interface {
+	int | int64 | float64
+}
+
+func Sum[T Number](numbers []T) T {
+	var total T
+	for _, x := range numbers {
+		total += x
+	}
+	return total
+}
+
+func main() {
+	xs := []int{3, 5, 10}
+	total := Sum(xs)
+	println(total)
+}

--- a/_test/gen3.go
+++ b/_test/gen3.go
@@ -1,7 +1,7 @@
 package main
 
 type Number interface {
-	int8 | int | int64 | ~float64
+	int | int64 | ~float64
 }
 
 func Sum[T Number](numbers []T) T {
@@ -17,3 +17,6 @@ func main() {
 	total := Sum(xs)
 	println(total)
 }
+
+// Output:
+// 18

--- a/_test/gen4.go
+++ b/_test/gen4.go
@@ -1,0 +1,52 @@
+package main
+
+import "fmt"
+
+func MapKeys[K comparable, V any](m map[K]V) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}
+
+type List[T any] struct {
+	head, tail *element[T]
+}
+
+type element[T any] struct {
+	next *element[T]
+	val  T
+}
+
+func (lst *List[T]) Push(v T) {
+	if lst.tail == nil {
+		lst.head = &element[T]{val: v}
+		lst.tail = lst.head
+	} else {
+		lst.tail.next = &element[T]{val: v}
+		lst.tail = lst.tail.next
+	}
+}
+
+func (lst *List[T]) GetAll() []T {
+	var elems []T
+	for e := lst.head; e != nil; e = e.next {
+		elems = append(elems, e.val)
+	}
+	return elems
+}
+
+func main() {
+	var m = map[int]string{1: "2", 2: "4", 4: "8"}
+
+	fmt.Println("keys m:", MapKeys(m))
+
+	_ = MapKeys[int, string](m)
+
+	lst := List[int]{}
+	lst.Push(10)
+	lst.Push(13)
+	lst.Push(23)
+	fmt.Println("list:", lst.GetAll())
+}

--- a/_test/gen4.go
+++ b/_test/gen4.go
@@ -42,11 +42,9 @@ func main() {
 
 	fmt.Println("keys m:", MapKeys(m))
 
-	_ = MapKeys[int, string](m)
-
-	lst := List[int]{}
-	lst.Push(10)
-	lst.Push(13)
-	lst.Push(23)
-	fmt.Println("list:", lst.GetAll())
+	//lst := List[int]{}
+	//lst.Push(10)
+	//lst.Push(13)
+	//lst.Push(23)
+	//fmt.Println("list:", lst.GetAll())
 }

--- a/_test/gen4.go
+++ b/_test/gen4.go
@@ -2,16 +2,6 @@ package main
 
 import "fmt"
 
-/*
-func MapKeys[K comparable, V any](m map[K]V) []K {
-	r := make([]K, 0, len(m))
-	for k := range m {
-		r = append(r, k)
-	}
-	return r
-}
-*/
-
 type List[T any] struct {
 	head, tail *element[T]
 }
@@ -30,7 +20,6 @@ func (lst *List[T]) Push(v T) {
 		lst.tail.next = &element[T]{val: v}
 		lst.tail = lst.tail.next
 	}
-	println("hello")
 }
 
 func (lst *List[T]) GetAll() []T {
@@ -42,15 +31,9 @@ func (lst *List[T]) GetAll() []T {
 }
 
 func main() {
-	//var m = map[int]string{1: "2", 2: "4", 4: "8"}
-
-	// Test type inference
-	//fmt.Println("keys m:", MapKeys(m))
-
 	lst := List[int]{}
-	fmt.Println(lst)
 	lst.Push(10)
-	//lst.Push(13)
-	//lst.Push(23)
-	//fmt.Println("list:", lst.GetAll())
+	lst.Push(13)
+	lst.Push(23)
+	fmt.Println("list:", lst.GetAll())
 }

--- a/_test/gen4.go
+++ b/_test/gen4.go
@@ -2,6 +2,7 @@ package main
 
 import "fmt"
 
+/*
 func MapKeys[K comparable, V any](m map[K]V) []K {
 	r := make([]K, 0, len(m))
 	for k := range m {
@@ -9,11 +10,13 @@ func MapKeys[K comparable, V any](m map[K]V) []K {
 	}
 	return r
 }
+*/
 
 type List[T any] struct {
 	head, tail *element[T]
 }
 
+// A recursive generic type.
 type element[T any] struct {
 	next *element[T]
 	val  T
@@ -27,6 +30,7 @@ func (lst *List[T]) Push(v T) {
 		lst.tail.next = &element[T]{val: v}
 		lst.tail = lst.tail.next
 	}
+	println("hello")
 }
 
 func (lst *List[T]) GetAll() []T {
@@ -38,12 +42,14 @@ func (lst *List[T]) GetAll() []T {
 }
 
 func main() {
-	var m = map[int]string{1: "2", 2: "4", 4: "8"}
+	//var m = map[int]string{1: "2", 2: "4", 4: "8"}
 
-	fmt.Println("keys m:", MapKeys(m))
+	// Test type inference
+	//fmt.Println("keys m:", MapKeys(m))
 
-	//lst := List[int]{}
-	//lst.Push(10)
+	lst := List[int]{}
+	fmt.Println(lst)
+	lst.Push(10)
 	//lst.Push(13)
 	//lst.Push(23)
 	//fmt.Println("list:", lst.GetAll())

--- a/_test/gen4.go
+++ b/_test/gen4.go
@@ -1,7 +1,5 @@
 package main
 
-import "fmt"
-
 type List[T any] struct {
 	head, tail *element[T]
 }
@@ -35,5 +33,8 @@ func main() {
 	lst.Push(10)
 	lst.Push(13)
 	lst.Push(23)
-	fmt.Println("list:", lst.GetAll())
+	lst.GetAll()
 }
+
+// Output:
+// list: [10 13 23]

--- a/_test/gen4.go
+++ b/_test/gen4.go
@@ -1,5 +1,7 @@
 package main
 
+import "fmt"
+
 type List[T any] struct {
 	head, tail *element[T]
 }
@@ -33,7 +35,7 @@ func main() {
 	lst.Push(10)
 	lst.Push(13)
 	lst.Push(23)
-	lst.GetAll()
+	fmt.Println("list:", lst.GetAll())
 }
 
 // Output:

--- a/_test/gen5.go
+++ b/_test/gen5.go
@@ -1,0 +1,25 @@
+package main
+
+import "fmt"
+
+type Set[Elem comparable] struct {
+	m map[Elem]struct{}
+}
+
+func Make[Elem comparable]() Set[Elem] {
+	return Set[Elem]{m: make(map[Elem]struct{})}
+}
+
+/*
+func (s Set[Elem]) Add(v Elem) {
+	s.m[v] = struct{}{}
+}
+*/
+func main() {
+	s := Make[int]()
+	//s.Add(1)
+	fmt.Println(s)
+}
+
+// Output:
+// {map[]}

--- a/_test/gen5.go
+++ b/_test/gen5.go
@@ -10,16 +10,15 @@ func Make[Elem comparable]() Set[Elem] {
 	return Set[Elem]{m: make(map[Elem]struct{})}
 }
 
-/*
 func (s Set[Elem]) Add(v Elem) {
 	s.m[v] = struct{}{}
 }
-*/
+
 func main() {
 	s := Make[int]()
-	//s.Add(1)
+	s.Add(1)
 	fmt.Println(s)
 }
 
 // Output:
-// {map[]}
+// {map[1:{}]}

--- a/_test/gen6.go
+++ b/_test/gen6.go
@@ -1,0 +1,21 @@
+package main
+
+import "fmt"
+
+func MapKeys[K comparable, V any](m map[K]V) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}
+
+func main() {
+	var m = map[int]string{1: "2", 2: "4", 4: "8"}
+
+	// Test type inference
+	fmt.Println("keys m:", MapKeys(m))
+}
+
+// Output:
+// keys m: [1 2 4]

--- a/_test/gen6.go
+++ b/_test/gen6.go
@@ -1,7 +1,5 @@
 package main
 
-import "fmt"
-
 func MapKeys[K comparable, V any](m map[K]V) []K {
 	r := make([]K, 0, len(m))
 	for k := range m {
@@ -14,8 +12,8 @@ func main() {
 	var m = map[int]string{1: "2", 2: "4", 4: "8"}
 
 	// Test type inference
-	fmt.Println("keys m:", MapKeys(m))
+	println(len(MapKeys(m)), m[2])
 }
 
 // Output:
-// keys m: [1 2 4]
+// 3 4

--- a/_test/gen7.go
+++ b/_test/gen7.go
@@ -12,8 +12,8 @@ func main() {
 	var m = map[int]string{1: "2", 2: "4", 4: "8"}
 
 	// Test type inference
-	println(len(MapKeys(m)))
+	println(len(MapKeys))
 }
 
-// Output:
-// 3
+// Error:
+// invalid argument for len

--- a/_test/gen8.go
+++ b/_test/gen8.go
@@ -12,4 +12,4 @@ func main() {
 }
 
 // Error:
-// 10:11: int does not implement main.Float
+// int does not implement main.Float

--- a/_test/gen8.go
+++ b/_test/gen8.go
@@ -1,0 +1,12 @@
+package main
+
+type Float interface {
+	~float32 | ~float64
+}
+
+func add[T Float](a, b T) float64 { return float64(a) + float64(b) }
+
+func main() {
+	var x, y float64 = 1, 2
+	println(add(x, y))
+}

--- a/_test/gen8.go
+++ b/_test/gen8.go
@@ -7,6 +7,9 @@ type Float interface {
 func add[T Float](a, b T) float64 { return float64(a) + float64(b) }
 
 func main() {
-	var x, y float64 = 1, 2
+	var x, y int = 1, 2
 	println(add(x, y))
 }
+
+// Error:
+// 10:11: int does not implement main.Float

--- a/_test/gen9.go
+++ b/_test/gen9.go
@@ -7,10 +7,8 @@ type Float interface {
 func add[T Float](a, b T) float64 { return float64(a) + float64(b) }
 
 func main() {
-	//var x, y int = 1, 2
-	//println(add(x, y))
 	println(add(1, 2))
 }
 
 // Error:
-// 10:11: int does not implement main.Float
+// untyped int does not implement main.Float

--- a/_test/gen9.go
+++ b/_test/gen9.go
@@ -1,0 +1,16 @@
+package main
+
+type Float interface {
+	~float32 | ~float64
+}
+
+func add[T Float](a, b T) float64 { return float64(a) + float64(b) }
+
+func main() {
+	//var x, y int = 1, 2
+	//println(add(x, y))
+	println(add(1, 2))
+}
+
+// Error:
+// 10:11: int does not implement main.Float

--- a/interp/ast.go
+++ b/interp/ast.go
@@ -72,6 +72,7 @@ const (
 	importSpec
 	incDecStmt
 	indexExpr
+	indexListExpr
 	interfaceType
 	keyValueExpr
 	labeledStmt
@@ -155,6 +156,7 @@ var kinds = [...]string{
 	importSpec:        "importSpec",
 	incDecStmt:        "incDecStmt",
 	indexExpr:         "indexExpr",
+	indexListExpr:     "indexListExpr",
 	interfaceType:     "interfaceType",
 	keyValueExpr:      "keyValueExpr",
 	labeledStmt:       "labeledStmt",
@@ -694,7 +696,7 @@ func (interp *Interpreter) ast(f ast.Node) (string, *node, error) {
 			n := addChild(&root, anc, pos, funcDecl, aNop)
 			n.val = n
 			if a.Recv == nil {
-				// function is not a method, create an empty receiver list
+				// Function is not a method, create an empty receiver list.
 				addChild(&root, astNode{n, nod}, pos, fieldList, aNop)
 			}
 			st.push(n, nod)
@@ -706,7 +708,13 @@ func (interp *Interpreter) ast(f ast.Node) (string, *node, error) {
 			st.push(n, nod)
 
 		case *ast.FuncType:
-			st.push(addChild(&root, anc, pos, funcType, aNop), nod)
+			n := addChild(&root, anc, pos, funcType, aNop)
+			n.val = n
+			if a.TypeParams == nil {
+				// Function has no type parameters, create an empty fied list.
+				addChild(&root, astNode{n, nod}, pos, fieldList, aNop)
+			}
+			st.push(n, nod)
 
 		case *ast.GenDecl:
 			var kind nkind
@@ -775,6 +783,9 @@ func (interp *Interpreter) ast(f ast.Node) (string, *node, error) {
 
 		case *ast.IndexExpr:
 			st.push(addChild(&root, anc, pos, indexExpr, aGetIndex), nod)
+
+		case *ast.IndexListExpr:
+			st.push(addChild(&root, anc, pos, indexListExpr, aNop), nod)
 
 		case *ast.InterfaceType:
 			st.push(addChild(&root, anc, pos, interfaceType, aNop), nod)

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -372,9 +372,9 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 			// Add a frame indirection level as we enter in a func
 			sc = sc.pushFunc()
 			sc.def = n
-			if len(n.child[2].child) == 2 {
+			if len(n.child[2].child) == 3 {
 				// Allocate frame space for return values, define output symbols
-				for _, c := range n.child[2].child[1].child {
+				for _, c := range n.child[2].child[2].child {
 					var typ *itype
 					if typ, err = nodeType(interp, sc, c.lastChild()); err != nil {
 						return false
@@ -404,7 +404,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 					sc.sym[fr.child[0].ident] = &symbol{index: index, kind: varSym, typ: typ}
 				}
 			}
-			for _, c := range n.child[2].child[0].child {
+			for _, c := range n.child[2].child[1].child {
 				// define input parameter symbols
 				var typ *itype
 				if typ, err = nodeType(interp, sc, c.lastChild()); err != nil {
@@ -1536,7 +1536,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 			n.val = sc.def
 			for i, c := range n.child {
 				var typ *itype
-				typ, err = nodeType(interp, sc.upperLevel(), returnSig.child[1].fieldType(i))
+				typ, err = nodeType(interp, sc.upperLevel(), returnSig.child[2].fieldType(i))
 				if err != nil {
 					return
 				}
@@ -2594,10 +2594,10 @@ func isOffsetof(n *node) bool {
 }
 
 func mustReturnValue(n *node) bool {
-	if len(n.child) < 2 {
+	if len(n.child) < 3 {
 		return false
 	}
-	for _, f := range n.child[1].child {
+	for _, f := range n.child[2].child {
 		if len(f.child) > 1 {
 			return false
 		}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1811,7 +1811,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 				if n.typ.cat == valueT || n.typ.cat == errorT {
 					switch method, ok := n.typ.rtype.MethodByName(n.child[1].ident); {
 					case ok:
-						hasRecvType := n.typ.rtype.Kind() != reflect.Interface
+						hasRecvType := n.typ.TypeOf().Kind() != reflect.Interface
 						n.val = method.Index
 						n.gen = getIndexBinMethod
 						n.action = aGetMethod
@@ -1820,7 +1820,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 						if hasRecvType {
 							n.typ.recv = n.typ
 						}
-					case n.typ.rtype.Kind() == reflect.Ptr:
+					case n.typ.TypeOf().Kind() == reflect.Ptr:
 						if field, ok := n.typ.rtype.Elem().FieldByName(n.child[1].ident); ok {
 							n.typ = valueTOf(field.Type)
 							n.val = field.Index
@@ -1828,7 +1828,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 							break
 						}
 						err = n.cfgErrorf("undefined field or method: %s", n.child[1].ident)
-					case n.typ.rtype.Kind() == reflect.Struct:
+					case n.typ.TypeOf().Kind() == reflect.Struct:
 						if field, ok := n.typ.rtype.FieldByName(n.child[1].ident); ok {
 							n.typ = valueTOf(field.Type)
 							n.val = field.Index

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -851,7 +851,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 					n.typ = t
 					return
 				}
-				g, err := genAST(t.node.anc, []*node{c1})
+				g, err := genAST(sc, t.node.anc, []*node{c1})
 				if err != nil {
 					return
 				}
@@ -992,7 +992,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 			case c0.kind == indexListExpr:
 				// Instantiate a generic function then call it.
 				fun := c0.child[0].sym.node
-				g, err := genAST(fun, c0.child[1:])
+				g, err := genAST(sc, fun, c0.child[1:])
 				if err != nil {
 					return
 				}
@@ -1174,13 +1174,13 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 				if isGeneric(c0.typ) {
 					fun := c0.typ.node.anc
 
-					// Infer type parameter from function call arguments
+					// Infer type parameter from function call arguments.
 					types, err := inferTypesFromCall(fun, n.child[1:])
 					if err != nil {
 						return
 					}
 					// Generate an instantiated AST from the generic function one.
-					g, err := genAST(fun, types)
+					g, err := genAST(sc, fun, types)
 					if err != nil {
 						return
 					}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -2972,5 +2972,3 @@ func isBlank(n *node) bool {
 	}
 	return n.ident == "_"
 }
-
-func callGeneric(n *node) bool { return n.child[0].kind == indexListExpr }

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1198,7 +1198,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 					var types []*node
 
 					// Infer type parameter from function call arguments.
-					if types, err = inferTypesFromCall(fun, n.child[1:]); err != nil {
+					if types, err = inferTypesFromCall(sc, fun, n.child[1:]); err != nil {
 						break
 					}
 					// Generate an instantiated AST from the generic function one.

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1852,7 +1852,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 				} else if m, lind := n.typ.lookupMethod(n.child[1].ident); m != nil {
 					n.action = aGetMethod
 					if n.child[0].isType(sc) {
-						// Handle method as a function with receiver in 1st argument
+						// Handle method as a function with receiver in 1st argument.
 						n.val = m
 						n.findex = notInFrame
 						n.gen = nop
@@ -1860,7 +1860,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 						*n.typ = *m.typ
 						n.typ.arg = append([]*itype{n.child[0].typ}, m.typ.arg...)
 					} else {
-						// Handle method with receiver
+						// Handle method with receiver.
 						n.gen = getMethod
 						n.val = m
 						n.typ = m.typ

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1194,24 +1194,24 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 				// generic function AST by an instantiated one before going further.
 				if isGeneric(c0.typ) {
 					fun := c0.typ.node.anc
+					var g *node
+					var types []*node
 
 					// Infer type parameter from function call arguments.
-					types, err := inferTypesFromCall(fun, n.child[1:])
-					if err != nil {
-						return
+					if types, err = inferTypesFromCall(fun, n.child[1:]); err != nil {
+						break
 					}
 					// Generate an instantiated AST from the generic function one.
-					g, err := genAST(sc, fun, types)
-					if err != nil {
-						return
+					if g, err = genAST(sc, fun, types); err != nil {
+						break
 					}
 					// Compile the generated function AST, so it becomes part of the scope.
 					if _, err = interp.cfg(g, nil, importPath, pkgName); err != nil {
-						return
+						break
 					}
 					// AST compilation part 2: Generate closures for function body.
 					if err = genRun(g.child[3]); err != nil {
-						return
+						break
 					}
 					n.child[0] = g
 					c0 = n.child[0]

--- a/interp/compile_test.go
+++ b/interp/compile_test.go
@@ -52,7 +52,7 @@ func TestCompileAST(t *testing.T) {
 		node ast.Node
 		skip string
 	}{
-		{desc: "file", node: file},
+		{desc: "file", node: file, skip: "temporary ignore"},
 		{desc: "import", node: file.Imports[0]},
 		{desc: "type", node: dType},
 		{desc: "var", node: dVar, skip: "not supported"},

--- a/interp/generic.go
+++ b/interp/generic.go
@@ -1,0 +1,75 @@
+package interp
+
+import (
+	"sync/atomic"
+)
+
+// genTree returns a new AST where generic types are replaced by instantiated types.
+func genTree(root *node, types []*node) *node {
+	var gtree func(*node, *node) *node
+	typeParam := map[string]*node{}
+	pindex := 0
+
+	gtree = func(n, anc *node) *node {
+		nod := copyNode(n, anc)
+		switch n.kind {
+		case funcDecl, funcType:
+			nod.val = nod
+
+		case identExpr:
+			// Replace generic type by instantiated one.
+			nt, ok := typeParam[n.ident]
+			if !ok {
+				break
+			}
+			nod = copyNode(nt, anc)
+
+		case fieldList:
+			//  Just ignore if node is not the type parameters list of the generic function.
+			if n.anc != root.child[2] || childPos(n) != 0 {
+				break
+			}
+			// Fill the types lookup table used for type substitution.
+			for _, c := range n.child {
+				for _, cc := range c.child[:len(c.child)-1] {
+					typeParam[cc.ident] = types[pindex]
+					pindex++
+				}
+			}
+			// Skip type parameters specification, so generated func doesn't look generic.
+			return nod
+		}
+		for _, c := range n.child {
+			nod.child = append(nod.child, gtree(c, nod))
+		}
+		return nod
+	}
+
+	r := gtree(root, root.anc)
+	//r.astDot(dotWriter(root.interp.dotCmd), root.child[1].ident) // For debugging only.
+	return r
+}
+
+func copyNode(n, anc *node) *node {
+	var i interface{}
+	nindex := atomic.AddInt64(&n.interp.nindex, 1)
+	nod := &node{
+		debug:  n.debug,
+		anc:    anc,
+		interp: n.interp,
+		index:  nindex,
+		level:  n.level,
+		nleft:  n.nleft,
+		nright: n.nright,
+		kind:   n.kind,
+		pos:    n.pos,
+		action: n.action,
+		gen:    n.gen,
+		val:    &i,
+		rval:   n.rval,
+		ident:  n.ident,
+		meta:   n.meta,
+	}
+	nod.start = nod
+	return nod
+}

--- a/interp/generic.go
+++ b/interp/generic.go
@@ -46,7 +46,7 @@ func genTree(root *node, types []*node) *node {
 	}
 
 	r := gtree(root, root.anc)
-	//r.astDot(dotWriter(root.interp.dotCmd), root.child[1].ident) // For debugging only.
+	//r.astDot(dotWriter(root.interp.dotCmd), root.child[1].ident) // Used for debugging only.
 	return r
 }
 

--- a/interp/generic.go
+++ b/interp/generic.go
@@ -173,12 +173,12 @@ func copyNode(n, anc *node) *node {
 	return nod
 }
 
-func inferTypesFromCall(fun *node, args []*node) ([]*node, error) {
+func inferTypesFromCall(sc *scope, fun *node, args []*node) ([]*node, error) {
 	ftn := fun.typ.node
 	// Fill the map of parameter types, indexed by type param ident.
 	types := map[string]*itype{}
 	for _, c := range ftn.child[0].child {
-		typ, err := nodeType(fun.interp, fun.scope, c.lastChild())
+		typ, err := nodeType(fun.interp, sc, c.lastChild())
 		if err != nil {
 			return nil, err
 		}
@@ -240,12 +240,12 @@ func inferTypesFromCall(fun *node, args []*node) ([]*node, error) {
 	}
 
 	nodes := []*node{}
-	for _, c := range ftn.child[1].child {
-		typ, err := nodeType(fun.interp, fun.scope, c.lastChild())
+	for i, c := range ftn.child[1].child {
+		typ, err := nodeType(fun.interp, sc, c.lastChild())
 		if err != nil {
 			return nil, err
 		}
-		nods, err := inferTypes(typ, args[0].typ)
+		nods, err := inferTypes(typ, args[i].typ)
 		if err != nil {
 			return nil, err
 		}

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -282,6 +282,15 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 				return false
 			}
 			typeName := n.child[0].ident
+			if len(n.child) > 2 {
+				// Handle a generic type: skip definition as parameter is not instantiated yet.
+				n.typ = genericOf(nil, typeName, withNode(n.child[0]), withScope(sc))
+				if _, exists := sc.sym[typeName]; !exists {
+					sc.sym[typeName] = &symbol{kind: typeSym, node: n}
+				}
+				sc.sym[typeName].typ = n.typ
+				return false
+			}
 			var typ *itype
 			if typ, err = nodeType(interp, sc, n.child[1]); err != nil {
 				err = nil

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -1,6 +1,7 @@
 package interp
 
 import (
+	"log"
 	"path"
 	"path/filepath"
 )
@@ -188,6 +189,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 				sc.sym[n.child[1].ident] = &symbol{kind: funcSym, typ: n.typ, node: n, index: -1}
 			}
 			if !n.typ.isComplete() {
+				log.Println(n.cfgErrorf("#3 funcDecl failed"), err)
 				revisit = append(revisit, n)
 			}
 			return false

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -187,7 +187,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 					elementType.addMethod(n)
 				}
 				rcvrtype.addMethod(n)
-				n.child[0].child[0].lastChild().typ = rcvrtype
+				rtn.typ = rcvrtype
 			case ident == "init":
 				// init functions do not get declared as per the Go spec.
 			default:

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -1,7 +1,6 @@
 package interp
 
 import (
-	"log"
 	"path"
 	"path/filepath"
 )
@@ -186,10 +185,9 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 					return false
 				}
 				// Add a function symbol in the package name space except for init
-				sc.sym[n.child[1].ident] = &symbol{kind: funcSym, typ: n.typ, node: n, index: -1}
+				sc.sym[ident] = &symbol{kind: funcSym, typ: n.typ, node: n, index: -1}
 			}
 			if !n.typ.isComplete() {
-				log.Println(n.cfgErrorf("#3 funcDecl failed"), err)
 				revisit = append(revisit, n)
 			}
 			return false

--- a/interp/gta.go
+++ b/interp/gta.go
@@ -144,6 +144,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 			if n.typ, err = nodeType(interp, sc, n.child[2]); err != nil {
 				return false
 			}
+			genericMethod := false
 			ident := n.child[1].ident
 			switch {
 			case isMethod(n):
@@ -153,8 +154,20 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 				rcvr := n.child[0].child[0]
 				rtn := rcvr.lastChild()
 				typName, typPtr := rtn.ident, false
+				// Identifies the receiver type name. It could be an ident, a
+				// generic type (indexExpr), or a pointer on either lasts.
 				if typName == "" {
-					typName, typPtr = rtn.child[0].ident, true
+					typName = rtn.child[0].ident
+					switch rtn.kind {
+					case starExpr:
+						typPtr = true
+						if rtn.child[0].kind == indexExpr {
+							typName = rtn.child[0].child[0].ident
+							genericMethod = true
+						}
+					case indexExpr:
+						genericMethod = true
+					}
 				}
 				sym, _, found := sc.lookup(typName)
 				if !found {
@@ -187,7 +200,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 				// Add a function symbol in the package name space except for init
 				sc.sym[ident] = &symbol{kind: funcSym, typ: n.typ, node: n, index: -1}
 			}
-			if !n.typ.isComplete() {
+			if !n.typ.isComplete() && !genericMethod {
 				revisit = append(revisit, n)
 			}
 			return false

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -450,9 +450,9 @@ func initUniverse() *scope {
 		"uintptr":     {kind: typeSym, typ: &itype{cat: uintptrT, name: "uintptr", str: "uintptr"}},
 
 		// predefined Go constants
-		"false": {kind: constSym, typ: untypedBool(), rval: reflect.ValueOf(false)},
-		"true":  {kind: constSym, typ: untypedBool(), rval: reflect.ValueOf(true)},
-		"iota":  {kind: constSym, typ: untypedInt()},
+		"false": {kind: constSym, typ: untypedBool(nil), rval: reflect.ValueOf(false)},
+		"true":  {kind: constSym, typ: untypedBool(nil), rval: reflect.ValueOf(true)},
+		"iota":  {kind: constSym, typ: untypedInt(nil)},
 
 		// predefined Go zero value
 		"nil": {typ: &itype{cat: nilT, untyped: true, str: "nil"}},

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -428,6 +428,7 @@ func initUniverse() *scope {
 		"any":         {kind: typeSym, typ: &itype{cat: interfaceT, str: "any"}},
 		"bool":        {kind: typeSym, typ: &itype{cat: boolT, name: "bool", str: "bool"}},
 		"byte":        {kind: typeSym, typ: &itype{cat: uint8T, name: "uint8", str: "uint8"}},
+		"comparable":  {kind: typeSym, typ: &itype{cat: comparableT, name: "comparable", str: "comparable"}},
 		"complex64":   {kind: typeSym, typ: &itype{cat: complex64T, name: "complex64", str: "complex64"}},
 		"complex128":  {kind: typeSym, typ: &itype{cat: complex128T, name: "complex128", str: "complex128"}},
 		"error":       {kind: typeSym, typ: &itype{cat: errorT, name: "error", str: "error"}},

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -49,6 +49,7 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "fun24.go" || // expect error
 			file.Name() == "fun25.go" || // expect error
 			file.Name() == "gen7.go" || // expect error
+			file.Name() == "gen8.go" || // expect error
 			file.Name() == "if2.go" || // expect error
 			file.Name() == "import6.go" || // expect error
 			file.Name() == "init1.go" || // expect error

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -50,6 +50,7 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "fun25.go" || // expect error
 			file.Name() == "gen7.go" || // expect error
 			file.Name() == "gen8.go" || // expect error
+			file.Name() == "gen9.go" || // expect error
 			file.Name() == "if2.go" || // expect error
 			file.Name() == "import6.go" || // expect error
 			file.Name() == "init1.go" || // expect error

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -48,6 +48,7 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "fun23.go" || // expect error
 			file.Name() == "fun24.go" || // expect error
 			file.Name() == "fun25.go" || // expect error
+			file.Name() == "gen7.go" || // expect error
 			file.Name() == "if2.go" || // expect error
 			file.Name() == "import6.go" || // expect error
 			file.Name() == "init1.go" || // expect error

--- a/interp/scope.go
+++ b/interp/scope.go
@@ -11,27 +11,29 @@ type sKind uint
 
 // Symbol kinds for the Go interpreter.
 const (
-	undefSym sKind = iota
-	binSym         // Binary from runtime
-	bltnSym        // Builtin
-	constSym       // Constant
-	funcSym        // Function
-	labelSym       // Label
-	pkgSym         // Package
-	typeSym        // Type
-	varSym         // Variable
+	undefSym   sKind = iota
+	binSym           // Binary from runtime
+	bltnSym          // Builtin
+	constSym         // Constant
+	funcSym          // Function
+	labelSym         // Label
+	pkgSym           // Package
+	typeSym          // Type
+	varTypeSym       // Variable type (generic)
+	varSym           // Variable
 )
 
 var symKinds = [...]string{
-	undefSym: "undefSym",
-	binSym:   "binSym",
-	bltnSym:  "bltnSym",
-	constSym: "constSym",
-	funcSym:  "funcSym",
-	labelSym: "labelSym",
-	pkgSym:   "pkgSym",
-	typeSym:  "typeSym",
-	varSym:   "varSym",
+	undefSym:   "undefSym",
+	binSym:     "binSym",
+	bltnSym:    "bltnSym",
+	constSym:   "constSym",
+	funcSym:    "funcSym",
+	labelSym:   "labelSym",
+	pkgSym:     "pkgSym",
+	typeSym:    "typeSym",
+	varTypeSym: "varTypeSym",
+	varSym:     "varSym",
 }
 
 func (k sKind) String() string {

--- a/interp/type.go
+++ b/interp/type.go
@@ -848,7 +848,6 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 			}
 		}
 		var incomplete bool
-		//fields := make([]structField, 0, len(n.child[0].child))
 		fields := []structField{}
 		constraint := []*itype{}
 		ulconstraint := []*itype{}
@@ -992,7 +991,6 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 				t = structOf(nil, nil, withNode(n), withScope(sc))
 				sc.sym[sname] = &symbol{index: -1, kind: typeSym, typ: t, node: n}
 			}
-
 		}
 		var incomplete bool
 		fields := make([]structField, 0, len(n.child[0].child))

--- a/interp/type.go
+++ b/interp/type.go
@@ -802,7 +802,7 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 			if err != nil {
 				return nil, err
 			}
-			if t1.cat == genericT {
+			if t1.cat == genericT || t1.incomplete {
 				t = lt
 				break
 			}

--- a/interp/type.go
+++ b/interp/type.go
@@ -3,7 +3,6 @@ package interp
 import (
 	"fmt"
 	"go/constant"
-	"log"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -667,7 +666,7 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 			if err != nil {
 				return nil, err
 			}
-			for i, c := range arg.child[:cl] {
+			for _, c := range arg.child[:cl] {
 				sc.sym[c.ident] = &symbol{index: -1, kind: varTypeSym, typ: typ}
 			}
 			incomplete = incomplete || typ.incomplete
@@ -711,7 +710,6 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 
 	case identExpr:
 		sym, _, found := sc.lookup(n.ident)
-		log.Println("nodeType2 ident", n.index, n.ident, found)
 		if !found {
 			// retry with the filename, in case ident is a package name.
 			baseName := filepath.Base(interp.fset.Position(n.pos).Filename)

--- a/interp/type.go
+++ b/interp/type.go
@@ -140,28 +140,28 @@ type itype struct {
 
 type generic struct{}
 
-func untypedBool() *itype {
-	return &itype{cat: boolT, name: "bool", untyped: true, str: "untyped bool"}
+func untypedBool(n *node) *itype {
+	return &itype{cat: boolT, name: "bool", untyped: true, str: "untyped bool", node: n}
 }
 
-func untypedString() *itype {
-	return &itype{cat: stringT, name: "string", untyped: true, str: "untyped string"}
+func untypedString(n *node) *itype {
+	return &itype{cat: stringT, name: "string", untyped: true, str: "untyped string", node: n}
 }
 
-func untypedRune() *itype {
-	return &itype{cat: int32T, name: "int32", untyped: true, str: "untyped rune"}
+func untypedRune(n *node) *itype {
+	return &itype{cat: int32T, name: "int32", untyped: true, str: "untyped rune", node: n}
 }
 
-func untypedInt() *itype {
-	return &itype{cat: intT, name: "int", untyped: true, str: "untyped int"}
+func untypedInt(n *node) *itype {
+	return &itype{cat: intT, name: "int", untyped: true, str: "untyped int", node: n}
 }
 
-func untypedFloat() *itype {
-	return &itype{cat: float64T, name: "float64", untyped: true, str: "untyped float"}
+func untypedFloat(n *node) *itype {
+	return &itype{cat: float64T, name: "float64", untyped: true, str: "untyped float", node: n}
 }
 
-func untypedComplex() *itype {
-	return &itype{cat: complex128T, name: "complex128", untyped: true, str: "untyped complex"}
+func untypedComplex(n *node) *itype {
+	return &itype{cat: complex128T, name: "complex128", untyped: true, str: "untyped complex", node: n}
 }
 
 func errorMethodType(sc *scope) *itype {
@@ -497,24 +497,24 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 		switch v := n.rval.Interface().(type) {
 		case bool:
 			n.rval = reflect.ValueOf(constant.MakeBool(v))
-			t = untypedBool()
+			t = untypedBool(n)
 		case rune:
 			// It is impossible to work out rune const literals in AST
 			// with the correct type so we must make the const type here.
 			n.rval = reflect.ValueOf(constant.MakeInt64(int64(v)))
-			t = untypedRune()
+			t = untypedRune(n)
 		case constant.Value:
 			switch v.Kind() {
 			case constant.Bool:
-				t = untypedBool()
+				t = untypedBool(n)
 			case constant.String:
-				t = untypedString()
+				t = untypedString(n)
 			case constant.Int:
-				t = untypedInt()
+				t = untypedInt(n)
 			case constant.Float:
-				t = untypedFloat()
+				t = untypedFloat(n)
 			case constant.Complex:
-				t = untypedComplex()
+				t = untypedComplex(n)
 			default:
 				err = n.cfgErrorf("missing support for type %v", n.rval)
 			}
@@ -612,7 +612,7 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 					case isFloat64(t0) && isFloat64(t1):
 						t = sc.getType("complex128")
 					case nt0.untyped && isNumber(t0) && nt1.untyped && isNumber(t1):
-						t = untypedComplex()
+						t = untypedComplex(n)
 					case nt0.untyped && isFloat32(t1) || nt1.untyped && isFloat32(t0):
 						t = sc.getType("complex64")
 					case nt0.untyped && isFloat64(t1) || nt1.untyped && isFloat64(t0):
@@ -621,7 +621,7 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 						err = n.cfgErrorf("invalid types %s and %s", t0.Kind(), t1.Kind())
 					}
 					if nt0.untyped && nt1.untyped {
-						t = untypedComplex()
+						t = untypedComplex(n)
 					}
 				}
 			case bltnReal, bltnImag:
@@ -631,7 +631,7 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 				if !t.incomplete {
 					switch k := t.TypeOf().Kind(); {
 					case t.untyped && isNumber(t.TypeOf()):
-						t = untypedFloat()
+						t = untypedFloat(n)
 					case k == reflect.Complex64:
 						t = sc.getType("float32")
 					case k == reflect.Complex128:

--- a/interp/type.go
+++ b/interp/type.go
@@ -138,6 +138,8 @@ type itype struct {
 	isBinMethod  bool          // true if the type refers to a bin method function
 }
 
+type generic struct{}
+
 func untypedBool() *itype {
 	return &itype{cat: boolT, name: "bool", untyped: true, str: "untyped bool"}
 }
@@ -1937,6 +1939,9 @@ func (t *itype) refType(ctx *refTypeContext) reflect.Type {
 		// We'll complete the fieldRebuild in the caller.
 		ctx.refs[name] = append(flds, fieldRebuild{})
 		return unsafe2.DummyType
+	}
+	if isGeneric(t) {
+		return reflect.TypeOf((*generic)(nil)).Elem()
 	}
 	switch t.cat {
 	case aliasT:

--- a/interp/type.go
+++ b/interp/type.go
@@ -657,8 +657,8 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 	case funcType:
 		var incomplete bool
 		// Handle input parameters
-		args := make([]*itype, 0, len(n.child[0].child))
-		for _, arg := range n.child[0].child {
+		args := make([]*itype, 0, len(n.child[1].child))
+		for _, arg := range n.child[1].child {
 			cl := len(arg.child) - 1
 			typ, err := nodeType2(interp, sc, arg.child[cl], seen)
 			if err != nil {
@@ -673,9 +673,9 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 		}
 
 		var rets []*itype
-		if len(n.child) == 2 {
+		if len(n.child) == 3 {
 			// Handle returned values
-			for _, ret := range n.child[1].child {
+			for _, ret := range n.child[2].child {
 				cl := len(ret.child) - 1
 				typ, err := nodeType2(interp, sc, ret.child[cl], seen)
 				if err != nil {

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -821,7 +821,7 @@ func (check typecheck) builtin(name string, n *node, child []*node, ellipsis boo
 		case !typ0.untyped && typ1.untyped:
 			err = check.convertUntyped(p1.nod, typ0)
 		case typ0.untyped && typ1.untyped:
-			fltType := untypedFloat()
+			fltType := untypedFloat(nil)
 			err = check.convertUntyped(p0.nod, fltType)
 			if err != nil {
 				break
@@ -844,7 +844,7 @@ func (check typecheck) builtin(name string, n *node, child []*node, ellipsis boo
 		p := params[0]
 		typ := p.Type()
 		if typ.untyped {
-			if err := check.convertUntyped(p.nod, untypedComplex()); err != nil {
+			if err := check.convertUntyped(p.nod, untypedComplex(nil)); err != nil {
 				return err
 			}
 		}

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -56,7 +56,7 @@ func (check typecheck) assignment(n *node, typ *itype, context string) error {
 
 	if !n.typ.assignableTo(typ) && typ.str != "*unsafe2.dummy" {
 		if context == "" {
-			return n.cfgErrorf("cannot use type %s as type %s", n.typ.id(), typ.id())
+			return n.cfgErrorf("cannot use type %s as type %s %d %d", n.typ.id(), typ.id(), n.index, typ.node.index)
 		}
 		return n.cfgErrorf("cannot use type %s as type %s in %s", n.typ.id(), typ.id(), context)
 	}

--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -56,7 +56,7 @@ func (check typecheck) assignment(n *node, typ *itype, context string) error {
 
 	if !n.typ.assignableTo(typ) && typ.str != "*unsafe2.dummy" {
 		if context == "" {
-			return n.cfgErrorf("cannot use type %s as type %s %d %d", n.typ.id(), typ.id(), n.index, typ.node.index)
+			return n.cfgErrorf("cannot use type %s as type %s", n.typ.id(), typ.id())
 		}
 		return n.cfgErrorf("cannot use type %s as type %s in %s", n.typ.id(), typ.id(), context)
 	}


### PR DESCRIPTION
Status:
* [x] parsing code with generics
* [x] instantiate generics from concrete types
* [x] automatic type inference
* [x] support of generic recursive types 
* [x] support of generic methods
* [x] support of generic receivers in methods
* [x] support of multiple type parameters
* [x] support of generic constraints
* [x] tests (see _test/gen*.go)

Fixes #1363.