### PR TITLE
fix: re-import of identical package with `sym.typ.cat == binPkgT`

### DIFF
--- a/interp/gta.go
+++ b/interp/gta.go
@@ -261,7 +261,7 @@ func (interp *Interpreter) gta(root *node, rpath, importPath, pkgName string) ([
 					if sym, exists := sc.sym[name]; !exists {
 						sc.sym[name] = &symbol{kind: pkgSym, typ: &itype{cat: binPkgT, path: ipath, scope: sc}}
 						break
-					} else if sym.kind == pkgSym && sym.typ.cat == srcPkgT && sym.typ.path == ipath {
+					} else if sym.kind == pkgSym && sym.typ.cat == binPkgT && sym.typ.path == ipath {
 						// ignore re-import of identical package
 						break
 					}


### PR DESCRIPTION
test case:
```
func main() {
	script1 := `package script
import "encoding/json"
var _ = json.Marshal
`
	script2 := `package script
import "encoding/json"
var _ = json.Marshal
`
	inter := interp.New(interp.Options{GoPath: build.Default.GOPATH})
	_ = inter.Use(stdlib.Symbols)

	inter.Eval(script1)
	_, err := inter.Eval(script2)
	fmt.Println(err)
	// 2:8: json/_.go redeclared in this block
}
```

Related to: https://github.com/traefik/yaegi/pull/1066/files