### PR TITLE
interp: fix default comm clause in select

### DIFF
--- a/_test/issue-1442.go
+++ b/_test/issue-1442.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func main() {
+	ctx, _ := context.WithCancel(context.Background())
+	ch := make(chan string, 20)
+	defer close(ch)
+
+	for i := 0; i < 6; i++ {
+		fmt.Println(i)
+		go func(ctx context.Context, ch <-chan string) {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case tmp := <-ch:
+					fmt.Println(tmp)
+				}
+			}
+		}(ctx, ch)
+	}
+	//	for _, i := range "abcdef" {
+	//		for _, j := range "0123456789" {
+	i, j := "a", "0"
+	for _, k := range "ABCDEF" {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			tmp := string(i) + string(j) + string(k)
+			ch <- tmp
+		}
+	}
+	//		}
+	//	}
+	return
+}

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1923,6 +1923,10 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 			// Chain channel init actions in commClauses prior to invoke select.
 			var cur *node
 			for _, c := range n.child[0].child {
+				if c.kind == commClauseDefault {
+					// No channel init in this case.
+					continue
+				}
 				var an, pn *node // channel init action nodes
 				if len(c.child) > 0 {
 					switch c0 := c.child[0]; {


### PR DESCRIPTION
Do not attempt to init a non-existent channel setting when in
default communication clause in select.

Fixes #1442.