### PR TITLE
interp: allow assignment to exported variables

### DIFF
--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -654,7 +654,7 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 				var sym *symbol
 				var level int
 
-				if dest.rval.IsValid() && isConstType(dest.typ) {
+				if dest.rval.IsValid() && !dest.rval.CanSet() && isConstType(dest.typ) {
 					err = n.cfgErrorf("cannot assign to %s (%s constant)", dest.rval, dest.typ.str)
 					break
 				}

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -1906,3 +1906,27 @@ func TestIssue1383(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestIssue1623(t *testing.T) {
+	var f float64
+	var j int
+	var s string = "foo"
+
+	i := interp.New(interp.Options{})
+	if err := i.Use(interp.Exports{
+		"pkg/pkg": map[string]reflect.Value{
+			"F": reflect.ValueOf(&f).Elem(),
+			"J": reflect.ValueOf(&j).Elem(),
+			"S": reflect.ValueOf(&s).Elem(),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	i.ImportUsed()
+
+	runTests(t, i, []testCase{
+		{desc: "pkg.F = 2.0", src: "pkg.F = 2.0; pkg.F", res: "2"},
+		{desc: "pkg.J = 3", src: "pkg.J = 3; pkg.J", res: "3"},
+		{desc: `pkg.S = "bar"`, src: `pkg.S = "bar"; pkg.S`, res: "bar"},
+	})
+}


### PR DESCRIPTION
If you (*interp.Interpreter).Use a variable, you should be able to assign to it.

Fixes #1623.