### PR TITLE
More safeguards when searching for vendor root.

### DIFF
--- a/interp/src.go
+++ b/interp/src.go
@@ -248,6 +248,10 @@ func previousRoot(filesystem fs.FS, rootPath, root string) (string, error) {
 			if !os.IsNotExist(err) {
 				return "", err
 			}
+			// stop when we reach GOPATH/src
+			if parent == prefix {
+				break
+			}
 
 			// stop when we reach GOPATH/src/blah
 			parent = filepath.Dir(parent)
@@ -259,7 +263,8 @@ func previousRoot(filesystem fs.FS, rootPath, root string) (string, error) {
 			// we are dealing with relative paths).
 			// TODO(mpl): It should probably be a critical error actually,
 			// as we shouldn't have gone that high up in the tree.
-			if parent == string(filepath.Separator) || parent == "." {
+			// TODO(dennwc): This partially fails on Windows, since it cannot recognize drive letters as "root".
+			if parent == string(filepath.Separator) || parent == "." || parent == "" {
 				break
 			}
 		}


### PR DESCRIPTION
With certain yaegi configuration on Windows, the loop in `previousRoot` can be infinite, because it fails to recognize driver letters as root.

This change adds a few more safeguards: checks path prefix earlier and checks if `filepath.Dir` produces an empty path.