### PR TITLE
interp: fix spurious variable declaration loop

### DIFF
--- a/_test/p4/p4.go
+++ b/_test/p4/p4.go
@@ -1,0 +1,3 @@
+package p4
+
+var Value1 = "value1"

--- a/_test/p5.go
+++ b/_test/p5.go
@@ -5,3 +5,6 @@ import "github.com/traefik/yaegi/_test/p5"
 func main() {
 	println(*p5.Value1)
 }
+
+// Output:
+// value1

--- a/_test/p5.go
+++ b/_test/p5.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/traefik/yaegi/_test/p5"
+
+func main() {
+	println(*p5.Value1)
+}

--- a/_test/p5/p5.go
+++ b/_test/p5/p5.go
@@ -1,0 +1,8 @@
+package p5
+
+import "github.com/traefik/yaegi/_test/p4"
+
+var (
+	Value1 = &val1
+	val1   = p4.Value1
+)


### PR DESCRIPTION
The variable dependency check function was confused by a dependency
variable with the same name but in an external package.

This change is necessary to address #1427.