### PR TITLE
interp: fix support of type assert expressions in the global scope

### DIFF
--- a/_test/assert4.go
+++ b/_test/assert4.go
@@ -1,0 +1,11 @@
+package main
+
+var cc interface{} = 2
+var dd = cc.(int)
+
+func main() {
+	println(dd)
+}
+
+// Output:
+// 2

--- a/interp/type.go
+++ b/interp/type.go
@@ -1090,6 +1090,9 @@ func nodeType2(interp *Interpreter, sc *scope, n *node, seen []*node) (t *itype,
 			sc.sym[sname].typ = t
 		}
 
+	case typeAssertExpr:
+		t, err = nodeType2(interp, sc, n.child[1], seen)
+
 	default:
 		err = n.cfgErrorf("type definition not implemented: %s", n.kind)
 	}


### PR DESCRIPTION
Add the support of type assert expressions in type parsing
which allows to process type assertions in the global scope.

Fixes #1543.