### PR TITLE
interp: wrap source functions when used as input parameters.

### DIFF
--- a/_test/fun28.go
+++ b/_test/fun28.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"runtime"
+)
+
+type T struct {
+	name string
+}
+
+func finalize(t *T) { println("finalize") }
+
+func newT() *T {
+	t := new(T)
+	runtime.SetFinalizer(t, finalize)
+	return t
+}
+
+func main() {
+	t := newT()
+	println(t != nil)
+}
+
+// Output:
+// true

--- a/interp/run.go
+++ b/interp/run.go
@@ -1561,6 +1561,8 @@ func callBin(n *node) {
 				values = append(values, genValue(c))
 			case isInterfaceSrc(c.typ):
 				values = append(values, genValueInterfaceValue(c))
+			case isFuncSrc(c.typ):
+				values = append(values, genFunctionWrapper(c))
 			case c.typ.cat == arrayT || c.typ.cat == variadicT:
 				if isEmptyInterface(c.typ.val) {
 					values = append(values, genValueArray(c))


### PR DESCRIPTION
It allows to use interpreter functions as parameters in the runtime, even for defered callbacks, or when passed as empty interfaces, as for runtime.SetFinalizer.

Fixes #1503