### PR TITLE
interp: fix type assertion for wrapped empty interface

### DIFF
--- a/_test/cli7.go
+++ b/_test/cli7.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+)
+
+type T struct {
+	http.ResponseWriter
+}
+
+type mw1 struct {
+	next http.Handler
+}
+
+var obj = map[string]interface{}{}
+
+func (m *mw1) ServeHTTP(rw http.ResponseWriter, rq *http.Request) {
+	t := &T{
+		ResponseWriter: rw,
+	}
+	x := t.Header()
+	i := obj["m1"].(*mw1)
+	fmt.Fprint(rw, "Welcome to my website!", x, i)
+}
+
+func main() {
+	m1 := &mw1{}
+
+	obj["m1"] = m1
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", m1.ServeHTTP)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client(server.URL)
+}
+
+func client(uri string) {
+	resp, err := http.Get(uri)
+	if err != nil {
+		log.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(body))
+}
+
+// Output:
+// Welcome to my website!map[] &{<nil>}

--- a/_test/type24.go
+++ b/_test/type24.go
@@ -43,6 +43,6 @@ func assertValue() {
 }
 
 // Output:
-// interface conversion: interface {} is int, not string
-// interface conversion: interface {} is nil, not string
-// interface conversion: *httptest.ResponseRecorder is not http.Pusher: missing method Push
+// 22:10: interface conversion: interface {} is int, not string
+// 32:10: interface conversion: interface {} is nil, not string
+// 42:10: interface conversion: *httptest.ResponseRecorder is not http.Pusher: missing method Push

--- a/interp/interp_consistent_test.go
+++ b/interp/interp_consistent_test.go
@@ -109,6 +109,7 @@ func TestInterpConsistencyBuild(t *testing.T) {
 			file.Name() == "range9.go" || // expect error
 			file.Name() == "unsafe6.go" || // needs go.mod to be 1.17
 			file.Name() == "unsafe7.go" || // needs go.mod to be 1.17
+			file.Name() == "type24.go" || // expect error
 			file.Name() == "type27.go" || // expect error
 			file.Name() == "type28.go" || // expect error
 			file.Name() == "type29.go" || // expect error

--- a/interp/interp_file_test.go
+++ b/interp/interp_file_test.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -76,7 +77,9 @@ func runCheck(t *testing.T, p string) {
 		t.Fatal(err)
 	}
 
-	if res := strings.TrimSpace(stdout.String()); res != wanted {
+	// Remove path in output, to have results independent of location.
+	re := regexp.MustCompile(p + ":")
+	if res := re.ReplaceAllString(strings.TrimSpace(stdout.String()), ""); res != wanted {
 		t.Errorf("\ngot:  %q,\nwant: %q", res, wanted)
 	}
 }


### PR DESCRIPTION
Although empty interfaces are usually not wrapped, for compatibility with the runtime, we may have to wrap them sometime into `valueInterface` type.

It allows to preserve interpreter type metadata for interface values exchanged with the runtime. It is necessary to resolve methods and receivers in the absence of reflect support.

During type assertions on empty interfaces, we now handle a possible valueInterface and dereference the original value to pursue the type assertion.

In the same change, we have improved the format of some panic messages at runtime to give location of offending source at interpreter level.

This change will allow to fix traefik/traefik#9362.