### PR TITLE
interp: improve handling of methods defined on interfaces

### DIFF
--- a/_test/issue-1515.go
+++ b/_test/issue-1515.go
@@ -1,0 +1,43 @@
+package main
+
+type I1 interface {
+	I2
+	Wrap() *S3
+}
+
+type I2 interface {
+	F()
+}
+
+type S2 struct {
+	I2
+}
+
+func newS2(i2 I2) I1 {
+	return &S2{i2}
+}
+
+type S3 struct {
+	base *S2
+}
+
+func (s *S2) Wrap() *S3 {
+	i2 := s
+	return &S3{i2}
+}
+
+type T struct {
+	name string
+}
+
+func (t *T) F() { println("in F", t.name) }
+
+func main() {
+	t := &T{"test"}
+	s2 := newS2(t)
+	s3 := s2.Wrap()
+	s3.base.F()
+}
+
+// Output:
+// in F test

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -1992,6 +1992,9 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 					n.recv = &receiver{node: n.child[0], index: lind}
 					n.val = append([]int{m.Index}, lind...)
 					n.typ = valueTOf(m.Type, isBinMethod(), withRecv(n.child[0].typ))
+				} else if n.typ.hasInterfaceMethod(n.child[1].ident) {
+					n.action = aGetMethod
+					n.gen = getMethodByName
 				} else {
 					err = n.cfgErrorf("undefined selector: %s", n.child[1].ident)
 				}

--- a/interp/value.go
+++ b/interp/value.go
@@ -55,10 +55,19 @@ func genValueRecv(n *node) func(*frame) reflect.Value {
 
 	return func(f *frame) reflect.Value {
 		r := v(f)
-		if r.Kind() == reflect.Ptr {
-			r = r.Elem()
+		for _, i := range fi {
+			if r.Kind() == reflect.Ptr {
+				r = r.Elem()
+			}
+			// Note that we can't use reflect FieldByIndex method, as we may
+			// traverse valueInterface wrappers to access the embedded receiver.
+			r = r.Field(i)
+			vi, ok := r.Interface().(valueInterface)
+			if ok {
+				r = vi.value
+			}
 		}
-		return r.FieldByIndex(fi)
+		return r
 	}
 }
 


### PR DESCRIPTION
For methods defined on interfaces (vs concrete methods), the resolution of the method is necessarily delayed at the run time and can not be completed at compile time.

The selectorExpr processing has been changed to correctly identify calls on interface methods which were confused as fields rather than methods (due to the fact that in a interface definition, methods are fields of the interface).

Then at runtime, method lookup has been fixed to correctly recurse in nested valueInterface wrappers and to find embedded interface fields in case of struct or pointer to structs.

Fixes #1515.