### PR TITLE
extract: escape ~ in package name

### DIFF
--- a/cmd/yaegi/extract.go
+++ b/cmd/yaegi/extract.go
@@ -69,7 +69,7 @@ func extractCmd(arg []string) error {
 		ext.Include = strings.Split(include, ",")
 	}
 
-	r := strings.NewReplacer("/", "-", ".", "_")
+	r := strings.NewReplacer("/", "-", ".", "_", "~", "_")
 
 	for _, pkgIdent := range args {
 		var buf bytes.Buffer

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -132,7 +132,7 @@ func matchList(name string, list []string) (match bool, err error) {
 
 func (e *Extractor) genContent(importPath string, p *types.Package) ([]byte, error) {
 	prefix := "_" + importPath + "_"
-	prefix = strings.NewReplacer("/", "_", "-", "_", ".", "_").Replace(prefix)
+	prefix = strings.NewReplacer("/", "_", "-", "_", ".", "_", "~", "_").Replace(prefix)
 
 	typ := map[string]string{}
 	val := map[string]Val{}


### PR DESCRIPTION
consider packages from git.sr.ht, the user namespace is prefixed with `~`

so running something like `yaegi extract git.sr.ht/~emersion/scfg`

was producing syntax errors with `~` in identifiers. and also `~` in filenames which worked but probably best not to have it there either

thanks! 