### PR TITLE
interp: fix issue where a var is reused instead of redefined

### DIFF
--- a/_test/issue-1594.go
+++ b/_test/issue-1594.go
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+	var fns []func()
+	for _, v := range []int{1, 2, 3} {
+		x := v*100 + v
+		fns = append(fns, func() { println(x) })
+	}
+	for _, fn := range fns {
+		fn()
+	}
+}
+
+// Output:
+// 101
+// 202
+// 303

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -716,6 +716,9 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 				// location in the frame.
 				//
 				switch {
+				case n.kind == defineStmt:
+					// Do not skip assign operation for initializing variables, otherwise
+					// a var in a loop is reused instead of redefined.
 				case n.action != aAssign:
 					// Do not skip assign operation if it is combined with another operator.
 				case src.rval.IsValid():


### PR DESCRIPTION
Fix #1594