### PR TITLE
test: use `t.TempDir` to create temporary test directory

### DIFF
--- a/cmd/yaegi/yaegi_test.go
+++ b/cmd/yaegi/yaegi_test.go
@@ -37,17 +37,7 @@ func applyCIMultiplier(timeout time.Duration) time.Duration {
 }
 
 func TestYaegiCmdCancel(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "yaegi-")
-	if err != nil {
-		t.Fatalf("failed to create tmp directory: %v", err)
-	}
-	defer func() {
-		err = os.RemoveAll(tmp)
-		if err != nil {
-			t.Errorf("failed to clean up %v: %v", tmp, err)
-		}
-	}()
-
+	tmp := t.TempDir()
 	yaegi := filepath.Join(tmp, "yaegi")
 
 	args := []string{"build"}

--- a/interp/src_test.go
+++ b/interp/src_test.go
@@ -49,13 +49,7 @@ func Test_effectivePkg(t *testing.T) {
 
 func Test_pkgDir(t *testing.T) {
 	// create GOPATH
-	goPath, err := os.MkdirTemp("", "pkdir")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(goPath)
-	}()
+	goPath := t.TempDir()
 
 	// Create project
 	project := filepath.Join(goPath, "src", "guthib.com", "foo", "root")


### PR DESCRIPTION
This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `t.TempDir` function from the `testing` package to create temporary directory. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatalf("failed to create tmp directory: %v", err)
	}
	defer func() {
		if err := os.RemoveAll(dir); err != nil {
			t.Fatal(err)
		}
	}

	// now
	tmpDir := t.TempDir()
}
```