### PR TITLE
cli: disable race detector if GOFLAGS contains -buildmode=pie

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Beside the known [bugs] which are supposed to be fixed in the short term, there 
 - Representation of types by `reflect` and printing values using %T may give different results between compiled mode and interpreted mode.
 - Interpreting computation intensive code is likely to remain significantly slower than in compiled mode.
 
+Go modules are not supported yet. Until that, it is necessary to install the source into `$GOPATH/src/github.com/traefik/yaegi` to pass all the tests.
+
 ## Contributing
 
 [Contributing guide](CONTRIBUTING.md).

--- a/cmd/yaegi/yaegi_test.go
+++ b/cmd/yaegi/yaegi_test.go
@@ -125,6 +125,12 @@ func TestYaegiCmdCancel(t *testing.T) {
 }
 
 func raceDetectorSupported(goos, goarch string) bool {
+	if strings.Contains(os.GetEnv("GOFLAGS"), "-buildmode=pie") {
+		// The Go race detector is not compatible with position independent code (pie).
+		// We read the conventional GOFLAGS env variable used for example on AlpineLinux
+		// to build packages, as there is no way to get this information from the runtime.
+		return false
+	}
 	switch goos {
 	case "linux":
 		return goarch == "amd64" || goarch == "ppc64le" || goarch == "arm64"


### PR DESCRIPTION
This should allow to build the package on AlpineLinux. Also document the constraint of having to install the source under $GOPATH/src/github.com/traefik/yaegi until Go modules are supported.

Fixes #1523.