### PR TITLE
doc: install using go install 

### DIFF
--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ 1.19, '1.20' ]
+        go-version: [ 1.18, 1.19, 1.20 ]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
         include:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ It powers executable Go scripts and plugins, in embedded interpreters or interac
 import "github.com/traefik/yaegi/interp"
 ```
 
-### Command-line executable
+### Command-line executable [REPL]
+
+#### Option 1 
+
+```bash
+go install github.com/traefik/yaegi@latest
+```
+
+#### Option 2
 
 ```bash
 go get -u github.com/traefik/yaegi/cmd/yaegi
@@ -35,6 +43,7 @@ go get -u github.com/traefik/yaegi/cmd/yaegi
 
 Note that you can use [rlwrap](https://github.com/hanslub42/rlwrap) (install with your favorite package manager),
 and alias the `yaegi` command in `alias yaegi='rlwrap yaegi'` in your `~/.bashrc`, to have history and command line edition.
+
 
 ### CI Integration
 


### PR DESCRIPTION
- Update workflow based on review on https://github.com/traefik/yaegi/pull/1563
- Extend workflow to support go 1.18
- Update markdown to document `go install` as preferred way for installation of yaegi REPL
