### PR TITLE
interp: fix fieldName method parsing embedded + generic fields

### DIFF
--- a/interp/type.go
+++ b/interp/type.go
@@ -1230,6 +1230,8 @@ func fieldName(n *node) string {
 		return fieldName(n.child[1])
 	case starExpr:
 		return fieldName(n.child[0])
+	case indexExpr:
+		return fieldName(n.child[0])
 	case identExpr:
 		return n.ident
 	default:


### PR DESCRIPTION
Fix https://github.com/traefik/yaegi/issues/1571