### PR TITLE
interp: Add wasip1 to known OS list

### DIFF
--- a/interp/build.go
+++ b/interp/build.go
@@ -182,6 +182,7 @@ var knownOs = map[string]bool{
 	"openbsd":   true,
 	"plan9":     true,
 	"solaris":   true,
+	"wasip1":    true,
 	"windows":   true,
 }
 


### PR DESCRIPTION
Adds `wasip1` to known OS list, introduced in golang/go#58141.

Without this change, `yaegi extract` may fail on Go 1.21 with the following message:
```
type-checking package "time" failed (<GOROOT>/src/time/zoneinfo_wasip1.go:8:5: platformZoneSources redeclared in this block)
```