### PR TITLE
interp: add missing conversion for non integer array dimension

### DIFF
--- a/_test/issue-1451.go
+++ b/_test/issue-1451.go
@@ -1,0 +1,19 @@
+package main
+
+type t1 uint8
+
+const (
+	n1 t1 = iota
+	n2
+)
+
+type T struct {
+	elem [n2 + 1]int
+}
+
+func main() {
+	println(len(T{}.elem))
+}
+
+// Output:
+// 2

--- a/interp/type.go
+++ b/interp/type.go
@@ -446,7 +446,7 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 		)
 		switch v := c0.rval; {
 		case v.IsValid():
-			// Size if defined by a constant litteral value.
+			// Size if defined by a constant literal value.
 			if isConstantValue(v.Type()) {
 				c := v.Interface().(constant.Value)
 				length = constToInt(c)

--- a/interp/type.go
+++ b/interp/type.go
@@ -456,10 +456,6 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 					length = int(v.Int())
 				case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 					length = int(v.Uint())
-				case reflect.Float32, reflect.Float64:
-					length = int(v.Float())
-				case reflect.Complex64, reflect.Complex128:
-					length = int(real(v.Complex()))
 				default:
 					return nil, c0.cfgErrorf("non integer constant %v", v)
 				}

--- a/interp/type.go
+++ b/interp/type.go
@@ -451,7 +451,18 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 				c := v.Interface().(constant.Value)
 				length = constToInt(c)
 			} else {
-				length = int(v.Int())
+				switch v.Type().Kind() {
+				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+					length = int(v.Int())
+				case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+					length = int(v.Uint())
+				case reflect.Float32, reflect.Float64:
+					length = int(v.Float())
+				case reflect.Complex64, reflect.Complex128:
+					length = int(real(v.Complex()))
+				default:
+					return nil, c0.cfgErrorf("non integer constant %v", v)
+				}
 			}
 		case c0.kind == ellipsisExpr:
 			// [...]T expression, get size from the length of composite array.


### PR DESCRIPTION
Fixes #1451.