### PR TITLE
interp: do not allow function declaration without body

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -360,6 +360,11 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 			fallthrough
 
 		case funcDecl:
+			// Do not allow function declarations without body.
+			if len(n.child) < 4 {
+				err = n.cfgErrorf("function declaration without body is unsupported (linkname or assembly can not be interperted).")
+				return false
+			}
 			n.val = n
 			// Compute function type before entering local scope to avoid
 			// possible collisions with function argument names.

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -362,7 +362,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 		case funcDecl:
 			// Do not allow function declarations without body.
 			if len(n.child) < 4 {
-				err = n.cfgErrorf("function declaration without body is unsupported (linkname or assembly can not be interperted).")
+				err = n.cfgErrorf("function declaration without body is unsupported (linkname or assembly can not be interpreted).")
 				return false
 			}
 			n.val = n

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -701,6 +701,7 @@ func TestEvalCall(t *testing.T) {
 		{src: ` test := func(a, b int) int { return a }
 				blah := func() (int, float64) { return 1, 1.1 }
 				a := test(blah())`, err: "3:15: cannot use func() (int,float64) as type (int,int)"},
+		{src: "func f()", err: "function declaration without body is unsupported"},
 	})
 }
 


### PR DESCRIPTION
Such function declaration denotes either a linkname (an access to
an arbitrary, typically unexported symbol, solved by go compiler),
or a foreign C or assembly implementation of the body.

Those cases are not supported (or planned to be) by the interpreter.

Fixes #1431.