### PR TITLE
interp: fix type assertion issues

### DIFF
--- a/interp/run.go
+++ b/interp/run.go
@@ -290,7 +290,7 @@ func typeAssert(n *node, withResult, withOk bool) {
 
 	typ := c1.typ // type to assert or convert to
 	typID := typ.id()
-	rtype := typ.rtype // type to assert
+	rtype := typ.refType(nil) // type to assert
 	next := getExec(n.tnext)
 
 	switch {


### PR DESCRIPTION
closes #1514

hi!
I had the same problem as #1514 and I wanted to fix it, I found
When asserting *crypto/rsa.PublicKey, using the typ attribute of node to get an nil rtype, resulting in the assertion result being nok

So I submitted this Pull Request, hope it will be merged
