### PR TITLE
Remove unnecessary additional newlines in extract generated interface wrappers

### DIFF
--- a/extract/extract.go
+++ b/extract/extract.go
@@ -87,8 +87,8 @@ func init() {
 			if W.WString == nil {
 				return ""
 			}
-			{{end -}}
-			{{$m.Ret}} W.W{{$m.Name}}{{$m.Arg}}
+			{{end}}
+			{{- $m.Ret}} W.W{{$m.Name}}{{$m.Arg -}}
 		}
 	{{end}}
 {{end}}

--- a/stdlib/go1_21_compress_flate.go
+++ b/stdlib/go1_21_compress_flate.go
@@ -48,12 +48,8 @@ type _compress_flate_Reader struct {
 	WReadByte func() (byte, error)
 }
 
-func (W _compress_flate_Reader) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _compress_flate_Reader) ReadByte() (byte, error) {
-	return W.WReadByte()
-}
+func (W _compress_flate_Reader) Read(p []byte) (n int, err error) { return W.WRead(p) }
+func (W _compress_flate_Reader) ReadByte() (byte, error)          { return W.WReadByte() }
 
 // _compress_flate_Resetter is an interface wrapper for Resetter type
 type _compress_flate_Resetter struct {
@@ -61,6 +57,4 @@ type _compress_flate_Resetter struct {
 	WReset func(r io.Reader, dict []byte) error
 }
 
-func (W _compress_flate_Resetter) Reset(r io.Reader, dict []byte) error {
-	return W.WReset(r, dict)
-}
+func (W _compress_flate_Resetter) Reset(r io.Reader, dict []byte) error { return W.WReset(r, dict) }

--- a/stdlib/go1_21_compress_zlib.go
+++ b/stdlib/go1_21_compress_zlib.go
@@ -45,6 +45,4 @@ type _compress_zlib_Resetter struct {
 	WReset func(r io.Reader, dict []byte) error
 }
 
-func (W _compress_zlib_Resetter) Reset(r io.Reader, dict []byte) error {
-	return W.WReset(r, dict)
-}
+func (W _compress_zlib_Resetter) Reset(r io.Reader, dict []byte) error { return W.WReset(r, dict) }

--- a/stdlib/go1_21_container_heap.go
+++ b/stdlib/go1_21_container_heap.go
@@ -37,18 +37,8 @@ type _container_heap_Interface struct {
 	WSwap  func(i int, j int)
 }
 
-func (W _container_heap_Interface) Len() int {
-	return W.WLen()
-}
-func (W _container_heap_Interface) Less(i int, j int) bool {
-	return W.WLess(i, j)
-}
-func (W _container_heap_Interface) Pop() any {
-	return W.WPop()
-}
-func (W _container_heap_Interface) Push(x any) {
-	W.WPush(x)
-}
-func (W _container_heap_Interface) Swap(i int, j int) {
-	W.WSwap(i, j)
-}
+func (W _container_heap_Interface) Len() int               { return W.WLen() }
+func (W _container_heap_Interface) Less(i int, j int) bool { return W.WLess(i, j) }
+func (W _container_heap_Interface) Pop() any               { return W.WPop() }
+func (W _container_heap_Interface) Push(x any)             { W.WPush(x) }
+func (W _container_heap_Interface) Swap(i int, j int)      { W.WSwap(i, j) }

--- a/stdlib/go1_21_context.go
+++ b/stdlib/go1_21_context.go
@@ -48,15 +48,7 @@ type _context_Context struct {
 	WValue    func(key any) any
 }
 
-func (W _context_Context) Deadline() (deadline time.Time, ok bool) {
-	return W.WDeadline()
-}
-func (W _context_Context) Done() <-chan struct{} {
-	return W.WDone()
-}
-func (W _context_Context) Err() error {
-	return W.WErr()
-}
-func (W _context_Context) Value(key any) any {
-	return W.WValue(key)
-}
+func (W _context_Context) Deadline() (deadline time.Time, ok bool) { return W.WDeadline() }
+func (W _context_Context) Done() <-chan struct{}                   { return W.WDone() }
+func (W _context_Context) Err() error                              { return W.WErr() }
+func (W _context_Context) Value(key any) any                       { return W.WValue(key) }

--- a/stdlib/go1_21_crypto.go
+++ b/stdlib/go1_21_crypto.go
@@ -64,9 +64,7 @@ type _crypto_Decrypter struct {
 func (W _crypto_Decrypter) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) (plaintext []byte, err error) {
 	return W.WDecrypt(rand, msg, opts)
 }
-func (W _crypto_Decrypter) Public() crypto.PublicKey {
-	return W.WPublic()
-}
+func (W _crypto_Decrypter) Public() crypto.PublicKey { return W.WPublic() }
 
 // _crypto_DecrypterOpts is an interface wrapper for DecrypterOpts type
 type _crypto_DecrypterOpts struct {
@@ -90,9 +88,7 @@ type _crypto_Signer struct {
 	WSign   func(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error)
 }
 
-func (W _crypto_Signer) Public() crypto.PublicKey {
-	return W.WPublic()
-}
+func (W _crypto_Signer) Public() crypto.PublicKey { return W.WPublic() }
 func (W _crypto_Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	return W.WSign(rand, digest, opts)
 }
@@ -103,6 +99,4 @@ type _crypto_SignerOpts struct {
 	WHashFunc func() crypto.Hash
 }
 
-func (W _crypto_SignerOpts) HashFunc() crypto.Hash {
-	return W.WHashFunc()
-}
+func (W _crypto_SignerOpts) HashFunc() crypto.Hash { return W.WHashFunc() }

--- a/stdlib/go1_21_crypto_cipher.go
+++ b/stdlib/go1_21_crypto_cipher.go
@@ -48,15 +48,11 @@ type _crypto_cipher_AEAD struct {
 	WSeal      func(dst []byte, nonce []byte, plaintext []byte, additionalData []byte) []byte
 }
 
-func (W _crypto_cipher_AEAD) NonceSize() int {
-	return W.WNonceSize()
-}
+func (W _crypto_cipher_AEAD) NonceSize() int { return W.WNonceSize() }
 func (W _crypto_cipher_AEAD) Open(dst []byte, nonce []byte, ciphertext []byte, additionalData []byte) ([]byte, error) {
 	return W.WOpen(dst, nonce, ciphertext, additionalData)
 }
-func (W _crypto_cipher_AEAD) Overhead() int {
-	return W.WOverhead()
-}
+func (W _crypto_cipher_AEAD) Overhead() int { return W.WOverhead() }
 func (W _crypto_cipher_AEAD) Seal(dst []byte, nonce []byte, plaintext []byte, additionalData []byte) []byte {
 	return W.WSeal(dst, nonce, plaintext, additionalData)
 }
@@ -69,15 +65,9 @@ type _crypto_cipher_Block struct {
 	WEncrypt   func(dst []byte, src []byte)
 }
 
-func (W _crypto_cipher_Block) BlockSize() int {
-	return W.WBlockSize()
-}
-func (W _crypto_cipher_Block) Decrypt(dst []byte, src []byte) {
-	W.WDecrypt(dst, src)
-}
-func (W _crypto_cipher_Block) Encrypt(dst []byte, src []byte) {
-	W.WEncrypt(dst, src)
-}
+func (W _crypto_cipher_Block) BlockSize() int                 { return W.WBlockSize() }
+func (W _crypto_cipher_Block) Decrypt(dst []byte, src []byte) { W.WDecrypt(dst, src) }
+func (W _crypto_cipher_Block) Encrypt(dst []byte, src []byte) { W.WEncrypt(dst, src) }
 
 // _crypto_cipher_BlockMode is an interface wrapper for BlockMode type
 type _crypto_cipher_BlockMode struct {
@@ -86,12 +76,8 @@ type _crypto_cipher_BlockMode struct {
 	WCryptBlocks func(dst []byte, src []byte)
 }
 
-func (W _crypto_cipher_BlockMode) BlockSize() int {
-	return W.WBlockSize()
-}
-func (W _crypto_cipher_BlockMode) CryptBlocks(dst []byte, src []byte) {
-	W.WCryptBlocks(dst, src)
-}
+func (W _crypto_cipher_BlockMode) BlockSize() int                     { return W.WBlockSize() }
+func (W _crypto_cipher_BlockMode) CryptBlocks(dst []byte, src []byte) { W.WCryptBlocks(dst, src) }
 
 // _crypto_cipher_Stream is an interface wrapper for Stream type
 type _crypto_cipher_Stream struct {
@@ -99,6 +85,4 @@ type _crypto_cipher_Stream struct {
 	WXORKeyStream func(dst []byte, src []byte)
 }
 
-func (W _crypto_cipher_Stream) XORKeyStream(dst []byte, src []byte) {
-	W.WXORKeyStream(dst, src)
-}
+func (W _crypto_cipher_Stream) XORKeyStream(dst []byte, src []byte) { W.WXORKeyStream(dst, src) }

--- a/stdlib/go1_21_crypto_elliptic.go
+++ b/stdlib/go1_21_crypto_elliptic.go
@@ -50,12 +50,8 @@ func (W _crypto_elliptic_Curve) Add(x1 *big.Int, y1 *big.Int, x2 *big.Int, y2 *b
 func (W _crypto_elliptic_Curve) Double(x1 *big.Int, y1 *big.Int) (x *big.Int, y *big.Int) {
 	return W.WDouble(x1, y1)
 }
-func (W _crypto_elliptic_Curve) IsOnCurve(x *big.Int, y *big.Int) bool {
-	return W.WIsOnCurve(x, y)
-}
-func (W _crypto_elliptic_Curve) Params() *elliptic.CurveParams {
-	return W.WParams()
-}
+func (W _crypto_elliptic_Curve) IsOnCurve(x *big.Int, y *big.Int) bool { return W.WIsOnCurve(x, y) }
+func (W _crypto_elliptic_Curve) Params() *elliptic.CurveParams         { return W.WParams() }
 func (W _crypto_elliptic_Curve) ScalarBaseMult(k []byte) (x *big.Int, y *big.Int) {
 	return W.WScalarBaseMult(k)
 }

--- a/stdlib/go1_21_database_sql.go
+++ b/stdlib/go1_21_database_sql.go
@@ -68,12 +68,8 @@ type _database_sql_Result struct {
 	WRowsAffected func() (int64, error)
 }
 
-func (W _database_sql_Result) LastInsertId() (int64, error) {
-	return W.WLastInsertId()
-}
-func (W _database_sql_Result) RowsAffected() (int64, error) {
-	return W.WRowsAffected()
-}
+func (W _database_sql_Result) LastInsertId() (int64, error) { return W.WLastInsertId() }
+func (W _database_sql_Result) RowsAffected() (int64, error) { return W.WRowsAffected() }
 
 // _database_sql_Scanner is an interface wrapper for Scanner type
 type _database_sql_Scanner struct {
@@ -81,6 +77,4 @@ type _database_sql_Scanner struct {
 	WScan  func(src any) error
 }
 
-func (W _database_sql_Scanner) Scan(src any) error {
-	return W.WScan(src)
-}
+func (W _database_sql_Scanner) Scan(src any) error { return W.WScan(src) }

--- a/stdlib/go1_21_database_sql_driver.go
+++ b/stdlib/go1_21_database_sql_driver.go
@@ -115,12 +115,8 @@ type _database_sql_driver_Conn struct {
 	WPrepare func(query string) (driver.Stmt, error)
 }
 
-func (W _database_sql_driver_Conn) Begin() (driver.Tx, error) {
-	return W.WBegin()
-}
-func (W _database_sql_driver_Conn) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_Conn) Begin() (driver.Tx, error) { return W.WBegin() }
+func (W _database_sql_driver_Conn) Close() error              { return W.WClose() }
 func (W _database_sql_driver_Conn) Prepare(query string) (driver.Stmt, error) {
 	return W.WPrepare(query)
 }
@@ -155,9 +151,7 @@ type _database_sql_driver_Connector struct {
 func (W _database_sql_driver_Connector) Connect(a0 context.Context) (driver.Conn, error) {
 	return W.WConnect(a0)
 }
-func (W _database_sql_driver_Connector) Driver() driver.Driver {
-	return W.WDriver()
-}
+func (W _database_sql_driver_Connector) Driver() driver.Driver { return W.WDriver() }
 
 // _database_sql_driver_Driver is an interface wrapper for Driver type
 type _database_sql_driver_Driver struct {
@@ -165,9 +159,7 @@ type _database_sql_driver_Driver struct {
 	WOpen  func(name string) (driver.Conn, error)
 }
 
-func (W _database_sql_driver_Driver) Open(name string) (driver.Conn, error) {
-	return W.WOpen(name)
-}
+func (W _database_sql_driver_Driver) Open(name string) (driver.Conn, error) { return W.WOpen(name) }
 
 // _database_sql_driver_DriverContext is an interface wrapper for DriverContext type
 type _database_sql_driver_DriverContext struct {
@@ -215,9 +207,7 @@ type _database_sql_driver_Pinger struct {
 	WPing  func(ctx context.Context) error
 }
 
-func (W _database_sql_driver_Pinger) Ping(ctx context.Context) error {
-	return W.WPing(ctx)
-}
+func (W _database_sql_driver_Pinger) Ping(ctx context.Context) error { return W.WPing(ctx) }
 
 // _database_sql_driver_Queryer is an interface wrapper for Queryer type
 type _database_sql_driver_Queryer struct {
@@ -246,12 +236,8 @@ type _database_sql_driver_Result struct {
 	WRowsAffected func() (int64, error)
 }
 
-func (W _database_sql_driver_Result) LastInsertId() (int64, error) {
-	return W.WLastInsertId()
-}
-func (W _database_sql_driver_Result) RowsAffected() (int64, error) {
-	return W.WRowsAffected()
-}
+func (W _database_sql_driver_Result) LastInsertId() (int64, error) { return W.WLastInsertId() }
+func (W _database_sql_driver_Result) RowsAffected() (int64, error) { return W.WRowsAffected() }
 
 // _database_sql_driver_Rows is an interface wrapper for Rows type
 type _database_sql_driver_Rows struct {
@@ -261,15 +247,9 @@ type _database_sql_driver_Rows struct {
 	WNext    func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_Rows) Close() error {
-	return W.WClose()
-}
-func (W _database_sql_driver_Rows) Columns() []string {
-	return W.WColumns()
-}
-func (W _database_sql_driver_Rows) Next(dest []driver.Value) error {
-	return W.WNext(dest)
-}
+func (W _database_sql_driver_Rows) Close() error                   { return W.WClose() }
+func (W _database_sql_driver_Rows) Columns() []string              { return W.WColumns() }
+func (W _database_sql_driver_Rows) Next(dest []driver.Value) error { return W.WNext(dest) }
 
 // _database_sql_driver_RowsColumnTypeDatabaseTypeName is an interface wrapper for RowsColumnTypeDatabaseTypeName type
 type _database_sql_driver_RowsColumnTypeDatabaseTypeName struct {
@@ -280,15 +260,11 @@ type _database_sql_driver_RowsColumnTypeDatabaseTypeName struct {
 	WNext                       func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) Close() error { return W.WClose() }
 func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) ColumnTypeDatabaseTypeName(index int) string {
 	return W.WColumnTypeDatabaseTypeName(index)
 }
-func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) Columns() []string {
-	return W.WColumns()
-}
+func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) Columns() []string { return W.WColumns() }
 func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) Next(dest []driver.Value) error {
 	return W.WNext(dest)
 }
@@ -302,15 +278,11 @@ type _database_sql_driver_RowsColumnTypeLength struct {
 	WNext             func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_RowsColumnTypeLength) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_RowsColumnTypeLength) Close() error { return W.WClose() }
 func (W _database_sql_driver_RowsColumnTypeLength) ColumnTypeLength(index int) (length int64, ok bool) {
 	return W.WColumnTypeLength(index)
 }
-func (W _database_sql_driver_RowsColumnTypeLength) Columns() []string {
-	return W.WColumns()
-}
+func (W _database_sql_driver_RowsColumnTypeLength) Columns() []string { return W.WColumns() }
 func (W _database_sql_driver_RowsColumnTypeLength) Next(dest []driver.Value) error {
 	return W.WNext(dest)
 }
@@ -324,15 +296,11 @@ type _database_sql_driver_RowsColumnTypeNullable struct {
 	WNext               func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_RowsColumnTypeNullable) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_RowsColumnTypeNullable) Close() error { return W.WClose() }
 func (W _database_sql_driver_RowsColumnTypeNullable) ColumnTypeNullable(index int) (nullable bool, ok bool) {
 	return W.WColumnTypeNullable(index)
 }
-func (W _database_sql_driver_RowsColumnTypeNullable) Columns() []string {
-	return W.WColumns()
-}
+func (W _database_sql_driver_RowsColumnTypeNullable) Columns() []string { return W.WColumns() }
 func (W _database_sql_driver_RowsColumnTypeNullable) Next(dest []driver.Value) error {
 	return W.WNext(dest)
 }
@@ -346,15 +314,11 @@ type _database_sql_driver_RowsColumnTypePrecisionScale struct {
 	WNext                     func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_RowsColumnTypePrecisionScale) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_RowsColumnTypePrecisionScale) Close() error { return W.WClose() }
 func (W _database_sql_driver_RowsColumnTypePrecisionScale) ColumnTypePrecisionScale(index int) (precision int64, scale int64, ok bool) {
 	return W.WColumnTypePrecisionScale(index)
 }
-func (W _database_sql_driver_RowsColumnTypePrecisionScale) Columns() []string {
-	return W.WColumns()
-}
+func (W _database_sql_driver_RowsColumnTypePrecisionScale) Columns() []string { return W.WColumns() }
 func (W _database_sql_driver_RowsColumnTypePrecisionScale) Next(dest []driver.Value) error {
 	return W.WNext(dest)
 }
@@ -368,15 +332,11 @@ type _database_sql_driver_RowsColumnTypeScanType struct {
 	WNext               func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_RowsColumnTypeScanType) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_RowsColumnTypeScanType) Close() error { return W.WClose() }
 func (W _database_sql_driver_RowsColumnTypeScanType) ColumnTypeScanType(index int) reflect.Type {
 	return W.WColumnTypeScanType(index)
 }
-func (W _database_sql_driver_RowsColumnTypeScanType) Columns() []string {
-	return W.WColumns()
-}
+func (W _database_sql_driver_RowsColumnTypeScanType) Columns() []string { return W.WColumns() }
 func (W _database_sql_driver_RowsColumnTypeScanType) Next(dest []driver.Value) error {
 	return W.WNext(dest)
 }
@@ -391,21 +351,11 @@ type _database_sql_driver_RowsNextResultSet struct {
 	WNextResultSet    func() error
 }
 
-func (W _database_sql_driver_RowsNextResultSet) Close() error {
-	return W.WClose()
-}
-func (W _database_sql_driver_RowsNextResultSet) Columns() []string {
-	return W.WColumns()
-}
-func (W _database_sql_driver_RowsNextResultSet) HasNextResultSet() bool {
-	return W.WHasNextResultSet()
-}
-func (W _database_sql_driver_RowsNextResultSet) Next(dest []driver.Value) error {
-	return W.WNext(dest)
-}
-func (W _database_sql_driver_RowsNextResultSet) NextResultSet() error {
-	return W.WNextResultSet()
-}
+func (W _database_sql_driver_RowsNextResultSet) Close() error                   { return W.WClose() }
+func (W _database_sql_driver_RowsNextResultSet) Columns() []string              { return W.WColumns() }
+func (W _database_sql_driver_RowsNextResultSet) HasNextResultSet() bool         { return W.WHasNextResultSet() }
+func (W _database_sql_driver_RowsNextResultSet) Next(dest []driver.Value) error { return W.WNext(dest) }
+func (W _database_sql_driver_RowsNextResultSet) NextResultSet() error           { return W.WNextResultSet() }
 
 // _database_sql_driver_SessionResetter is an interface wrapper for SessionResetter type
 type _database_sql_driver_SessionResetter struct {
@@ -426,15 +376,11 @@ type _database_sql_driver_Stmt struct {
 	WQuery    func(args []driver.Value) (driver.Rows, error)
 }
 
-func (W _database_sql_driver_Stmt) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_Stmt) Close() error { return W.WClose() }
 func (W _database_sql_driver_Stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return W.WExec(args)
 }
-func (W _database_sql_driver_Stmt) NumInput() int {
-	return W.WNumInput()
-}
+func (W _database_sql_driver_Stmt) NumInput() int { return W.WNumInput() }
 func (W _database_sql_driver_Stmt) Query(args []driver.Value) (driver.Rows, error) {
 	return W.WQuery(args)
 }
@@ -466,12 +412,8 @@ type _database_sql_driver_Tx struct {
 	WRollback func() error
 }
 
-func (W _database_sql_driver_Tx) Commit() error {
-	return W.WCommit()
-}
-func (W _database_sql_driver_Tx) Rollback() error {
-	return W.WRollback()
-}
+func (W _database_sql_driver_Tx) Commit() error   { return W.WCommit() }
+func (W _database_sql_driver_Tx) Rollback() error { return W.WRollback() }
 
 // _database_sql_driver_Validator is an interface wrapper for Validator type
 type _database_sql_driver_Validator struct {
@@ -479,9 +421,7 @@ type _database_sql_driver_Validator struct {
 	WIsValid func() bool
 }
 
-func (W _database_sql_driver_Validator) IsValid() bool {
-	return W.WIsValid()
-}
+func (W _database_sql_driver_Validator) IsValid() bool { return W.WIsValid() }
 
 // _database_sql_driver_Value is an interface wrapper for Value type
 type _database_sql_driver_Value struct {
@@ -504,6 +444,4 @@ type _database_sql_driver_Valuer struct {
 	WValue func() (driver.Value, error)
 }
 
-func (W _database_sql_driver_Valuer) Value() (driver.Value, error) {
-	return W.WValue()
-}
+func (W _database_sql_driver_Valuer) Value() (driver.Value, error) { return W.WValue() }

--- a/stdlib/go1_21_debug_dwarf.go
+++ b/stdlib/go1_21_debug_dwarf.go
@@ -278,12 +278,8 @@ type _debug_dwarf_Type struct {
 	WString func() string
 }
 
-func (W _debug_dwarf_Type) Common() *dwarf.CommonType {
-	return W.WCommon()
-}
-func (W _debug_dwarf_Type) Size() int64 {
-	return W.WSize()
-}
+func (W _debug_dwarf_Type) Common() *dwarf.CommonType { return W.WCommon() }
+func (W _debug_dwarf_Type) Size() int64               { return W.WSize() }
 func (W _debug_dwarf_Type) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_21_debug_macho.go
+++ b/stdlib/go1_21_debug_macho.go
@@ -155,6 +155,4 @@ type _debug_macho_Load struct {
 	WRaw   func() []byte
 }
 
-func (W _debug_macho_Load) Raw() []byte {
-	return W.WRaw()
-}
+func (W _debug_macho_Load) Raw() []byte { return W.WRaw() }

--- a/stdlib/go1_21_encoding.go
+++ b/stdlib/go1_21_encoding.go
@@ -52,9 +52,7 @@ type _encoding_TextMarshaler struct {
 	WMarshalText func() (text []byte, err error)
 }
 
-func (W _encoding_TextMarshaler) MarshalText() (text []byte, err error) {
-	return W.WMarshalText()
-}
+func (W _encoding_TextMarshaler) MarshalText() (text []byte, err error) { return W.WMarshalText() }
 
 // _encoding_TextUnmarshaler is an interface wrapper for TextUnmarshaler type
 type _encoding_TextUnmarshaler struct {
@@ -62,6 +60,4 @@ type _encoding_TextUnmarshaler struct {
 	WUnmarshalText func(text []byte) error
 }
 
-func (W _encoding_TextUnmarshaler) UnmarshalText(text []byte) error {
-	return W.WUnmarshalText(text)
-}
+func (W _encoding_TextUnmarshaler) UnmarshalText(text []byte) error { return W.WUnmarshalText(text) }

--- a/stdlib/go1_21_encoding_binary.go
+++ b/stdlib/go1_21_encoding_binary.go
@@ -80,27 +80,15 @@ type _encoding_binary_ByteOrder struct {
 	WUint64    func(a0 []byte) uint64
 }
 
-func (W _encoding_binary_ByteOrder) PutUint16(a0 []byte, a1 uint16) {
-	W.WPutUint16(a0, a1)
-}
-func (W _encoding_binary_ByteOrder) PutUint32(a0 []byte, a1 uint32) {
-	W.WPutUint32(a0, a1)
-}
-func (W _encoding_binary_ByteOrder) PutUint64(a0 []byte, a1 uint64) {
-	W.WPutUint64(a0, a1)
-}
+func (W _encoding_binary_ByteOrder) PutUint16(a0 []byte, a1 uint16) { W.WPutUint16(a0, a1) }
+func (W _encoding_binary_ByteOrder) PutUint32(a0 []byte, a1 uint32) { W.WPutUint32(a0, a1) }
+func (W _encoding_binary_ByteOrder) PutUint64(a0 []byte, a1 uint64) { W.WPutUint64(a0, a1) }
 func (W _encoding_binary_ByteOrder) String() string {
 	if W.WString == nil {
 		return ""
 	}
 	return W.WString()
 }
-func (W _encoding_binary_ByteOrder) Uint16(a0 []byte) uint16 {
-	return W.WUint16(a0)
-}
-func (W _encoding_binary_ByteOrder) Uint32(a0 []byte) uint32 {
-	return W.WUint32(a0)
-}
-func (W _encoding_binary_ByteOrder) Uint64(a0 []byte) uint64 {
-	return W.WUint64(a0)
-}
+func (W _encoding_binary_ByteOrder) Uint16(a0 []byte) uint16 { return W.WUint16(a0) }
+func (W _encoding_binary_ByteOrder) Uint32(a0 []byte) uint32 { return W.WUint32(a0) }
+func (W _encoding_binary_ByteOrder) Uint64(a0 []byte) uint64 { return W.WUint64(a0) }

--- a/stdlib/go1_21_encoding_gob.go
+++ b/stdlib/go1_21_encoding_gob.go
@@ -37,9 +37,7 @@ type _encoding_gob_GobDecoder struct {
 	WGobDecode func(a0 []byte) error
 }
 
-func (W _encoding_gob_GobDecoder) GobDecode(a0 []byte) error {
-	return W.WGobDecode(a0)
-}
+func (W _encoding_gob_GobDecoder) GobDecode(a0 []byte) error { return W.WGobDecode(a0) }
 
 // _encoding_gob_GobEncoder is an interface wrapper for GobEncoder type
 type _encoding_gob_GobEncoder struct {
@@ -47,6 +45,4 @@ type _encoding_gob_GobEncoder struct {
 	WGobEncode func() ([]byte, error)
 }
 
-func (W _encoding_gob_GobEncoder) GobEncode() ([]byte, error) {
-	return W.WGobEncode()
-}
+func (W _encoding_gob_GobEncoder) GobEncode() ([]byte, error) { return W.WGobEncode() }

--- a/stdlib/go1_21_encoding_json.go
+++ b/stdlib/go1_21_encoding_json.go
@@ -54,9 +54,7 @@ type _encoding_json_Marshaler struct {
 	WMarshalJSON func() ([]byte, error)
 }
 
-func (W _encoding_json_Marshaler) MarshalJSON() ([]byte, error) {
-	return W.WMarshalJSON()
-}
+func (W _encoding_json_Marshaler) MarshalJSON() ([]byte, error) { return W.WMarshalJSON() }
 
 // _encoding_json_Token is an interface wrapper for Token type
 type _encoding_json_Token struct {
@@ -69,6 +67,4 @@ type _encoding_json_Unmarshaler struct {
 	WUnmarshalJSON func(a0 []byte) error
 }
 
-func (W _encoding_json_Unmarshaler) UnmarshalJSON(a0 []byte) error {
-	return W.WUnmarshalJSON(a0)
-}
+func (W _encoding_json_Unmarshaler) UnmarshalJSON(a0 []byte) error { return W.WUnmarshalJSON(a0) }

--- a/stdlib/go1_21_encoding_xml.go
+++ b/stdlib/go1_21_encoding_xml.go
@@ -91,9 +91,7 @@ type _encoding_xml_TokenReader struct {
 	WToken func() (xml.Token, error)
 }
 
-func (W _encoding_xml_TokenReader) Token() (xml.Token, error) {
-	return W.WToken()
-}
+func (W _encoding_xml_TokenReader) Token() (xml.Token, error) { return W.WToken() }
 
 // _encoding_xml_Unmarshaler is an interface wrapper for Unmarshaler type
 type _encoding_xml_Unmarshaler struct {

--- a/stdlib/go1_21_flag.go
+++ b/stdlib/go1_21_flag.go
@@ -74,12 +74,8 @@ type _flag_Getter struct {
 	WString func() string
 }
 
-func (W _flag_Getter) Get() any {
-	return W.WGet()
-}
-func (W _flag_Getter) Set(a0 string) error {
-	return W.WSet(a0)
-}
+func (W _flag_Getter) Get() any            { return W.WGet() }
+func (W _flag_Getter) Set(a0 string) error { return W.WSet(a0) }
 func (W _flag_Getter) String() string {
 	if W.WString == nil {
 		return ""
@@ -94,9 +90,7 @@ type _flag_Value struct {
 	WString func() string
 }
 
-func (W _flag_Value) Set(a0 string) error {
-	return W.WSet(a0)
-}
+func (W _flag_Value) Set(a0 string) error { return W.WSet(a0) }
 func (W _flag_Value) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_21_fmt.go
+++ b/stdlib/go1_21_fmt.go
@@ -61,9 +61,7 @@ type _fmt_Formatter struct {
 	WFormat func(f fmt.State, verb rune)
 }
 
-func (W _fmt_Formatter) Format(f fmt.State, verb rune) {
-	W.WFormat(f, verb)
-}
+func (W _fmt_Formatter) Format(f fmt.State, verb rune) { W.WFormat(f, verb) }
 
 // _fmt_GoStringer is an interface wrapper for GoStringer type
 type _fmt_GoStringer struct {
@@ -71,9 +69,7 @@ type _fmt_GoStringer struct {
 	WGoString func() string
 }
 
-func (W _fmt_GoStringer) GoString() string {
-	return W.WGoString()
-}
+func (W _fmt_GoStringer) GoString() string { return W.WGoString() }
 
 // _fmt_ScanState is an interface wrapper for ScanState type
 type _fmt_ScanState struct {
@@ -86,24 +82,14 @@ type _fmt_ScanState struct {
 	WWidth      func() (wid int, ok bool)
 }
 
-func (W _fmt_ScanState) Read(buf []byte) (n int, err error) {
-	return W.WRead(buf)
-}
-func (W _fmt_ScanState) ReadRune() (r rune, size int, err error) {
-	return W.WReadRune()
-}
-func (W _fmt_ScanState) SkipSpace() {
-	W.WSkipSpace()
-}
+func (W _fmt_ScanState) Read(buf []byte) (n int, err error)      { return W.WRead(buf) }
+func (W _fmt_ScanState) ReadRune() (r rune, size int, err error) { return W.WReadRune() }
+func (W _fmt_ScanState) SkipSpace()                              { W.WSkipSpace() }
 func (W _fmt_ScanState) Token(skipSpace bool, f func(rune) bool) (token []byte, err error) {
 	return W.WToken(skipSpace, f)
 }
-func (W _fmt_ScanState) UnreadRune() error {
-	return W.WUnreadRune()
-}
-func (W _fmt_ScanState) Width() (wid int, ok bool) {
-	return W.WWidth()
-}
+func (W _fmt_ScanState) UnreadRune() error         { return W.WUnreadRune() }
+func (W _fmt_ScanState) Width() (wid int, ok bool) { return W.WWidth() }
 
 // _fmt_Scanner is an interface wrapper for Scanner type
 type _fmt_Scanner struct {
@@ -111,9 +97,7 @@ type _fmt_Scanner struct {
 	WScan  func(state fmt.ScanState, verb rune) error
 }
 
-func (W _fmt_Scanner) Scan(state fmt.ScanState, verb rune) error {
-	return W.WScan(state, verb)
-}
+func (W _fmt_Scanner) Scan(state fmt.ScanState, verb rune) error { return W.WScan(state, verb) }
 
 // _fmt_State is an interface wrapper for State type
 type _fmt_State struct {
@@ -124,18 +108,10 @@ type _fmt_State struct {
 	WWrite     func(b []byte) (n int, err error)
 }
 
-func (W _fmt_State) Flag(c int) bool {
-	return W.WFlag(c)
-}
-func (W _fmt_State) Precision() (prec int, ok bool) {
-	return W.WPrecision()
-}
-func (W _fmt_State) Width() (wid int, ok bool) {
-	return W.WWidth()
-}
-func (W _fmt_State) Write(b []byte) (n int, err error) {
-	return W.WWrite(b)
-}
+func (W _fmt_State) Flag(c int) bool                   { return W.WFlag(c) }
+func (W _fmt_State) Precision() (prec int, ok bool)    { return W.WPrecision() }
+func (W _fmt_State) Width() (wid int, ok bool)         { return W.WWidth() }
+func (W _fmt_State) Write(b []byte) (n int, err error) { return W.WWrite(b) }
 
 // _fmt_Stringer is an interface wrapper for Stringer type
 type _fmt_Stringer struct {

--- a/stdlib/go1_21_go_ast.go
+++ b/stdlib/go1_21_go_ast.go
@@ -136,12 +136,8 @@ type _go_ast_Decl struct {
 	WPos   func() token.Pos
 }
 
-func (W _go_ast_Decl) End() token.Pos {
-	return W.WEnd()
-}
-func (W _go_ast_Decl) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_ast_Decl) End() token.Pos { return W.WEnd() }
+func (W _go_ast_Decl) Pos() token.Pos { return W.WPos() }
 
 // _go_ast_Expr is an interface wrapper for Expr type
 type _go_ast_Expr struct {
@@ -150,12 +146,8 @@ type _go_ast_Expr struct {
 	WPos   func() token.Pos
 }
 
-func (W _go_ast_Expr) End() token.Pos {
-	return W.WEnd()
-}
-func (W _go_ast_Expr) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_ast_Expr) End() token.Pos { return W.WEnd() }
+func (W _go_ast_Expr) Pos() token.Pos { return W.WPos() }
 
 // _go_ast_Node is an interface wrapper for Node type
 type _go_ast_Node struct {
@@ -164,12 +156,8 @@ type _go_ast_Node struct {
 	WPos   func() token.Pos
 }
 
-func (W _go_ast_Node) End() token.Pos {
-	return W.WEnd()
-}
-func (W _go_ast_Node) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_ast_Node) End() token.Pos { return W.WEnd() }
+func (W _go_ast_Node) Pos() token.Pos { return W.WPos() }
 
 // _go_ast_Spec is an interface wrapper for Spec type
 type _go_ast_Spec struct {
@@ -178,12 +166,8 @@ type _go_ast_Spec struct {
 	WPos   func() token.Pos
 }
 
-func (W _go_ast_Spec) End() token.Pos {
-	return W.WEnd()
-}
-func (W _go_ast_Spec) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_ast_Spec) End() token.Pos { return W.WEnd() }
+func (W _go_ast_Spec) Pos() token.Pos { return W.WPos() }
 
 // _go_ast_Stmt is an interface wrapper for Stmt type
 type _go_ast_Stmt struct {
@@ -192,12 +176,8 @@ type _go_ast_Stmt struct {
 	WPos   func() token.Pos
 }
 
-func (W _go_ast_Stmt) End() token.Pos {
-	return W.WEnd()
-}
-func (W _go_ast_Stmt) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_ast_Stmt) End() token.Pos { return W.WEnd() }
+func (W _go_ast_Stmt) Pos() token.Pos { return W.WPos() }
 
 // _go_ast_Visitor is an interface wrapper for Visitor type
 type _go_ast_Visitor struct {
@@ -205,6 +185,4 @@ type _go_ast_Visitor struct {
 	WVisit func(node ast.Node) (w ast.Visitor)
 }
 
-func (W _go_ast_Visitor) Visit(node ast.Node) (w ast.Visitor) {
-	return W.WVisit(node)
-}
+func (W _go_ast_Visitor) Visit(node ast.Node) (w ast.Visitor) { return W.WVisit(node) }

--- a/stdlib/go1_21_go_build_constraint.go
+++ b/stdlib/go1_21_go_build_constraint.go
@@ -39,9 +39,7 @@ type _go_build_constraint_Expr struct {
 	WString func() string
 }
 
-func (W _go_build_constraint_Expr) Eval(ok func(tag string) bool) bool {
-	return W.WEval(ok)
-}
+func (W _go_build_constraint_Expr) Eval(ok func(tag string) bool) bool { return W.WEval(ok) }
 func (W _go_build_constraint_Expr) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_21_go_constant.go
+++ b/stdlib/go1_21_go_constant.go
@@ -68,12 +68,8 @@ type _go_constant_Value struct {
 	WString      func() string
 }
 
-func (W _go_constant_Value) ExactString() string {
-	return W.WExactString()
-}
-func (W _go_constant_Value) Kind() constant.Kind {
-	return W.WKind()
-}
+func (W _go_constant_Value) ExactString() string { return W.WExactString() }
+func (W _go_constant_Value) Kind() constant.Kind { return W.WKind() }
 func (W _go_constant_Value) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_21_go_types.go
+++ b/stdlib/go1_21_go_types.go
@@ -182,9 +182,7 @@ type _go_types_Importer struct {
 	WImport func(path string) (*types.Package, error)
 }
 
-func (W _go_types_Importer) Import(path string) (*types.Package, error) {
-	return W.WImport(path)
-}
+func (W _go_types_Importer) Import(path string) (*types.Package, error) { return W.WImport(path) }
 
 // _go_types_ImporterFrom is an interface wrapper for ImporterFrom type
 type _go_types_ImporterFrom struct {
@@ -193,9 +191,7 @@ type _go_types_ImporterFrom struct {
 	WImportFrom func(path string, dir string, mode types.ImportMode) (*types.Package, error)
 }
 
-func (W _go_types_ImporterFrom) Import(path string) (*types.Package, error) {
-	return W.WImport(path)
-}
+func (W _go_types_ImporterFrom) Import(path string) (*types.Package, error) { return W.WImport(path) }
 func (W _go_types_ImporterFrom) ImportFrom(path string, dir string, mode types.ImportMode) (*types.Package, error) {
 	return W.WImportFrom(path, dir, mode)
 }
@@ -213,33 +209,19 @@ type _go_types_Object struct {
 	WType     func() types.Type
 }
 
-func (W _go_types_Object) Exported() bool {
-	return W.WExported()
-}
-func (W _go_types_Object) Id() string {
-	return W.WId()
-}
-func (W _go_types_Object) Name() string {
-	return W.WName()
-}
-func (W _go_types_Object) Parent() *types.Scope {
-	return W.WParent()
-}
-func (W _go_types_Object) Pkg() *types.Package {
-	return W.WPkg()
-}
-func (W _go_types_Object) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_types_Object) Exported() bool       { return W.WExported() }
+func (W _go_types_Object) Id() string           { return W.WId() }
+func (W _go_types_Object) Name() string         { return W.WName() }
+func (W _go_types_Object) Parent() *types.Scope { return W.WParent() }
+func (W _go_types_Object) Pkg() *types.Package  { return W.WPkg() }
+func (W _go_types_Object) Pos() token.Pos       { return W.WPos() }
 func (W _go_types_Object) String() string {
 	if W.WString == nil {
 		return ""
 	}
 	return W.WString()
 }
-func (W _go_types_Object) Type() types.Type {
-	return W.WType()
-}
+func (W _go_types_Object) Type() types.Type { return W.WType() }
 
 // _go_types_Sizes is an interface wrapper for Sizes type
 type _go_types_Sizes struct {
@@ -249,15 +231,9 @@ type _go_types_Sizes struct {
 	WSizeof    func(T types.Type) int64
 }
 
-func (W _go_types_Sizes) Alignof(T types.Type) int64 {
-	return W.WAlignof(T)
-}
-func (W _go_types_Sizes) Offsetsof(fields []*types.Var) []int64 {
-	return W.WOffsetsof(fields)
-}
-func (W _go_types_Sizes) Sizeof(T types.Type) int64 {
-	return W.WSizeof(T)
-}
+func (W _go_types_Sizes) Alignof(T types.Type) int64            { return W.WAlignof(T) }
+func (W _go_types_Sizes) Offsetsof(fields []*types.Var) []int64 { return W.WOffsetsof(fields) }
+func (W _go_types_Sizes) Sizeof(T types.Type) int64             { return W.WSizeof(T) }
 
 // _go_types_Type is an interface wrapper for Type type
 type _go_types_Type struct {
@@ -272,6 +248,4 @@ func (W _go_types_Type) String() string {
 	}
 	return W.WString()
 }
-func (W _go_types_Type) Underlying() types.Type {
-	return W.WUnderlying()
-}
+func (W _go_types_Type) Underlying() types.Type { return W.WUnderlying() }

--- a/stdlib/go1_21_hash.go
+++ b/stdlib/go1_21_hash.go
@@ -34,21 +34,11 @@ type _hash_Hash struct {
 	WWrite     func(p []byte) (n int, err error)
 }
 
-func (W _hash_Hash) BlockSize() int {
-	return W.WBlockSize()
-}
-func (W _hash_Hash) Reset() {
-	W.WReset()
-}
-func (W _hash_Hash) Size() int {
-	return W.WSize()
-}
-func (W _hash_Hash) Sum(b []byte) []byte {
-	return W.WSum(b)
-}
-func (W _hash_Hash) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _hash_Hash) BlockSize() int                    { return W.WBlockSize() }
+func (W _hash_Hash) Reset()                            { W.WReset() }
+func (W _hash_Hash) Size() int                         { return W.WSize() }
+func (W _hash_Hash) Sum(b []byte) []byte               { return W.WSum(b) }
+func (W _hash_Hash) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _hash_Hash32 is an interface wrapper for Hash32 type
 type _hash_Hash32 struct {
@@ -61,24 +51,12 @@ type _hash_Hash32 struct {
 	WWrite     func(p []byte) (n int, err error)
 }
 
-func (W _hash_Hash32) BlockSize() int {
-	return W.WBlockSize()
-}
-func (W _hash_Hash32) Reset() {
-	W.WReset()
-}
-func (W _hash_Hash32) Size() int {
-	return W.WSize()
-}
-func (W _hash_Hash32) Sum(b []byte) []byte {
-	return W.WSum(b)
-}
-func (W _hash_Hash32) Sum32() uint32 {
-	return W.WSum32()
-}
-func (W _hash_Hash32) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _hash_Hash32) BlockSize() int                    { return W.WBlockSize() }
+func (W _hash_Hash32) Reset()                            { W.WReset() }
+func (W _hash_Hash32) Size() int                         { return W.WSize() }
+func (W _hash_Hash32) Sum(b []byte) []byte               { return W.WSum(b) }
+func (W _hash_Hash32) Sum32() uint32                     { return W.WSum32() }
+func (W _hash_Hash32) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _hash_Hash64 is an interface wrapper for Hash64 type
 type _hash_Hash64 struct {
@@ -91,21 +69,9 @@ type _hash_Hash64 struct {
 	WWrite     func(p []byte) (n int, err error)
 }
 
-func (W _hash_Hash64) BlockSize() int {
-	return W.WBlockSize()
-}
-func (W _hash_Hash64) Reset() {
-	W.WReset()
-}
-func (W _hash_Hash64) Size() int {
-	return W.WSize()
-}
-func (W _hash_Hash64) Sum(b []byte) []byte {
-	return W.WSum(b)
-}
-func (W _hash_Hash64) Sum64() uint64 {
-	return W.WSum64()
-}
-func (W _hash_Hash64) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _hash_Hash64) BlockSize() int                    { return W.WBlockSize() }
+func (W _hash_Hash64) Reset()                            { W.WReset() }
+func (W _hash_Hash64) Size() int                         { return W.WSize() }
+func (W _hash_Hash64) Sum(b []byte) []byte               { return W.WSum(b) }
+func (W _hash_Hash64) Sum64() uint64                     { return W.WSum64() }
+func (W _hash_Hash64) Write(p []byte) (n int, err error) { return W.WWrite(p) }

--- a/stdlib/go1_21_image.go
+++ b/stdlib/go1_21_image.go
@@ -83,15 +83,9 @@ type _image_Image struct {
 	WColorModel func() color.Model
 }
 
-func (W _image_Image) At(x int, y int) color.Color {
-	return W.WAt(x, y)
-}
-func (W _image_Image) Bounds() image.Rectangle {
-	return W.WBounds()
-}
-func (W _image_Image) ColorModel() color.Model {
-	return W.WColorModel()
-}
+func (W _image_Image) At(x int, y int) color.Color { return W.WAt(x, y) }
+func (W _image_Image) Bounds() image.Rectangle     { return W.WBounds() }
+func (W _image_Image) ColorModel() color.Model     { return W.WColorModel() }
 
 // _image_PalettedImage is an interface wrapper for PalettedImage type
 type _image_PalettedImage struct {
@@ -102,18 +96,10 @@ type _image_PalettedImage struct {
 	WColorModel   func() color.Model
 }
 
-func (W _image_PalettedImage) At(x int, y int) color.Color {
-	return W.WAt(x, y)
-}
-func (W _image_PalettedImage) Bounds() image.Rectangle {
-	return W.WBounds()
-}
-func (W _image_PalettedImage) ColorIndexAt(x int, y int) uint8 {
-	return W.WColorIndexAt(x, y)
-}
-func (W _image_PalettedImage) ColorModel() color.Model {
-	return W.WColorModel()
-}
+func (W _image_PalettedImage) At(x int, y int) color.Color     { return W.WAt(x, y) }
+func (W _image_PalettedImage) Bounds() image.Rectangle         { return W.WBounds() }
+func (W _image_PalettedImage) ColorIndexAt(x int, y int) uint8 { return W.WColorIndexAt(x, y) }
+func (W _image_PalettedImage) ColorModel() color.Model         { return W.WColorModel() }
 
 // _image_RGBA64Image is an interface wrapper for RGBA64Image type
 type _image_RGBA64Image struct {
@@ -124,15 +110,7 @@ type _image_RGBA64Image struct {
 	WRGBA64At   func(x int, y int) color.RGBA64
 }
 
-func (W _image_RGBA64Image) At(x int, y int) color.Color {
-	return W.WAt(x, y)
-}
-func (W _image_RGBA64Image) Bounds() image.Rectangle {
-	return W.WBounds()
-}
-func (W _image_RGBA64Image) ColorModel() color.Model {
-	return W.WColorModel()
-}
-func (W _image_RGBA64Image) RGBA64At(x int, y int) color.RGBA64 {
-	return W.WRGBA64At(x, y)
-}
+func (W _image_RGBA64Image) At(x int, y int) color.Color        { return W.WAt(x, y) }
+func (W _image_RGBA64Image) Bounds() image.Rectangle            { return W.WBounds() }
+func (W _image_RGBA64Image) ColorModel() color.Model            { return W.WColorModel() }
+func (W _image_RGBA64Image) RGBA64At(x int, y int) color.RGBA64 { return W.WRGBA64At(x, y) }

--- a/stdlib/go1_21_image_color.go
+++ b/stdlib/go1_21_image_color.go
@@ -62,9 +62,7 @@ type _image_color_Color struct {
 	WRGBA  func() (r uint32, g uint32, b uint32, a uint32)
 }
 
-func (W _image_color_Color) RGBA() (r uint32, g uint32, b uint32, a uint32) {
-	return W.WRGBA()
-}
+func (W _image_color_Color) RGBA() (r uint32, g uint32, b uint32, a uint32) { return W.WRGBA() }
 
 // _image_color_Model is an interface wrapper for Model type
 type _image_color_Model struct {
@@ -72,6 +70,4 @@ type _image_color_Model struct {
 	WConvert func(c color.Color) color.Color
 }
 
-func (W _image_color_Model) Convert(c color.Color) color.Color {
-	return W.WConvert(c)
-}
+func (W _image_color_Model) Convert(c color.Color) color.Color { return W.WConvert(c) }

--- a/stdlib/go1_21_image_draw.go
+++ b/stdlib/go1_21_image_draw.go
@@ -55,18 +55,10 @@ type _image_draw_Image struct {
 	WSet        func(x int, y int, c color.Color)
 }
 
-func (W _image_draw_Image) At(x int, y int) color.Color {
-	return W.WAt(x, y)
-}
-func (W _image_draw_Image) Bounds() image.Rectangle {
-	return W.WBounds()
-}
-func (W _image_draw_Image) ColorModel() color.Model {
-	return W.WColorModel()
-}
-func (W _image_draw_Image) Set(x int, y int, c color.Color) {
-	W.WSet(x, y, c)
-}
+func (W _image_draw_Image) At(x int, y int) color.Color     { return W.WAt(x, y) }
+func (W _image_draw_Image) Bounds() image.Rectangle         { return W.WBounds() }
+func (W _image_draw_Image) ColorModel() color.Model         { return W.WColorModel() }
+func (W _image_draw_Image) Set(x int, y int, c color.Color) { W.WSet(x, y, c) }
 
 // _image_draw_Quantizer is an interface wrapper for Quantizer type
 type _image_draw_Quantizer struct {
@@ -89,21 +81,9 @@ type _image_draw_RGBA64Image struct {
 	WSetRGBA64  func(x int, y int, c color.RGBA64)
 }
 
-func (W _image_draw_RGBA64Image) At(x int, y int) color.Color {
-	return W.WAt(x, y)
-}
-func (W _image_draw_RGBA64Image) Bounds() image.Rectangle {
-	return W.WBounds()
-}
-func (W _image_draw_RGBA64Image) ColorModel() color.Model {
-	return W.WColorModel()
-}
-func (W _image_draw_RGBA64Image) RGBA64At(x int, y int) color.RGBA64 {
-	return W.WRGBA64At(x, y)
-}
-func (W _image_draw_RGBA64Image) Set(x int, y int, c color.Color) {
-	W.WSet(x, y, c)
-}
-func (W _image_draw_RGBA64Image) SetRGBA64(x int, y int, c color.RGBA64) {
-	W.WSetRGBA64(x, y, c)
-}
+func (W _image_draw_RGBA64Image) At(x int, y int) color.Color            { return W.WAt(x, y) }
+func (W _image_draw_RGBA64Image) Bounds() image.Rectangle                { return W.WBounds() }
+func (W _image_draw_RGBA64Image) ColorModel() color.Model                { return W.WColorModel() }
+func (W _image_draw_RGBA64Image) RGBA64At(x int, y int) color.RGBA64     { return W.WRGBA64At(x, y) }
+func (W _image_draw_RGBA64Image) Set(x int, y int, c color.Color)        { W.WSet(x, y, c) }
+func (W _image_draw_RGBA64Image) SetRGBA64(x int, y int, c color.RGBA64) { W.WSetRGBA64(x, y, c) }

--- a/stdlib/go1_21_image_jpeg.go
+++ b/stdlib/go1_21_image_jpeg.go
@@ -38,9 +38,5 @@ type _image_jpeg_Reader struct {
 	WReadByte func() (byte, error)
 }
 
-func (W _image_jpeg_Reader) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _image_jpeg_Reader) ReadByte() (byte, error) {
-	return W.WReadByte()
-}
+func (W _image_jpeg_Reader) Read(p []byte) (n int, err error) { return W.WRead(p) }
+func (W _image_jpeg_Reader) ReadByte() (byte, error)          { return W.WReadByte() }

--- a/stdlib/go1_21_image_png.go
+++ b/stdlib/go1_21_image_png.go
@@ -41,9 +41,5 @@ type _image_png_EncoderBufferPool struct {
 	WPut   func(a0 *png.EncoderBuffer)
 }
 
-func (W _image_png_EncoderBufferPool) Get() *png.EncoderBuffer {
-	return W.WGet()
-}
-func (W _image_png_EncoderBufferPool) Put(a0 *png.EncoderBuffer) {
-	W.WPut(a0)
-}
+func (W _image_png_EncoderBufferPool) Get() *png.EncoderBuffer   { return W.WGet() }
+func (W _image_png_EncoderBufferPool) Put(a0 *png.EncoderBuffer) { W.WPut(a0) }

--- a/stdlib/go1_21_io.go
+++ b/stdlib/go1_21_io.go
@@ -102,9 +102,7 @@ type _io_ByteReader struct {
 	WReadByte func() (byte, error)
 }
 
-func (W _io_ByteReader) ReadByte() (byte, error) {
-	return W.WReadByte()
-}
+func (W _io_ByteReader) ReadByte() (byte, error) { return W.WReadByte() }
 
 // _io_ByteScanner is an interface wrapper for ByteScanner type
 type _io_ByteScanner struct {
@@ -113,12 +111,8 @@ type _io_ByteScanner struct {
 	WUnreadByte func() error
 }
 
-func (W _io_ByteScanner) ReadByte() (byte, error) {
-	return W.WReadByte()
-}
-func (W _io_ByteScanner) UnreadByte() error {
-	return W.WUnreadByte()
-}
+func (W _io_ByteScanner) ReadByte() (byte, error) { return W.WReadByte() }
+func (W _io_ByteScanner) UnreadByte() error       { return W.WUnreadByte() }
 
 // _io_ByteWriter is an interface wrapper for ByteWriter type
 type _io_ByteWriter struct {
@@ -126,9 +120,7 @@ type _io_ByteWriter struct {
 	WWriteByte func(c byte) error
 }
 
-func (W _io_ByteWriter) WriteByte(c byte) error {
-	return W.WWriteByte(c)
-}
+func (W _io_ByteWriter) WriteByte(c byte) error { return W.WWriteByte(c) }
 
 // _io_Closer is an interface wrapper for Closer type
 type _io_Closer struct {
@@ -136,9 +128,7 @@ type _io_Closer struct {
 	WClose func() error
 }
 
-func (W _io_Closer) Close() error {
-	return W.WClose()
-}
+func (W _io_Closer) Close() error { return W.WClose() }
 
 // _io_ReadCloser is an interface wrapper for ReadCloser type
 type _io_ReadCloser struct {
@@ -147,12 +137,8 @@ type _io_ReadCloser struct {
 	WRead  func(p []byte) (n int, err error)
 }
 
-func (W _io_ReadCloser) Close() error {
-	return W.WClose()
-}
-func (W _io_ReadCloser) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
+func (W _io_ReadCloser) Close() error                     { return W.WClose() }
+func (W _io_ReadCloser) Read(p []byte) (n int, err error) { return W.WRead(p) }
 
 // _io_ReadSeekCloser is an interface wrapper for ReadSeekCloser type
 type _io_ReadSeekCloser struct {
@@ -162,12 +148,8 @@ type _io_ReadSeekCloser struct {
 	WSeek  func(offset int64, whence int) (int64, error)
 }
 
-func (W _io_ReadSeekCloser) Close() error {
-	return W.WClose()
-}
-func (W _io_ReadSeekCloser) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
+func (W _io_ReadSeekCloser) Close() error                     { return W.WClose() }
+func (W _io_ReadSeekCloser) Read(p []byte) (n int, err error) { return W.WRead(p) }
 func (W _io_ReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
 	return W.WSeek(offset, whence)
 }
@@ -179,12 +161,8 @@ type _io_ReadSeeker struct {
 	WSeek  func(offset int64, whence int) (int64, error)
 }
 
-func (W _io_ReadSeeker) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _io_ReadSeeker) Seek(offset int64, whence int) (int64, error) {
-	return W.WSeek(offset, whence)
-}
+func (W _io_ReadSeeker) Read(p []byte) (n int, err error)             { return W.WRead(p) }
+func (W _io_ReadSeeker) Seek(offset int64, whence int) (int64, error) { return W.WSeek(offset, whence) }
 
 // _io_ReadWriteCloser is an interface wrapper for ReadWriteCloser type
 type _io_ReadWriteCloser struct {
@@ -194,15 +172,9 @@ type _io_ReadWriteCloser struct {
 	WWrite func(p []byte) (n int, err error)
 }
 
-func (W _io_ReadWriteCloser) Close() error {
-	return W.WClose()
-}
-func (W _io_ReadWriteCloser) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _io_ReadWriteCloser) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_ReadWriteCloser) Close() error                      { return W.WClose() }
+func (W _io_ReadWriteCloser) Read(p []byte) (n int, err error)  { return W.WRead(p) }
+func (W _io_ReadWriteCloser) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_ReadWriteSeeker is an interface wrapper for ReadWriteSeeker type
 type _io_ReadWriteSeeker struct {
@@ -212,15 +184,11 @@ type _io_ReadWriteSeeker struct {
 	WWrite func(p []byte) (n int, err error)
 }
 
-func (W _io_ReadWriteSeeker) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
+func (W _io_ReadWriteSeeker) Read(p []byte) (n int, err error) { return W.WRead(p) }
 func (W _io_ReadWriteSeeker) Seek(offset int64, whence int) (int64, error) {
 	return W.WSeek(offset, whence)
 }
-func (W _io_ReadWriteSeeker) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_ReadWriteSeeker) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_ReadWriter is an interface wrapper for ReadWriter type
 type _io_ReadWriter struct {
@@ -229,12 +197,8 @@ type _io_ReadWriter struct {
 	WWrite func(p []byte) (n int, err error)
 }
 
-func (W _io_ReadWriter) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _io_ReadWriter) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_ReadWriter) Read(p []byte) (n int, err error)  { return W.WRead(p) }
+func (W _io_ReadWriter) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_Reader is an interface wrapper for Reader type
 type _io_Reader struct {
@@ -242,9 +206,7 @@ type _io_Reader struct {
 	WRead  func(p []byte) (n int, err error)
 }
 
-func (W _io_Reader) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
+func (W _io_Reader) Read(p []byte) (n int, err error) { return W.WRead(p) }
 
 // _io_ReaderAt is an interface wrapper for ReaderAt type
 type _io_ReaderAt struct {
@@ -252,9 +214,7 @@ type _io_ReaderAt struct {
 	WReadAt func(p []byte, off int64) (n int, err error)
 }
 
-func (W _io_ReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
-	return W.WReadAt(p, off)
-}
+func (W _io_ReaderAt) ReadAt(p []byte, off int64) (n int, err error) { return W.WReadAt(p, off) }
 
 // _io_ReaderFrom is an interface wrapper for ReaderFrom type
 type _io_ReaderFrom struct {
@@ -262,9 +222,7 @@ type _io_ReaderFrom struct {
 	WReadFrom func(r io.Reader) (n int64, err error)
 }
 
-func (W _io_ReaderFrom) ReadFrom(r io.Reader) (n int64, err error) {
-	return W.WReadFrom(r)
-}
+func (W _io_ReaderFrom) ReadFrom(r io.Reader) (n int64, err error) { return W.WReadFrom(r) }
 
 // _io_RuneReader is an interface wrapper for RuneReader type
 type _io_RuneReader struct {
@@ -272,9 +230,7 @@ type _io_RuneReader struct {
 	WReadRune func() (r rune, size int, err error)
 }
 
-func (W _io_RuneReader) ReadRune() (r rune, size int, err error) {
-	return W.WReadRune()
-}
+func (W _io_RuneReader) ReadRune() (r rune, size int, err error) { return W.WReadRune() }
 
 // _io_RuneScanner is an interface wrapper for RuneScanner type
 type _io_RuneScanner struct {
@@ -283,12 +239,8 @@ type _io_RuneScanner struct {
 	WUnreadRune func() error
 }
 
-func (W _io_RuneScanner) ReadRune() (r rune, size int, err error) {
-	return W.WReadRune()
-}
-func (W _io_RuneScanner) UnreadRune() error {
-	return W.WUnreadRune()
-}
+func (W _io_RuneScanner) ReadRune() (r rune, size int, err error) { return W.WReadRune() }
+func (W _io_RuneScanner) UnreadRune() error                       { return W.WUnreadRune() }
 
 // _io_Seeker is an interface wrapper for Seeker type
 type _io_Seeker struct {
@@ -296,9 +248,7 @@ type _io_Seeker struct {
 	WSeek  func(offset int64, whence int) (int64, error)
 }
 
-func (W _io_Seeker) Seek(offset int64, whence int) (int64, error) {
-	return W.WSeek(offset, whence)
-}
+func (W _io_Seeker) Seek(offset int64, whence int) (int64, error) { return W.WSeek(offset, whence) }
 
 // _io_StringWriter is an interface wrapper for StringWriter type
 type _io_StringWriter struct {
@@ -306,9 +256,7 @@ type _io_StringWriter struct {
 	WWriteString func(s string) (n int, err error)
 }
 
-func (W _io_StringWriter) WriteString(s string) (n int, err error) {
-	return W.WWriteString(s)
-}
+func (W _io_StringWriter) WriteString(s string) (n int, err error) { return W.WWriteString(s) }
 
 // _io_WriteCloser is an interface wrapper for WriteCloser type
 type _io_WriteCloser struct {
@@ -317,12 +265,8 @@ type _io_WriteCloser struct {
 	WWrite func(p []byte) (n int, err error)
 }
 
-func (W _io_WriteCloser) Close() error {
-	return W.WClose()
-}
-func (W _io_WriteCloser) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_WriteCloser) Close() error                      { return W.WClose() }
+func (W _io_WriteCloser) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_WriteSeeker is an interface wrapper for WriteSeeker type
 type _io_WriteSeeker struct {
@@ -334,9 +278,7 @@ type _io_WriteSeeker struct {
 func (W _io_WriteSeeker) Seek(offset int64, whence int) (int64, error) {
 	return W.WSeek(offset, whence)
 }
-func (W _io_WriteSeeker) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_WriteSeeker) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_Writer is an interface wrapper for Writer type
 type _io_Writer struct {
@@ -344,9 +286,7 @@ type _io_Writer struct {
 	WWrite func(p []byte) (n int, err error)
 }
 
-func (W _io_Writer) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_Writer) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_WriterAt is an interface wrapper for WriterAt type
 type _io_WriterAt struct {
@@ -354,9 +294,7 @@ type _io_WriterAt struct {
 	WWriteAt func(p []byte, off int64) (n int, err error)
 }
 
-func (W _io_WriterAt) WriteAt(p []byte, off int64) (n int, err error) {
-	return W.WWriteAt(p, off)
-}
+func (W _io_WriterAt) WriteAt(p []byte, off int64) (n int, err error) { return W.WWriteAt(p, off) }
 
 // _io_WriterTo is an interface wrapper for WriterTo type
 type _io_WriterTo struct {
@@ -364,6 +302,4 @@ type _io_WriterTo struct {
 	WWriteTo func(w io.Writer) (n int64, err error)
 }
 
-func (W _io_WriterTo) WriteTo(w io.Writer) (n int64, err error) {
-	return W.WWriteTo(w)
-}
+func (W _io_WriterTo) WriteTo(w io.Writer) (n int64, err error) { return W.WWriteTo(w) }

--- a/stdlib/go1_21_io_fs.go
+++ b/stdlib/go1_21_io_fs.go
@@ -85,18 +85,10 @@ type _io_fs_DirEntry struct {
 	WType  func() fs.FileMode
 }
 
-func (W _io_fs_DirEntry) Info() (fs.FileInfo, error) {
-	return W.WInfo()
-}
-func (W _io_fs_DirEntry) IsDir() bool {
-	return W.WIsDir()
-}
-func (W _io_fs_DirEntry) Name() string {
-	return W.WName()
-}
-func (W _io_fs_DirEntry) Type() fs.FileMode {
-	return W.WType()
-}
+func (W _io_fs_DirEntry) Info() (fs.FileInfo, error) { return W.WInfo() }
+func (W _io_fs_DirEntry) IsDir() bool                { return W.WIsDir() }
+func (W _io_fs_DirEntry) Name() string               { return W.WName() }
+func (W _io_fs_DirEntry) Type() fs.FileMode          { return W.WType() }
 
 // _io_fs_FS is an interface wrapper for FS type
 type _io_fs_FS struct {
@@ -104,9 +96,7 @@ type _io_fs_FS struct {
 	WOpen  func(name string) (fs.File, error)
 }
 
-func (W _io_fs_FS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
+func (W _io_fs_FS) Open(name string) (fs.File, error) { return W.WOpen(name) }
 
 // _io_fs_File is an interface wrapper for File type
 type _io_fs_File struct {
@@ -116,15 +106,9 @@ type _io_fs_File struct {
 	WStat  func() (fs.FileInfo, error)
 }
 
-func (W _io_fs_File) Close() error {
-	return W.WClose()
-}
-func (W _io_fs_File) Read(a0 []byte) (int, error) {
-	return W.WRead(a0)
-}
-func (W _io_fs_File) Stat() (fs.FileInfo, error) {
-	return W.WStat()
-}
+func (W _io_fs_File) Close() error                { return W.WClose() }
+func (W _io_fs_File) Read(a0 []byte) (int, error) { return W.WRead(a0) }
+func (W _io_fs_File) Stat() (fs.FileInfo, error)  { return W.WStat() }
 
 // _io_fs_FileInfo is an interface wrapper for FileInfo type
 type _io_fs_FileInfo struct {
@@ -137,24 +121,12 @@ type _io_fs_FileInfo struct {
 	WSys     func() any
 }
 
-func (W _io_fs_FileInfo) IsDir() bool {
-	return W.WIsDir()
-}
-func (W _io_fs_FileInfo) ModTime() time.Time {
-	return W.WModTime()
-}
-func (W _io_fs_FileInfo) Mode() fs.FileMode {
-	return W.WMode()
-}
-func (W _io_fs_FileInfo) Name() string {
-	return W.WName()
-}
-func (W _io_fs_FileInfo) Size() int64 {
-	return W.WSize()
-}
-func (W _io_fs_FileInfo) Sys() any {
-	return W.WSys()
-}
+func (W _io_fs_FileInfo) IsDir() bool        { return W.WIsDir() }
+func (W _io_fs_FileInfo) ModTime() time.Time { return W.WModTime() }
+func (W _io_fs_FileInfo) Mode() fs.FileMode  { return W.WMode() }
+func (W _io_fs_FileInfo) Name() string       { return W.WName() }
+func (W _io_fs_FileInfo) Size() int64        { return W.WSize() }
+func (W _io_fs_FileInfo) Sys() any           { return W.WSys() }
 
 // _io_fs_GlobFS is an interface wrapper for GlobFS type
 type _io_fs_GlobFS struct {
@@ -163,12 +135,8 @@ type _io_fs_GlobFS struct {
 	WOpen  func(name string) (fs.File, error)
 }
 
-func (W _io_fs_GlobFS) Glob(pattern string) ([]string, error) {
-	return W.WGlob(pattern)
-}
-func (W _io_fs_GlobFS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
+func (W _io_fs_GlobFS) Glob(pattern string) ([]string, error) { return W.WGlob(pattern) }
+func (W _io_fs_GlobFS) Open(name string) (fs.File, error)     { return W.WOpen(name) }
 
 // _io_fs_ReadDirFS is an interface wrapper for ReadDirFS type
 type _io_fs_ReadDirFS struct {
@@ -177,12 +145,8 @@ type _io_fs_ReadDirFS struct {
 	WReadDir func(name string) ([]fs.DirEntry, error)
 }
 
-func (W _io_fs_ReadDirFS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
-func (W _io_fs_ReadDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	return W.WReadDir(name)
-}
+func (W _io_fs_ReadDirFS) Open(name string) (fs.File, error)          { return W.WOpen(name) }
+func (W _io_fs_ReadDirFS) ReadDir(name string) ([]fs.DirEntry, error) { return W.WReadDir(name) }
 
 // _io_fs_ReadDirFile is an interface wrapper for ReadDirFile type
 type _io_fs_ReadDirFile struct {
@@ -193,18 +157,10 @@ type _io_fs_ReadDirFile struct {
 	WStat    func() (fs.FileInfo, error)
 }
 
-func (W _io_fs_ReadDirFile) Close() error {
-	return W.WClose()
-}
-func (W _io_fs_ReadDirFile) Read(a0 []byte) (int, error) {
-	return W.WRead(a0)
-}
-func (W _io_fs_ReadDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
-	return W.WReadDir(n)
-}
-func (W _io_fs_ReadDirFile) Stat() (fs.FileInfo, error) {
-	return W.WStat()
-}
+func (W _io_fs_ReadDirFile) Close() error                         { return W.WClose() }
+func (W _io_fs_ReadDirFile) Read(a0 []byte) (int, error)          { return W.WRead(a0) }
+func (W _io_fs_ReadDirFile) ReadDir(n int) ([]fs.DirEntry, error) { return W.WReadDir(n) }
+func (W _io_fs_ReadDirFile) Stat() (fs.FileInfo, error)           { return W.WStat() }
 
 // _io_fs_ReadFileFS is an interface wrapper for ReadFileFS type
 type _io_fs_ReadFileFS struct {
@@ -213,12 +169,8 @@ type _io_fs_ReadFileFS struct {
 	WReadFile func(name string) ([]byte, error)
 }
 
-func (W _io_fs_ReadFileFS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
-func (W _io_fs_ReadFileFS) ReadFile(name string) ([]byte, error) {
-	return W.WReadFile(name)
-}
+func (W _io_fs_ReadFileFS) Open(name string) (fs.File, error)    { return W.WOpen(name) }
+func (W _io_fs_ReadFileFS) ReadFile(name string) ([]byte, error) { return W.WReadFile(name) }
 
 // _io_fs_StatFS is an interface wrapper for StatFS type
 type _io_fs_StatFS struct {
@@ -227,12 +179,8 @@ type _io_fs_StatFS struct {
 	WStat  func(name string) (fs.FileInfo, error)
 }
 
-func (W _io_fs_StatFS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
-func (W _io_fs_StatFS) Stat(name string) (fs.FileInfo, error) {
-	return W.WStat(name)
-}
+func (W _io_fs_StatFS) Open(name string) (fs.File, error)     { return W.WOpen(name) }
+func (W _io_fs_StatFS) Stat(name string) (fs.FileInfo, error) { return W.WStat(name) }
 
 // _io_fs_SubFS is an interface wrapper for SubFS type
 type _io_fs_SubFS struct {
@@ -241,9 +189,5 @@ type _io_fs_SubFS struct {
 	WSub   func(dir string) (fs.FS, error)
 }
 
-func (W _io_fs_SubFS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
-func (W _io_fs_SubFS) Sub(dir string) (fs.FS, error) {
-	return W.WSub(dir)
-}
+func (W _io_fs_SubFS) Open(name string) (fs.File, error) { return W.WOpen(name) }
+func (W _io_fs_SubFS) Sub(dir string) (fs.FS, error)     { return W.WSub(dir) }

--- a/stdlib/go1_21_log_slog.go
+++ b/stdlib/go1_21_log_slog.go
@@ -105,18 +105,10 @@ type _log_slog_Handler struct {
 	WWithGroup func(name string) slog.Handler
 }
 
-func (W _log_slog_Handler) Enabled(a0 context.Context, a1 slog.Level) bool {
-	return W.WEnabled(a0, a1)
-}
-func (W _log_slog_Handler) Handle(a0 context.Context, a1 slog.Record) error {
-	return W.WHandle(a0, a1)
-}
-func (W _log_slog_Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return W.WWithAttrs(attrs)
-}
-func (W _log_slog_Handler) WithGroup(name string) slog.Handler {
-	return W.WWithGroup(name)
-}
+func (W _log_slog_Handler) Enabled(a0 context.Context, a1 slog.Level) bool  { return W.WEnabled(a0, a1) }
+func (W _log_slog_Handler) Handle(a0 context.Context, a1 slog.Record) error { return W.WHandle(a0, a1) }
+func (W _log_slog_Handler) WithAttrs(attrs []slog.Attr) slog.Handler        { return W.WWithAttrs(attrs) }
+func (W _log_slog_Handler) WithGroup(name string) slog.Handler              { return W.WWithGroup(name) }
 
 // _log_slog_Leveler is an interface wrapper for Leveler type
 type _log_slog_Leveler struct {
@@ -124,9 +116,7 @@ type _log_slog_Leveler struct {
 	WLevel func() slog.Level
 }
 
-func (W _log_slog_Leveler) Level() slog.Level {
-	return W.WLevel()
-}
+func (W _log_slog_Leveler) Level() slog.Level { return W.WLevel() }
 
 // _log_slog_LogValuer is an interface wrapper for LogValuer type
 type _log_slog_LogValuer struct {
@@ -134,6 +124,4 @@ type _log_slog_LogValuer struct {
 	WLogValue func() slog.Value
 }
 
-func (W _log_slog_LogValuer) LogValue() slog.Value {
-	return W.WLogValue()
-}
+func (W _log_slog_LogValuer) LogValue() slog.Value { return W.WLogValue() }

--- a/stdlib/go1_21_math_rand.go
+++ b/stdlib/go1_21_math_rand.go
@@ -52,12 +52,8 @@ type _math_rand_Source struct {
 	WSeed  func(seed int64)
 }
 
-func (W _math_rand_Source) Int63() int64 {
-	return W.WInt63()
-}
-func (W _math_rand_Source) Seed(seed int64) {
-	W.WSeed(seed)
-}
+func (W _math_rand_Source) Int63() int64    { return W.WInt63() }
+func (W _math_rand_Source) Seed(seed int64) { W.WSeed(seed) }
 
 // _math_rand_Source64 is an interface wrapper for Source64 type
 type _math_rand_Source64 struct {
@@ -67,12 +63,6 @@ type _math_rand_Source64 struct {
 	WUint64 func() uint64
 }
 
-func (W _math_rand_Source64) Int63() int64 {
-	return W.WInt63()
-}
-func (W _math_rand_Source64) Seed(seed int64) {
-	W.WSeed(seed)
-}
-func (W _math_rand_Source64) Uint64() uint64 {
-	return W.WUint64()
-}
+func (W _math_rand_Source64) Int63() int64    { return W.WInt63() }
+func (W _math_rand_Source64) Seed(seed int64) { W.WSeed(seed) }
+func (W _math_rand_Source64) Uint64() uint64  { return W.WUint64() }

--- a/stdlib/go1_21_mime_multipart.go
+++ b/stdlib/go1_21_mime_multipart.go
@@ -39,12 +39,8 @@ type _mime_multipart_File struct {
 	WSeek   func(offset int64, whence int) (int64, error)
 }
 
-func (W _mime_multipart_File) Close() error {
-	return W.WClose()
-}
-func (W _mime_multipart_File) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
+func (W _mime_multipart_File) Close() error                     { return W.WClose() }
+func (W _mime_multipart_File) Read(p []byte) (n int, err error) { return W.WRead(p) }
 func (W _mime_multipart_File) ReadAt(p []byte, off int64) (n int, err error) {
 	return W.WReadAt(p, off)
 }

--- a/stdlib/go1_21_net.go
+++ b/stdlib/go1_21_net.go
@@ -136,9 +136,7 @@ type _net_Addr struct {
 	WString  func() string
 }
 
-func (W _net_Addr) Network() string {
-	return W.WNetwork()
-}
+func (W _net_Addr) Network() string { return W.WNetwork() }
 func (W _net_Addr) String() string {
 	if W.WString == nil {
 		return ""
@@ -159,30 +157,14 @@ type _net_Conn struct {
 	WWrite            func(b []byte) (n int, err error)
 }
 
-func (W _net_Conn) Close() error {
-	return W.WClose()
-}
-func (W _net_Conn) LocalAddr() net.Addr {
-	return W.WLocalAddr()
-}
-func (W _net_Conn) Read(b []byte) (n int, err error) {
-	return W.WRead(b)
-}
-func (W _net_Conn) RemoteAddr() net.Addr {
-	return W.WRemoteAddr()
-}
-func (W _net_Conn) SetDeadline(t time.Time) error {
-	return W.WSetDeadline(t)
-}
-func (W _net_Conn) SetReadDeadline(t time.Time) error {
-	return W.WSetReadDeadline(t)
-}
-func (W _net_Conn) SetWriteDeadline(t time.Time) error {
-	return W.WSetWriteDeadline(t)
-}
-func (W _net_Conn) Write(b []byte) (n int, err error) {
-	return W.WWrite(b)
-}
+func (W _net_Conn) Close() error                       { return W.WClose() }
+func (W _net_Conn) LocalAddr() net.Addr                { return W.WLocalAddr() }
+func (W _net_Conn) Read(b []byte) (n int, err error)   { return W.WRead(b) }
+func (W _net_Conn) RemoteAddr() net.Addr               { return W.WRemoteAddr() }
+func (W _net_Conn) SetDeadline(t time.Time) error      { return W.WSetDeadline(t) }
+func (W _net_Conn) SetReadDeadline(t time.Time) error  { return W.WSetReadDeadline(t) }
+func (W _net_Conn) SetWriteDeadline(t time.Time) error { return W.WSetWriteDeadline(t) }
+func (W _net_Conn) Write(b []byte) (n int, err error)  { return W.WWrite(b) }
 
 // _net_Error is an interface wrapper for Error type
 type _net_Error struct {
@@ -192,15 +174,9 @@ type _net_Error struct {
 	WTimeout   func() bool
 }
 
-func (W _net_Error) Error() string {
-	return W.WError()
-}
-func (W _net_Error) Temporary() bool {
-	return W.WTemporary()
-}
-func (W _net_Error) Timeout() bool {
-	return W.WTimeout()
-}
+func (W _net_Error) Error() string   { return W.WError() }
+func (W _net_Error) Temporary() bool { return W.WTemporary() }
+func (W _net_Error) Timeout() bool   { return W.WTimeout() }
 
 // _net_Listener is an interface wrapper for Listener type
 type _net_Listener struct {
@@ -210,15 +186,9 @@ type _net_Listener struct {
 	WClose  func() error
 }
 
-func (W _net_Listener) Accept() (net.Conn, error) {
-	return W.WAccept()
-}
-func (W _net_Listener) Addr() net.Addr {
-	return W.WAddr()
-}
-func (W _net_Listener) Close() error {
-	return W.WClose()
-}
+func (W _net_Listener) Accept() (net.Conn, error) { return W.WAccept() }
+func (W _net_Listener) Addr() net.Addr            { return W.WAddr() }
+func (W _net_Listener) Close() error              { return W.WClose() }
 
 // _net_PacketConn is an interface wrapper for PacketConn type
 type _net_PacketConn struct {
@@ -232,24 +202,12 @@ type _net_PacketConn struct {
 	WWriteTo          func(p []byte, addr net.Addr) (n int, err error)
 }
 
-func (W _net_PacketConn) Close() error {
-	return W.WClose()
-}
-func (W _net_PacketConn) LocalAddr() net.Addr {
-	return W.WLocalAddr()
-}
-func (W _net_PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
-	return W.WReadFrom(p)
-}
-func (W _net_PacketConn) SetDeadline(t time.Time) error {
-	return W.WSetDeadline(t)
-}
-func (W _net_PacketConn) SetReadDeadline(t time.Time) error {
-	return W.WSetReadDeadline(t)
-}
-func (W _net_PacketConn) SetWriteDeadline(t time.Time) error {
-	return W.WSetWriteDeadline(t)
-}
+func (W _net_PacketConn) Close() error                                        { return W.WClose() }
+func (W _net_PacketConn) LocalAddr() net.Addr                                 { return W.WLocalAddr() }
+func (W _net_PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) { return W.WReadFrom(p) }
+func (W _net_PacketConn) SetDeadline(t time.Time) error                       { return W.WSetDeadline(t) }
+func (W _net_PacketConn) SetReadDeadline(t time.Time) error                   { return W.WSetReadDeadline(t) }
+func (W _net_PacketConn) SetWriteDeadline(t time.Time) error                  { return W.WSetWriteDeadline(t) }
 func (W _net_PacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 	return W.WWriteTo(p, addr)
 }

--- a/stdlib/go1_21_net_http.go
+++ b/stdlib/go1_21_net_http.go
@@ -219,9 +219,7 @@ type _net_http_CloseNotifier struct {
 	WCloseNotify func() <-chan bool
 }
 
-func (W _net_http_CloseNotifier) CloseNotify() <-chan bool {
-	return W.WCloseNotify()
-}
+func (W _net_http_CloseNotifier) CloseNotify() <-chan bool { return W.WCloseNotify() }
 
 // _net_http_CookieJar is an interface wrapper for CookieJar type
 type _net_http_CookieJar struct {
@@ -230,9 +228,7 @@ type _net_http_CookieJar struct {
 	WSetCookies func(u *url.URL, cookies []*http.Cookie)
 }
 
-func (W _net_http_CookieJar) Cookies(u *url.URL) []*http.Cookie {
-	return W.WCookies(u)
-}
+func (W _net_http_CookieJar) Cookies(u *url.URL) []*http.Cookie { return W.WCookies(u) }
 func (W _net_http_CookieJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
 	W.WSetCookies(u, cookies)
 }
@@ -247,21 +243,11 @@ type _net_http_File struct {
 	WStat    func() (fs.FileInfo, error)
 }
 
-func (W _net_http_File) Close() error {
-	return W.WClose()
-}
-func (W _net_http_File) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _net_http_File) Readdir(count int) ([]fs.FileInfo, error) {
-	return W.WReaddir(count)
-}
-func (W _net_http_File) Seek(offset int64, whence int) (int64, error) {
-	return W.WSeek(offset, whence)
-}
-func (W _net_http_File) Stat() (fs.FileInfo, error) {
-	return W.WStat()
-}
+func (W _net_http_File) Close() error                                 { return W.WClose() }
+func (W _net_http_File) Read(p []byte) (n int, err error)             { return W.WRead(p) }
+func (W _net_http_File) Readdir(count int) ([]fs.FileInfo, error)     { return W.WReaddir(count) }
+func (W _net_http_File) Seek(offset int64, whence int) (int64, error) { return W.WSeek(offset, whence) }
+func (W _net_http_File) Stat() (fs.FileInfo, error)                   { return W.WStat() }
 
 // _net_http_FileSystem is an interface wrapper for FileSystem type
 type _net_http_FileSystem struct {
@@ -269,9 +255,7 @@ type _net_http_FileSystem struct {
 	WOpen  func(name string) (http.File, error)
 }
 
-func (W _net_http_FileSystem) Open(name string) (http.File, error) {
-	return W.WOpen(name)
-}
+func (W _net_http_FileSystem) Open(name string) (http.File, error) { return W.WOpen(name) }
 
 // _net_http_Flusher is an interface wrapper for Flusher type
 type _net_http_Flusher struct {
@@ -279,9 +263,7 @@ type _net_http_Flusher struct {
 	WFlush func()
 }
 
-func (W _net_http_Flusher) Flush() {
-	W.WFlush()
-}
+func (W _net_http_Flusher) Flush() { W.WFlush() }
 
 // _net_http_Handler is an interface wrapper for Handler type
 type _net_http_Handler struct {
@@ -289,9 +271,7 @@ type _net_http_Handler struct {
 	WServeHTTP func(a0 http.ResponseWriter, a1 *http.Request)
 }
 
-func (W _net_http_Handler) ServeHTTP(a0 http.ResponseWriter, a1 *http.Request) {
-	W.WServeHTTP(a0, a1)
-}
+func (W _net_http_Handler) ServeHTTP(a0 http.ResponseWriter, a1 *http.Request) { W.WServeHTTP(a0, a1) }
 
 // _net_http_Hijacker is an interface wrapper for Hijacker type
 type _net_http_Hijacker struct {
@@ -299,9 +279,7 @@ type _net_http_Hijacker struct {
 	WHijack func() (net.Conn, *bufio.ReadWriter, error)
 }
 
-func (W _net_http_Hijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	return W.WHijack()
-}
+func (W _net_http_Hijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) { return W.WHijack() }
 
 // _net_http_Pusher is an interface wrapper for Pusher type
 type _net_http_Pusher struct {
@@ -321,15 +299,9 @@ type _net_http_ResponseWriter struct {
 	WWriteHeader func(statusCode int)
 }
 
-func (W _net_http_ResponseWriter) Header() http.Header {
-	return W.WHeader()
-}
-func (W _net_http_ResponseWriter) Write(a0 []byte) (int, error) {
-	return W.WWrite(a0)
-}
-func (W _net_http_ResponseWriter) WriteHeader(statusCode int) {
-	W.WWriteHeader(statusCode)
-}
+func (W _net_http_ResponseWriter) Header() http.Header          { return W.WHeader() }
+func (W _net_http_ResponseWriter) Write(a0 []byte) (int, error) { return W.WWrite(a0) }
+func (W _net_http_ResponseWriter) WriteHeader(statusCode int)   { W.WWriteHeader(statusCode) }
 
 // _net_http_RoundTripper is an interface wrapper for RoundTripper type
 type _net_http_RoundTripper struct {

--- a/stdlib/go1_21_net_http_httputil.go
+++ b/stdlib/go1_21_net_http_httputil.go
@@ -46,9 +46,5 @@ type _net_http_httputil_BufferPool struct {
 	WPut   func(a0 []byte)
 }
 
-func (W _net_http_httputil_BufferPool) Get() []byte {
-	return W.WGet()
-}
-func (W _net_http_httputil_BufferPool) Put(a0 []byte) {
-	W.WPut(a0)
-}
+func (W _net_http_httputil_BufferPool) Get() []byte   { return W.WGet() }
+func (W _net_http_httputil_BufferPool) Put(a0 []byte) { W.WPut(a0) }

--- a/stdlib/go1_21_net_rpc.go
+++ b/stdlib/go1_21_net_rpc.go
@@ -58,12 +58,8 @@ type _net_rpc_ClientCodec struct {
 	WWriteRequest       func(a0 *rpc.Request, a1 any) error
 }
 
-func (W _net_rpc_ClientCodec) Close() error {
-	return W.WClose()
-}
-func (W _net_rpc_ClientCodec) ReadResponseBody(a0 any) error {
-	return W.WReadResponseBody(a0)
-}
+func (W _net_rpc_ClientCodec) Close() error                  { return W.WClose() }
+func (W _net_rpc_ClientCodec) ReadResponseBody(a0 any) error { return W.WReadResponseBody(a0) }
 func (W _net_rpc_ClientCodec) ReadResponseHeader(a0 *rpc.Response) error {
 	return W.WReadResponseHeader(a0)
 }
@@ -80,12 +76,8 @@ type _net_rpc_ServerCodec struct {
 	WWriteResponse     func(a0 *rpc.Response, a1 any) error
 }
 
-func (W _net_rpc_ServerCodec) Close() error {
-	return W.WClose()
-}
-func (W _net_rpc_ServerCodec) ReadRequestBody(a0 any) error {
-	return W.WReadRequestBody(a0)
-}
+func (W _net_rpc_ServerCodec) Close() error                 { return W.WClose() }
+func (W _net_rpc_ServerCodec) ReadRequestBody(a0 any) error { return W.WReadRequestBody(a0) }
 func (W _net_rpc_ServerCodec) ReadRequestHeader(a0 *rpc.Request) error {
 	return W.WReadRequestHeader(a0)
 }

--- a/stdlib/go1_21_os.go
+++ b/stdlib/go1_21_os.go
@@ -150,18 +150,10 @@ type _os_DirEntry struct {
 	WType  func() fs.FileMode
 }
 
-func (W _os_DirEntry) Info() (fs.FileInfo, error) {
-	return W.WInfo()
-}
-func (W _os_DirEntry) IsDir() bool {
-	return W.WIsDir()
-}
-func (W _os_DirEntry) Name() string {
-	return W.WName()
-}
-func (W _os_DirEntry) Type() fs.FileMode {
-	return W.WType()
-}
+func (W _os_DirEntry) Info() (fs.FileInfo, error) { return W.WInfo() }
+func (W _os_DirEntry) IsDir() bool                { return W.WIsDir() }
+func (W _os_DirEntry) Name() string               { return W.WName() }
+func (W _os_DirEntry) Type() fs.FileMode          { return W.WType() }
 
 // _os_FileInfo is an interface wrapper for FileInfo type
 type _os_FileInfo struct {
@@ -174,24 +166,12 @@ type _os_FileInfo struct {
 	WSys     func() any
 }
 
-func (W _os_FileInfo) IsDir() bool {
-	return W.WIsDir()
-}
-func (W _os_FileInfo) ModTime() time.Time {
-	return W.WModTime()
-}
-func (W _os_FileInfo) Mode() fs.FileMode {
-	return W.WMode()
-}
-func (W _os_FileInfo) Name() string {
-	return W.WName()
-}
-func (W _os_FileInfo) Size() int64 {
-	return W.WSize()
-}
-func (W _os_FileInfo) Sys() any {
-	return W.WSys()
-}
+func (W _os_FileInfo) IsDir() bool        { return W.WIsDir() }
+func (W _os_FileInfo) ModTime() time.Time { return W.WModTime() }
+func (W _os_FileInfo) Mode() fs.FileMode  { return W.WMode() }
+func (W _os_FileInfo) Name() string       { return W.WName() }
+func (W _os_FileInfo) Size() int64        { return W.WSize() }
+func (W _os_FileInfo) Sys() any           { return W.WSys() }
 
 // _os_Signal is an interface wrapper for Signal type
 type _os_Signal struct {
@@ -200,9 +180,7 @@ type _os_Signal struct {
 	WString func() string
 }
 
-func (W _os_Signal) Signal() {
-	W.WSignal()
-}
+func (W _os_Signal) Signal() { W.WSignal() }
 func (W _os_Signal) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_21_reflect.go
+++ b/stdlib/go1_21_reflect.go
@@ -127,90 +127,38 @@ type _reflect_Type struct {
 	WString          func() string
 }
 
-func (W _reflect_Type) Align() int {
-	return W.WAlign()
-}
-func (W _reflect_Type) AssignableTo(u reflect.Type) bool {
-	return W.WAssignableTo(u)
-}
-func (W _reflect_Type) Bits() int {
-	return W.WBits()
-}
-func (W _reflect_Type) ChanDir() reflect.ChanDir {
-	return W.WChanDir()
-}
-func (W _reflect_Type) Comparable() bool {
-	return W.WComparable()
-}
-func (W _reflect_Type) ConvertibleTo(u reflect.Type) bool {
-	return W.WConvertibleTo(u)
-}
-func (W _reflect_Type) Elem() reflect.Type {
-	return W.WElem()
-}
-func (W _reflect_Type) Field(i int) reflect.StructField {
-	return W.WField(i)
-}
-func (W _reflect_Type) FieldAlign() int {
-	return W.WFieldAlign()
-}
-func (W _reflect_Type) FieldByIndex(index []int) reflect.StructField {
-	return W.WFieldByIndex(index)
-}
+func (W _reflect_Type) Align() int                                   { return W.WAlign() }
+func (W _reflect_Type) AssignableTo(u reflect.Type) bool             { return W.WAssignableTo(u) }
+func (W _reflect_Type) Bits() int                                    { return W.WBits() }
+func (W _reflect_Type) ChanDir() reflect.ChanDir                     { return W.WChanDir() }
+func (W _reflect_Type) Comparable() bool                             { return W.WComparable() }
+func (W _reflect_Type) ConvertibleTo(u reflect.Type) bool            { return W.WConvertibleTo(u) }
+func (W _reflect_Type) Elem() reflect.Type                           { return W.WElem() }
+func (W _reflect_Type) Field(i int) reflect.StructField              { return W.WField(i) }
+func (W _reflect_Type) FieldAlign() int                              { return W.WFieldAlign() }
+func (W _reflect_Type) FieldByIndex(index []int) reflect.StructField { return W.WFieldByIndex(index) }
 func (W _reflect_Type) FieldByName(name string) (reflect.StructField, bool) {
 	return W.WFieldByName(name)
 }
 func (W _reflect_Type) FieldByNameFunc(match func(string) bool) (reflect.StructField, bool) {
 	return W.WFieldByNameFunc(match)
 }
-func (W _reflect_Type) Implements(u reflect.Type) bool {
-	return W.WImplements(u)
-}
-func (W _reflect_Type) In(i int) reflect.Type {
-	return W.WIn(i)
-}
-func (W _reflect_Type) IsVariadic() bool {
-	return W.WIsVariadic()
-}
-func (W _reflect_Type) Key() reflect.Type {
-	return W.WKey()
-}
-func (W _reflect_Type) Kind() reflect.Kind {
-	return W.WKind()
-}
-func (W _reflect_Type) Len() int {
-	return W.WLen()
-}
-func (W _reflect_Type) Method(a0 int) reflect.Method {
-	return W.WMethod(a0)
-}
-func (W _reflect_Type) MethodByName(a0 string) (reflect.Method, bool) {
-	return W.WMethodByName(a0)
-}
-func (W _reflect_Type) Name() string {
-	return W.WName()
-}
-func (W _reflect_Type) NumField() int {
-	return W.WNumField()
-}
-func (W _reflect_Type) NumIn() int {
-	return W.WNumIn()
-}
-func (W _reflect_Type) NumMethod() int {
-	return W.WNumMethod()
-}
-func (W _reflect_Type) NumOut() int {
-	return W.WNumOut()
-}
-func (W _reflect_Type) Out(i int) reflect.Type {
-	return W.WOut(i)
-}
-func (W _reflect_Type) PkgPath() string {
-	return W.WPkgPath()
-}
-func (W _reflect_Type) Size() uintptr {
-	return W.WSize()
-}
+func (W _reflect_Type) Implements(u reflect.Type) bool                { return W.WImplements(u) }
+func (W _reflect_Type) In(i int) reflect.Type                         { return W.WIn(i) }
+func (W _reflect_Type) IsVariadic() bool                              { return W.WIsVariadic() }
+func (W _reflect_Type) Key() reflect.Type                             { return W.WKey() }
+func (W _reflect_Type) Kind() reflect.Kind                            { return W.WKind() }
+func (W _reflect_Type) Len() int                                      { return W.WLen() }
+func (W _reflect_Type) Method(a0 int) reflect.Method                  { return W.WMethod(a0) }
+func (W _reflect_Type) MethodByName(a0 string) (reflect.Method, bool) { return W.WMethodByName(a0) }
+func (W _reflect_Type) Name() string                                  { return W.WName() }
+func (W _reflect_Type) NumField() int                                 { return W.WNumField() }
+func (W _reflect_Type) NumIn() int                                    { return W.WNumIn() }
+func (W _reflect_Type) NumMethod() int                                { return W.WNumMethod() }
+func (W _reflect_Type) NumOut() int                                   { return W.WNumOut() }
+func (W _reflect_Type) Out(i int) reflect.Type                        { return W.WOut(i) }
+func (W _reflect_Type) PkgPath() string                               { return W.WPkgPath() }
+func (W _reflect_Type) Size() uintptr                                 { return W.WSize() }
 func (W _reflect_Type) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_21_runtime.go
+++ b/stdlib/go1_21_runtime.go
@@ -78,9 +78,5 @@ type _runtime_Error struct {
 	WRuntimeError func()
 }
 
-func (W _runtime_Error) Error() string {
-	return W.WError()
-}
-func (W _runtime_Error) RuntimeError() {
-	W.WRuntimeError()
-}
+func (W _runtime_Error) Error() string { return W.WError() }
+func (W _runtime_Error) RuntimeError() { W.WRuntimeError() }

--- a/stdlib/go1_21_sort.go
+++ b/stdlib/go1_21_sort.go
@@ -51,12 +51,6 @@ type _sort_Interface struct {
 	WSwap  func(i int, j int)
 }
 
-func (W _sort_Interface) Len() int {
-	return W.WLen()
-}
-func (W _sort_Interface) Less(i int, j int) bool {
-	return W.WLess(i, j)
-}
-func (W _sort_Interface) Swap(i int, j int) {
-	W.WSwap(i, j)
-}
+func (W _sort_Interface) Len() int               { return W.WLen() }
+func (W _sort_Interface) Less(i int, j int) bool { return W.WLess(i, j) }
+func (W _sort_Interface) Swap(i int, j int)      { W.WSwap(i, j) }

--- a/stdlib/go1_21_sync.go
+++ b/stdlib/go1_21_sync.go
@@ -38,9 +38,5 @@ type _sync_Locker struct {
 	WUnlock func()
 }
 
-func (W _sync_Locker) Lock() {
-	W.WLock()
-}
-func (W _sync_Locker) Unlock() {
-	W.WUnlock()
-}
+func (W _sync_Locker) Lock()   { W.WLock() }
+func (W _sync_Locker) Unlock() { W.WUnlock() }

--- a/stdlib/go1_21_testing.go
+++ b/stdlib/go1_21_testing.go
@@ -71,57 +71,21 @@ type _testing_TB struct {
 	WTempDir func() string
 }
 
-func (W _testing_TB) Cleanup(a0 func()) {
-	W.WCleanup(a0)
-}
-func (W _testing_TB) Error(args ...any) {
-	W.WError(args...)
-}
-func (W _testing_TB) Errorf(format string, args ...any) {
-	W.WErrorf(format, args...)
-}
-func (W _testing_TB) Fail() {
-	W.WFail()
-}
-func (W _testing_TB) FailNow() {
-	W.WFailNow()
-}
-func (W _testing_TB) Failed() bool {
-	return W.WFailed()
-}
-func (W _testing_TB) Fatal(args ...any) {
-	W.WFatal(args...)
-}
-func (W _testing_TB) Fatalf(format string, args ...any) {
-	W.WFatalf(format, args...)
-}
-func (W _testing_TB) Helper() {
-	W.WHelper()
-}
-func (W _testing_TB) Log(args ...any) {
-	W.WLog(args...)
-}
-func (W _testing_TB) Logf(format string, args ...any) {
-	W.WLogf(format, args...)
-}
-func (W _testing_TB) Name() string {
-	return W.WName()
-}
-func (W _testing_TB) Setenv(key string, value string) {
-	W.WSetenv(key, value)
-}
-func (W _testing_TB) Skip(args ...any) {
-	W.WSkip(args...)
-}
-func (W _testing_TB) SkipNow() {
-	W.WSkipNow()
-}
-func (W _testing_TB) Skipf(format string, args ...any) {
-	W.WSkipf(format, args...)
-}
-func (W _testing_TB) Skipped() bool {
-	return W.WSkipped()
-}
-func (W _testing_TB) TempDir() string {
-	return W.WTempDir()
-}
+func (W _testing_TB) Cleanup(a0 func())                 { W.WCleanup(a0) }
+func (W _testing_TB) Error(args ...any)                 { W.WError(args...) }
+func (W _testing_TB) Errorf(format string, args ...any) { W.WErrorf(format, args...) }
+func (W _testing_TB) Fail()                             { W.WFail() }
+func (W _testing_TB) FailNow()                          { W.WFailNow() }
+func (W _testing_TB) Failed() bool                      { return W.WFailed() }
+func (W _testing_TB) Fatal(args ...any)                 { W.WFatal(args...) }
+func (W _testing_TB) Fatalf(format string, args ...any) { W.WFatalf(format, args...) }
+func (W _testing_TB) Helper()                           { W.WHelper() }
+func (W _testing_TB) Log(args ...any)                   { W.WLog(args...) }
+func (W _testing_TB) Logf(format string, args ...any)   { W.WLogf(format, args...) }
+func (W _testing_TB) Name() string                      { return W.WName() }
+func (W _testing_TB) Setenv(key string, value string)   { W.WSetenv(key, value) }
+func (W _testing_TB) Skip(args ...any)                  { W.WSkip(args...) }
+func (W _testing_TB) SkipNow()                          { W.WSkipNow() }
+func (W _testing_TB) Skipf(format string, args ...any)  { W.WSkipf(format, args...) }
+func (W _testing_TB) Skipped() bool                     { return W.WSkipped() }
+func (W _testing_TB) TempDir() string                   { return W.WTempDir() }

--- a/stdlib/go1_21_text_template_parse.go
+++ b/stdlib/go1_21_text_template_parse.go
@@ -84,18 +84,12 @@ type _text_template_parse_Node struct {
 	WType     func() parse.NodeType
 }
 
-func (W _text_template_parse_Node) Copy() parse.Node {
-	return W.WCopy()
-}
-func (W _text_template_parse_Node) Position() parse.Pos {
-	return W.WPosition()
-}
+func (W _text_template_parse_Node) Copy() parse.Node    { return W.WCopy() }
+func (W _text_template_parse_Node) Position() parse.Pos { return W.WPosition() }
 func (W _text_template_parse_Node) String() string {
 	if W.WString == nil {
 		return ""
 	}
 	return W.WString()
 }
-func (W _text_template_parse_Node) Type() parse.NodeType {
-	return W.WType()
-}
+func (W _text_template_parse_Node) Type() parse.NodeType { return W.WType() }

--- a/stdlib/go1_22_compress_flate.go
+++ b/stdlib/go1_22_compress_flate.go
@@ -48,12 +48,8 @@ type _compress_flate_Reader struct {
 	WReadByte func() (byte, error)
 }
 
-func (W _compress_flate_Reader) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _compress_flate_Reader) ReadByte() (byte, error) {
-	return W.WReadByte()
-}
+func (W _compress_flate_Reader) Read(p []byte) (n int, err error) { return W.WRead(p) }
+func (W _compress_flate_Reader) ReadByte() (byte, error)          { return W.WReadByte() }
 
 // _compress_flate_Resetter is an interface wrapper for Resetter type
 type _compress_flate_Resetter struct {
@@ -61,6 +57,4 @@ type _compress_flate_Resetter struct {
 	WReset func(r io.Reader, dict []byte) error
 }
 
-func (W _compress_flate_Resetter) Reset(r io.Reader, dict []byte) error {
-	return W.WReset(r, dict)
-}
+func (W _compress_flate_Resetter) Reset(r io.Reader, dict []byte) error { return W.WReset(r, dict) }

--- a/stdlib/go1_22_compress_zlib.go
+++ b/stdlib/go1_22_compress_zlib.go
@@ -45,6 +45,4 @@ type _compress_zlib_Resetter struct {
 	WReset func(r io.Reader, dict []byte) error
 }
 
-func (W _compress_zlib_Resetter) Reset(r io.Reader, dict []byte) error {
-	return W.WReset(r, dict)
-}
+func (W _compress_zlib_Resetter) Reset(r io.Reader, dict []byte) error { return W.WReset(r, dict) }

--- a/stdlib/go1_22_container_heap.go
+++ b/stdlib/go1_22_container_heap.go
@@ -37,18 +37,8 @@ type _container_heap_Interface struct {
 	WSwap  func(i int, j int)
 }
 
-func (W _container_heap_Interface) Len() int {
-	return W.WLen()
-}
-func (W _container_heap_Interface) Less(i int, j int) bool {
-	return W.WLess(i, j)
-}
-func (W _container_heap_Interface) Pop() any {
-	return W.WPop()
-}
-func (W _container_heap_Interface) Push(x any) {
-	W.WPush(x)
-}
-func (W _container_heap_Interface) Swap(i int, j int) {
-	W.WSwap(i, j)
-}
+func (W _container_heap_Interface) Len() int               { return W.WLen() }
+func (W _container_heap_Interface) Less(i int, j int) bool { return W.WLess(i, j) }
+func (W _container_heap_Interface) Pop() any               { return W.WPop() }
+func (W _container_heap_Interface) Push(x any)             { W.WPush(x) }
+func (W _container_heap_Interface) Swap(i int, j int)      { W.WSwap(i, j) }

--- a/stdlib/go1_22_context.go
+++ b/stdlib/go1_22_context.go
@@ -48,15 +48,7 @@ type _context_Context struct {
 	WValue    func(key any) any
 }
 
-func (W _context_Context) Deadline() (deadline time.Time, ok bool) {
-	return W.WDeadline()
-}
-func (W _context_Context) Done() <-chan struct{} {
-	return W.WDone()
-}
-func (W _context_Context) Err() error {
-	return W.WErr()
-}
-func (W _context_Context) Value(key any) any {
-	return W.WValue(key)
-}
+func (W _context_Context) Deadline() (deadline time.Time, ok bool) { return W.WDeadline() }
+func (W _context_Context) Done() <-chan struct{}                   { return W.WDone() }
+func (W _context_Context) Err() error                              { return W.WErr() }
+func (W _context_Context) Value(key any) any                       { return W.WValue(key) }

--- a/stdlib/go1_22_crypto.go
+++ b/stdlib/go1_22_crypto.go
@@ -64,9 +64,7 @@ type _crypto_Decrypter struct {
 func (W _crypto_Decrypter) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) (plaintext []byte, err error) {
 	return W.WDecrypt(rand, msg, opts)
 }
-func (W _crypto_Decrypter) Public() crypto.PublicKey {
-	return W.WPublic()
-}
+func (W _crypto_Decrypter) Public() crypto.PublicKey { return W.WPublic() }
 
 // _crypto_DecrypterOpts is an interface wrapper for DecrypterOpts type
 type _crypto_DecrypterOpts struct {
@@ -90,9 +88,7 @@ type _crypto_Signer struct {
 	WSign   func(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error)
 }
 
-func (W _crypto_Signer) Public() crypto.PublicKey {
-	return W.WPublic()
-}
+func (W _crypto_Signer) Public() crypto.PublicKey { return W.WPublic() }
 func (W _crypto_Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	return W.WSign(rand, digest, opts)
 }
@@ -103,6 +99,4 @@ type _crypto_SignerOpts struct {
 	WHashFunc func() crypto.Hash
 }
 
-func (W _crypto_SignerOpts) HashFunc() crypto.Hash {
-	return W.WHashFunc()
-}
+func (W _crypto_SignerOpts) HashFunc() crypto.Hash { return W.WHashFunc() }

--- a/stdlib/go1_22_crypto_cipher.go
+++ b/stdlib/go1_22_crypto_cipher.go
@@ -48,15 +48,11 @@ type _crypto_cipher_AEAD struct {
 	WSeal      func(dst []byte, nonce []byte, plaintext []byte, additionalData []byte) []byte
 }
 
-func (W _crypto_cipher_AEAD) NonceSize() int {
-	return W.WNonceSize()
-}
+func (W _crypto_cipher_AEAD) NonceSize() int { return W.WNonceSize() }
 func (W _crypto_cipher_AEAD) Open(dst []byte, nonce []byte, ciphertext []byte, additionalData []byte) ([]byte, error) {
 	return W.WOpen(dst, nonce, ciphertext, additionalData)
 }
-func (W _crypto_cipher_AEAD) Overhead() int {
-	return W.WOverhead()
-}
+func (W _crypto_cipher_AEAD) Overhead() int { return W.WOverhead() }
 func (W _crypto_cipher_AEAD) Seal(dst []byte, nonce []byte, plaintext []byte, additionalData []byte) []byte {
 	return W.WSeal(dst, nonce, plaintext, additionalData)
 }
@@ -69,15 +65,9 @@ type _crypto_cipher_Block struct {
 	WEncrypt   func(dst []byte, src []byte)
 }
 
-func (W _crypto_cipher_Block) BlockSize() int {
-	return W.WBlockSize()
-}
-func (W _crypto_cipher_Block) Decrypt(dst []byte, src []byte) {
-	W.WDecrypt(dst, src)
-}
-func (W _crypto_cipher_Block) Encrypt(dst []byte, src []byte) {
-	W.WEncrypt(dst, src)
-}
+func (W _crypto_cipher_Block) BlockSize() int                 { return W.WBlockSize() }
+func (W _crypto_cipher_Block) Decrypt(dst []byte, src []byte) { W.WDecrypt(dst, src) }
+func (W _crypto_cipher_Block) Encrypt(dst []byte, src []byte) { W.WEncrypt(dst, src) }
 
 // _crypto_cipher_BlockMode is an interface wrapper for BlockMode type
 type _crypto_cipher_BlockMode struct {
@@ -86,12 +76,8 @@ type _crypto_cipher_BlockMode struct {
 	WCryptBlocks func(dst []byte, src []byte)
 }
 
-func (W _crypto_cipher_BlockMode) BlockSize() int {
-	return W.WBlockSize()
-}
-func (W _crypto_cipher_BlockMode) CryptBlocks(dst []byte, src []byte) {
-	W.WCryptBlocks(dst, src)
-}
+func (W _crypto_cipher_BlockMode) BlockSize() int                     { return W.WBlockSize() }
+func (W _crypto_cipher_BlockMode) CryptBlocks(dst []byte, src []byte) { W.WCryptBlocks(dst, src) }
 
 // _crypto_cipher_Stream is an interface wrapper for Stream type
 type _crypto_cipher_Stream struct {
@@ -99,6 +85,4 @@ type _crypto_cipher_Stream struct {
 	WXORKeyStream func(dst []byte, src []byte)
 }
 
-func (W _crypto_cipher_Stream) XORKeyStream(dst []byte, src []byte) {
-	W.WXORKeyStream(dst, src)
-}
+func (W _crypto_cipher_Stream) XORKeyStream(dst []byte, src []byte) { W.WXORKeyStream(dst, src) }

--- a/stdlib/go1_22_crypto_elliptic.go
+++ b/stdlib/go1_22_crypto_elliptic.go
@@ -50,12 +50,8 @@ func (W _crypto_elliptic_Curve) Add(x1 *big.Int, y1 *big.Int, x2 *big.Int, y2 *b
 func (W _crypto_elliptic_Curve) Double(x1 *big.Int, y1 *big.Int) (x *big.Int, y *big.Int) {
 	return W.WDouble(x1, y1)
 }
-func (W _crypto_elliptic_Curve) IsOnCurve(x *big.Int, y *big.Int) bool {
-	return W.WIsOnCurve(x, y)
-}
-func (W _crypto_elliptic_Curve) Params() *elliptic.CurveParams {
-	return W.WParams()
-}
+func (W _crypto_elliptic_Curve) IsOnCurve(x *big.Int, y *big.Int) bool { return W.WIsOnCurve(x, y) }
+func (W _crypto_elliptic_Curve) Params() *elliptic.CurveParams         { return W.WParams() }
 func (W _crypto_elliptic_Curve) ScalarBaseMult(k []byte) (x *big.Int, y *big.Int) {
 	return W.WScalarBaseMult(k)
 }

--- a/stdlib/go1_22_database_sql.go
+++ b/stdlib/go1_22_database_sql.go
@@ -68,12 +68,8 @@ type _database_sql_Result struct {
 	WRowsAffected func() (int64, error)
 }
 
-func (W _database_sql_Result) LastInsertId() (int64, error) {
-	return W.WLastInsertId()
-}
-func (W _database_sql_Result) RowsAffected() (int64, error) {
-	return W.WRowsAffected()
-}
+func (W _database_sql_Result) LastInsertId() (int64, error) { return W.WLastInsertId() }
+func (W _database_sql_Result) RowsAffected() (int64, error) { return W.WRowsAffected() }
 
 // _database_sql_Scanner is an interface wrapper for Scanner type
 type _database_sql_Scanner struct {
@@ -81,6 +77,4 @@ type _database_sql_Scanner struct {
 	WScan  func(src any) error
 }
 
-func (W _database_sql_Scanner) Scan(src any) error {
-	return W.WScan(src)
-}
+func (W _database_sql_Scanner) Scan(src any) error { return W.WScan(src) }

--- a/stdlib/go1_22_database_sql_driver.go
+++ b/stdlib/go1_22_database_sql_driver.go
@@ -115,12 +115,8 @@ type _database_sql_driver_Conn struct {
 	WPrepare func(query string) (driver.Stmt, error)
 }
 
-func (W _database_sql_driver_Conn) Begin() (driver.Tx, error) {
-	return W.WBegin()
-}
-func (W _database_sql_driver_Conn) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_Conn) Begin() (driver.Tx, error) { return W.WBegin() }
+func (W _database_sql_driver_Conn) Close() error              { return W.WClose() }
 func (W _database_sql_driver_Conn) Prepare(query string) (driver.Stmt, error) {
 	return W.WPrepare(query)
 }
@@ -155,9 +151,7 @@ type _database_sql_driver_Connector struct {
 func (W _database_sql_driver_Connector) Connect(a0 context.Context) (driver.Conn, error) {
 	return W.WConnect(a0)
 }
-func (W _database_sql_driver_Connector) Driver() driver.Driver {
-	return W.WDriver()
-}
+func (W _database_sql_driver_Connector) Driver() driver.Driver { return W.WDriver() }
 
 // _database_sql_driver_Driver is an interface wrapper for Driver type
 type _database_sql_driver_Driver struct {
@@ -165,9 +159,7 @@ type _database_sql_driver_Driver struct {
 	WOpen  func(name string) (driver.Conn, error)
 }
 
-func (W _database_sql_driver_Driver) Open(name string) (driver.Conn, error) {
-	return W.WOpen(name)
-}
+func (W _database_sql_driver_Driver) Open(name string) (driver.Conn, error) { return W.WOpen(name) }
 
 // _database_sql_driver_DriverContext is an interface wrapper for DriverContext type
 type _database_sql_driver_DriverContext struct {
@@ -215,9 +207,7 @@ type _database_sql_driver_Pinger struct {
 	WPing  func(ctx context.Context) error
 }
 
-func (W _database_sql_driver_Pinger) Ping(ctx context.Context) error {
-	return W.WPing(ctx)
-}
+func (W _database_sql_driver_Pinger) Ping(ctx context.Context) error { return W.WPing(ctx) }
 
 // _database_sql_driver_Queryer is an interface wrapper for Queryer type
 type _database_sql_driver_Queryer struct {
@@ -246,12 +236,8 @@ type _database_sql_driver_Result struct {
 	WRowsAffected func() (int64, error)
 }
 
-func (W _database_sql_driver_Result) LastInsertId() (int64, error) {
-	return W.WLastInsertId()
-}
-func (W _database_sql_driver_Result) RowsAffected() (int64, error) {
-	return W.WRowsAffected()
-}
+func (W _database_sql_driver_Result) LastInsertId() (int64, error) { return W.WLastInsertId() }
+func (W _database_sql_driver_Result) RowsAffected() (int64, error) { return W.WRowsAffected() }
 
 // _database_sql_driver_Rows is an interface wrapper for Rows type
 type _database_sql_driver_Rows struct {
@@ -261,15 +247,9 @@ type _database_sql_driver_Rows struct {
 	WNext    func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_Rows) Close() error {
-	return W.WClose()
-}
-func (W _database_sql_driver_Rows) Columns() []string {
-	return W.WColumns()
-}
-func (W _database_sql_driver_Rows) Next(dest []driver.Value) error {
-	return W.WNext(dest)
-}
+func (W _database_sql_driver_Rows) Close() error                   { return W.WClose() }
+func (W _database_sql_driver_Rows) Columns() []string              { return W.WColumns() }
+func (W _database_sql_driver_Rows) Next(dest []driver.Value) error { return W.WNext(dest) }
 
 // _database_sql_driver_RowsColumnTypeDatabaseTypeName is an interface wrapper for RowsColumnTypeDatabaseTypeName type
 type _database_sql_driver_RowsColumnTypeDatabaseTypeName struct {
@@ -280,15 +260,11 @@ type _database_sql_driver_RowsColumnTypeDatabaseTypeName struct {
 	WNext                       func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) Close() error { return W.WClose() }
 func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) ColumnTypeDatabaseTypeName(index int) string {
 	return W.WColumnTypeDatabaseTypeName(index)
 }
-func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) Columns() []string {
-	return W.WColumns()
-}
+func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) Columns() []string { return W.WColumns() }
 func (W _database_sql_driver_RowsColumnTypeDatabaseTypeName) Next(dest []driver.Value) error {
 	return W.WNext(dest)
 }
@@ -302,15 +278,11 @@ type _database_sql_driver_RowsColumnTypeLength struct {
 	WNext             func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_RowsColumnTypeLength) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_RowsColumnTypeLength) Close() error { return W.WClose() }
 func (W _database_sql_driver_RowsColumnTypeLength) ColumnTypeLength(index int) (length int64, ok bool) {
 	return W.WColumnTypeLength(index)
 }
-func (W _database_sql_driver_RowsColumnTypeLength) Columns() []string {
-	return W.WColumns()
-}
+func (W _database_sql_driver_RowsColumnTypeLength) Columns() []string { return W.WColumns() }
 func (W _database_sql_driver_RowsColumnTypeLength) Next(dest []driver.Value) error {
 	return W.WNext(dest)
 }
@@ -324,15 +296,11 @@ type _database_sql_driver_RowsColumnTypeNullable struct {
 	WNext               func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_RowsColumnTypeNullable) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_RowsColumnTypeNullable) Close() error { return W.WClose() }
 func (W _database_sql_driver_RowsColumnTypeNullable) ColumnTypeNullable(index int) (nullable bool, ok bool) {
 	return W.WColumnTypeNullable(index)
 }
-func (W _database_sql_driver_RowsColumnTypeNullable) Columns() []string {
-	return W.WColumns()
-}
+func (W _database_sql_driver_RowsColumnTypeNullable) Columns() []string { return W.WColumns() }
 func (W _database_sql_driver_RowsColumnTypeNullable) Next(dest []driver.Value) error {
 	return W.WNext(dest)
 }
@@ -346,15 +314,11 @@ type _database_sql_driver_RowsColumnTypePrecisionScale struct {
 	WNext                     func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_RowsColumnTypePrecisionScale) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_RowsColumnTypePrecisionScale) Close() error { return W.WClose() }
 func (W _database_sql_driver_RowsColumnTypePrecisionScale) ColumnTypePrecisionScale(index int) (precision int64, scale int64, ok bool) {
 	return W.WColumnTypePrecisionScale(index)
 }
-func (W _database_sql_driver_RowsColumnTypePrecisionScale) Columns() []string {
-	return W.WColumns()
-}
+func (W _database_sql_driver_RowsColumnTypePrecisionScale) Columns() []string { return W.WColumns() }
 func (W _database_sql_driver_RowsColumnTypePrecisionScale) Next(dest []driver.Value) error {
 	return W.WNext(dest)
 }
@@ -368,15 +332,11 @@ type _database_sql_driver_RowsColumnTypeScanType struct {
 	WNext               func(dest []driver.Value) error
 }
 
-func (W _database_sql_driver_RowsColumnTypeScanType) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_RowsColumnTypeScanType) Close() error { return W.WClose() }
 func (W _database_sql_driver_RowsColumnTypeScanType) ColumnTypeScanType(index int) reflect.Type {
 	return W.WColumnTypeScanType(index)
 }
-func (W _database_sql_driver_RowsColumnTypeScanType) Columns() []string {
-	return W.WColumns()
-}
+func (W _database_sql_driver_RowsColumnTypeScanType) Columns() []string { return W.WColumns() }
 func (W _database_sql_driver_RowsColumnTypeScanType) Next(dest []driver.Value) error {
 	return W.WNext(dest)
 }
@@ -391,21 +351,11 @@ type _database_sql_driver_RowsNextResultSet struct {
 	WNextResultSet    func() error
 }
 
-func (W _database_sql_driver_RowsNextResultSet) Close() error {
-	return W.WClose()
-}
-func (W _database_sql_driver_RowsNextResultSet) Columns() []string {
-	return W.WColumns()
-}
-func (W _database_sql_driver_RowsNextResultSet) HasNextResultSet() bool {
-	return W.WHasNextResultSet()
-}
-func (W _database_sql_driver_RowsNextResultSet) Next(dest []driver.Value) error {
-	return W.WNext(dest)
-}
-func (W _database_sql_driver_RowsNextResultSet) NextResultSet() error {
-	return W.WNextResultSet()
-}
+func (W _database_sql_driver_RowsNextResultSet) Close() error                   { return W.WClose() }
+func (W _database_sql_driver_RowsNextResultSet) Columns() []string              { return W.WColumns() }
+func (W _database_sql_driver_RowsNextResultSet) HasNextResultSet() bool         { return W.WHasNextResultSet() }
+func (W _database_sql_driver_RowsNextResultSet) Next(dest []driver.Value) error { return W.WNext(dest) }
+func (W _database_sql_driver_RowsNextResultSet) NextResultSet() error           { return W.WNextResultSet() }
 
 // _database_sql_driver_SessionResetter is an interface wrapper for SessionResetter type
 type _database_sql_driver_SessionResetter struct {
@@ -426,15 +376,11 @@ type _database_sql_driver_Stmt struct {
 	WQuery    func(args []driver.Value) (driver.Rows, error)
 }
 
-func (W _database_sql_driver_Stmt) Close() error {
-	return W.WClose()
-}
+func (W _database_sql_driver_Stmt) Close() error { return W.WClose() }
 func (W _database_sql_driver_Stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return W.WExec(args)
 }
-func (W _database_sql_driver_Stmt) NumInput() int {
-	return W.WNumInput()
-}
+func (W _database_sql_driver_Stmt) NumInput() int { return W.WNumInput() }
 func (W _database_sql_driver_Stmt) Query(args []driver.Value) (driver.Rows, error) {
 	return W.WQuery(args)
 }
@@ -466,12 +412,8 @@ type _database_sql_driver_Tx struct {
 	WRollback func() error
 }
 
-func (W _database_sql_driver_Tx) Commit() error {
-	return W.WCommit()
-}
-func (W _database_sql_driver_Tx) Rollback() error {
-	return W.WRollback()
-}
+func (W _database_sql_driver_Tx) Commit() error   { return W.WCommit() }
+func (W _database_sql_driver_Tx) Rollback() error { return W.WRollback() }
 
 // _database_sql_driver_Validator is an interface wrapper for Validator type
 type _database_sql_driver_Validator struct {
@@ -479,9 +421,7 @@ type _database_sql_driver_Validator struct {
 	WIsValid func() bool
 }
 
-func (W _database_sql_driver_Validator) IsValid() bool {
-	return W.WIsValid()
-}
+func (W _database_sql_driver_Validator) IsValid() bool { return W.WIsValid() }
 
 // _database_sql_driver_Value is an interface wrapper for Value type
 type _database_sql_driver_Value struct {
@@ -504,6 +444,4 @@ type _database_sql_driver_Valuer struct {
 	WValue func() (driver.Value, error)
 }
 
-func (W _database_sql_driver_Valuer) Value() (driver.Value, error) {
-	return W.WValue()
-}
+func (W _database_sql_driver_Valuer) Value() (driver.Value, error) { return W.WValue() }

--- a/stdlib/go1_22_debug_dwarf.go
+++ b/stdlib/go1_22_debug_dwarf.go
@@ -278,12 +278,8 @@ type _debug_dwarf_Type struct {
 	WString func() string
 }
 
-func (W _debug_dwarf_Type) Common() *dwarf.CommonType {
-	return W.WCommon()
-}
-func (W _debug_dwarf_Type) Size() int64 {
-	return W.WSize()
-}
+func (W _debug_dwarf_Type) Common() *dwarf.CommonType { return W.WCommon() }
+func (W _debug_dwarf_Type) Size() int64               { return W.WSize() }
 func (W _debug_dwarf_Type) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_22_debug_macho.go
+++ b/stdlib/go1_22_debug_macho.go
@@ -155,6 +155,4 @@ type _debug_macho_Load struct {
 	WRaw   func() []byte
 }
 
-func (W _debug_macho_Load) Raw() []byte {
-	return W.WRaw()
-}
+func (W _debug_macho_Load) Raw() []byte { return W.WRaw() }

--- a/stdlib/go1_22_encoding.go
+++ b/stdlib/go1_22_encoding.go
@@ -52,9 +52,7 @@ type _encoding_TextMarshaler struct {
 	WMarshalText func() (text []byte, err error)
 }
 
-func (W _encoding_TextMarshaler) MarshalText() (text []byte, err error) {
-	return W.WMarshalText()
-}
+func (W _encoding_TextMarshaler) MarshalText() (text []byte, err error) { return W.WMarshalText() }
 
 // _encoding_TextUnmarshaler is an interface wrapper for TextUnmarshaler type
 type _encoding_TextUnmarshaler struct {
@@ -62,6 +60,4 @@ type _encoding_TextUnmarshaler struct {
 	WUnmarshalText func(text []byte) error
 }
 
-func (W _encoding_TextUnmarshaler) UnmarshalText(text []byte) error {
-	return W.WUnmarshalText(text)
-}
+func (W _encoding_TextUnmarshaler) UnmarshalText(text []byte) error { return W.WUnmarshalText(text) }

--- a/stdlib/go1_22_encoding_binary.go
+++ b/stdlib/go1_22_encoding_binary.go
@@ -80,27 +80,15 @@ type _encoding_binary_ByteOrder struct {
 	WUint64    func(a0 []byte) uint64
 }
 
-func (W _encoding_binary_ByteOrder) PutUint16(a0 []byte, a1 uint16) {
-	W.WPutUint16(a0, a1)
-}
-func (W _encoding_binary_ByteOrder) PutUint32(a0 []byte, a1 uint32) {
-	W.WPutUint32(a0, a1)
-}
-func (W _encoding_binary_ByteOrder) PutUint64(a0 []byte, a1 uint64) {
-	W.WPutUint64(a0, a1)
-}
+func (W _encoding_binary_ByteOrder) PutUint16(a0 []byte, a1 uint16) { W.WPutUint16(a0, a1) }
+func (W _encoding_binary_ByteOrder) PutUint32(a0 []byte, a1 uint32) { W.WPutUint32(a0, a1) }
+func (W _encoding_binary_ByteOrder) PutUint64(a0 []byte, a1 uint64) { W.WPutUint64(a0, a1) }
 func (W _encoding_binary_ByteOrder) String() string {
 	if W.WString == nil {
 		return ""
 	}
 	return W.WString()
 }
-func (W _encoding_binary_ByteOrder) Uint16(a0 []byte) uint16 {
-	return W.WUint16(a0)
-}
-func (W _encoding_binary_ByteOrder) Uint32(a0 []byte) uint32 {
-	return W.WUint32(a0)
-}
-func (W _encoding_binary_ByteOrder) Uint64(a0 []byte) uint64 {
-	return W.WUint64(a0)
-}
+func (W _encoding_binary_ByteOrder) Uint16(a0 []byte) uint16 { return W.WUint16(a0) }
+func (W _encoding_binary_ByteOrder) Uint32(a0 []byte) uint32 { return W.WUint32(a0) }
+func (W _encoding_binary_ByteOrder) Uint64(a0 []byte) uint64 { return W.WUint64(a0) }

--- a/stdlib/go1_22_encoding_gob.go
+++ b/stdlib/go1_22_encoding_gob.go
@@ -37,9 +37,7 @@ type _encoding_gob_GobDecoder struct {
 	WGobDecode func(a0 []byte) error
 }
 
-func (W _encoding_gob_GobDecoder) GobDecode(a0 []byte) error {
-	return W.WGobDecode(a0)
-}
+func (W _encoding_gob_GobDecoder) GobDecode(a0 []byte) error { return W.WGobDecode(a0) }
 
 // _encoding_gob_GobEncoder is an interface wrapper for GobEncoder type
 type _encoding_gob_GobEncoder struct {
@@ -47,6 +45,4 @@ type _encoding_gob_GobEncoder struct {
 	WGobEncode func() ([]byte, error)
 }
 
-func (W _encoding_gob_GobEncoder) GobEncode() ([]byte, error) {
-	return W.WGobEncode()
-}
+func (W _encoding_gob_GobEncoder) GobEncode() ([]byte, error) { return W.WGobEncode() }

--- a/stdlib/go1_22_encoding_json.go
+++ b/stdlib/go1_22_encoding_json.go
@@ -54,9 +54,7 @@ type _encoding_json_Marshaler struct {
 	WMarshalJSON func() ([]byte, error)
 }
 
-func (W _encoding_json_Marshaler) MarshalJSON() ([]byte, error) {
-	return W.WMarshalJSON()
-}
+func (W _encoding_json_Marshaler) MarshalJSON() ([]byte, error) { return W.WMarshalJSON() }
 
 // _encoding_json_Token is an interface wrapper for Token type
 type _encoding_json_Token struct {
@@ -69,6 +67,4 @@ type _encoding_json_Unmarshaler struct {
 	WUnmarshalJSON func(a0 []byte) error
 }
 
-func (W _encoding_json_Unmarshaler) UnmarshalJSON(a0 []byte) error {
-	return W.WUnmarshalJSON(a0)
-}
+func (W _encoding_json_Unmarshaler) UnmarshalJSON(a0 []byte) error { return W.WUnmarshalJSON(a0) }

--- a/stdlib/go1_22_encoding_xml.go
+++ b/stdlib/go1_22_encoding_xml.go
@@ -91,9 +91,7 @@ type _encoding_xml_TokenReader struct {
 	WToken func() (xml.Token, error)
 }
 
-func (W _encoding_xml_TokenReader) Token() (xml.Token, error) {
-	return W.WToken()
-}
+func (W _encoding_xml_TokenReader) Token() (xml.Token, error) { return W.WToken() }
 
 // _encoding_xml_Unmarshaler is an interface wrapper for Unmarshaler type
 type _encoding_xml_Unmarshaler struct {

--- a/stdlib/go1_22_flag.go
+++ b/stdlib/go1_22_flag.go
@@ -74,12 +74,8 @@ type _flag_Getter struct {
 	WString func() string
 }
 
-func (W _flag_Getter) Get() any {
-	return W.WGet()
-}
-func (W _flag_Getter) Set(a0 string) error {
-	return W.WSet(a0)
-}
+func (W _flag_Getter) Get() any            { return W.WGet() }
+func (W _flag_Getter) Set(a0 string) error { return W.WSet(a0) }
 func (W _flag_Getter) String() string {
 	if W.WString == nil {
 		return ""
@@ -94,9 +90,7 @@ type _flag_Value struct {
 	WString func() string
 }
 
-func (W _flag_Value) Set(a0 string) error {
-	return W.WSet(a0)
-}
+func (W _flag_Value) Set(a0 string) error { return W.WSet(a0) }
 func (W _flag_Value) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_22_fmt.go
+++ b/stdlib/go1_22_fmt.go
@@ -61,9 +61,7 @@ type _fmt_Formatter struct {
 	WFormat func(f fmt.State, verb rune)
 }
 
-func (W _fmt_Formatter) Format(f fmt.State, verb rune) {
-	W.WFormat(f, verb)
-}
+func (W _fmt_Formatter) Format(f fmt.State, verb rune) { W.WFormat(f, verb) }
 
 // _fmt_GoStringer is an interface wrapper for GoStringer type
 type _fmt_GoStringer struct {
@@ -71,9 +69,7 @@ type _fmt_GoStringer struct {
 	WGoString func() string
 }
 
-func (W _fmt_GoStringer) GoString() string {
-	return W.WGoString()
-}
+func (W _fmt_GoStringer) GoString() string { return W.WGoString() }
 
 // _fmt_ScanState is an interface wrapper for ScanState type
 type _fmt_ScanState struct {
@@ -86,24 +82,14 @@ type _fmt_ScanState struct {
 	WWidth      func() (wid int, ok bool)
 }
 
-func (W _fmt_ScanState) Read(buf []byte) (n int, err error) {
-	return W.WRead(buf)
-}
-func (W _fmt_ScanState) ReadRune() (r rune, size int, err error) {
-	return W.WReadRune()
-}
-func (W _fmt_ScanState) SkipSpace() {
-	W.WSkipSpace()
-}
+func (W _fmt_ScanState) Read(buf []byte) (n int, err error)      { return W.WRead(buf) }
+func (W _fmt_ScanState) ReadRune() (r rune, size int, err error) { return W.WReadRune() }
+func (W _fmt_ScanState) SkipSpace()                              { W.WSkipSpace() }
 func (W _fmt_ScanState) Token(skipSpace bool, f func(rune) bool) (token []byte, err error) {
 	return W.WToken(skipSpace, f)
 }
-func (W _fmt_ScanState) UnreadRune() error {
-	return W.WUnreadRune()
-}
-func (W _fmt_ScanState) Width() (wid int, ok bool) {
-	return W.WWidth()
-}
+func (W _fmt_ScanState) UnreadRune() error         { return W.WUnreadRune() }
+func (W _fmt_ScanState) Width() (wid int, ok bool) { return W.WWidth() }
 
 // _fmt_Scanner is an interface wrapper for Scanner type
 type _fmt_Scanner struct {
@@ -111,9 +97,7 @@ type _fmt_Scanner struct {
 	WScan  func(state fmt.ScanState, verb rune) error
 }
 
-func (W _fmt_Scanner) Scan(state fmt.ScanState, verb rune) error {
-	return W.WScan(state, verb)
-}
+func (W _fmt_Scanner) Scan(state fmt.ScanState, verb rune) error { return W.WScan(state, verb) }
 
 // _fmt_State is an interface wrapper for State type
 type _fmt_State struct {
@@ -124,18 +108,10 @@ type _fmt_State struct {
 	WWrite     func(b []byte) (n int, err error)
 }
 
-func (W _fmt_State) Flag(c int) bool {
-	return W.WFlag(c)
-}
-func (W _fmt_State) Precision() (prec int, ok bool) {
-	return W.WPrecision()
-}
-func (W _fmt_State) Width() (wid int, ok bool) {
-	return W.WWidth()
-}
-func (W _fmt_State) Write(b []byte) (n int, err error) {
-	return W.WWrite(b)
-}
+func (W _fmt_State) Flag(c int) bool                   { return W.WFlag(c) }
+func (W _fmt_State) Precision() (prec int, ok bool)    { return W.WPrecision() }
+func (W _fmt_State) Width() (wid int, ok bool)         { return W.WWidth() }
+func (W _fmt_State) Write(b []byte) (n int, err error) { return W.WWrite(b) }
 
 // _fmt_Stringer is an interface wrapper for Stringer type
 type _fmt_Stringer struct {

--- a/stdlib/go1_22_go_ast.go
+++ b/stdlib/go1_22_go_ast.go
@@ -137,12 +137,8 @@ type _go_ast_Decl struct {
 	WPos   func() token.Pos
 }
 
-func (W _go_ast_Decl) End() token.Pos {
-	return W.WEnd()
-}
-func (W _go_ast_Decl) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_ast_Decl) End() token.Pos { return W.WEnd() }
+func (W _go_ast_Decl) Pos() token.Pos { return W.WPos() }
 
 // _go_ast_Expr is an interface wrapper for Expr type
 type _go_ast_Expr struct {
@@ -151,12 +147,8 @@ type _go_ast_Expr struct {
 	WPos   func() token.Pos
 }
 
-func (W _go_ast_Expr) End() token.Pos {
-	return W.WEnd()
-}
-func (W _go_ast_Expr) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_ast_Expr) End() token.Pos { return W.WEnd() }
+func (W _go_ast_Expr) Pos() token.Pos { return W.WPos() }
 
 // _go_ast_Node is an interface wrapper for Node type
 type _go_ast_Node struct {
@@ -165,12 +157,8 @@ type _go_ast_Node struct {
 	WPos   func() token.Pos
 }
 
-func (W _go_ast_Node) End() token.Pos {
-	return W.WEnd()
-}
-func (W _go_ast_Node) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_ast_Node) End() token.Pos { return W.WEnd() }
+func (W _go_ast_Node) Pos() token.Pos { return W.WPos() }
 
 // _go_ast_Spec is an interface wrapper for Spec type
 type _go_ast_Spec struct {
@@ -179,12 +167,8 @@ type _go_ast_Spec struct {
 	WPos   func() token.Pos
 }
 
-func (W _go_ast_Spec) End() token.Pos {
-	return W.WEnd()
-}
-func (W _go_ast_Spec) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_ast_Spec) End() token.Pos { return W.WEnd() }
+func (W _go_ast_Spec) Pos() token.Pos { return W.WPos() }
 
 // _go_ast_Stmt is an interface wrapper for Stmt type
 type _go_ast_Stmt struct {
@@ -193,12 +177,8 @@ type _go_ast_Stmt struct {
 	WPos   func() token.Pos
 }
 
-func (W _go_ast_Stmt) End() token.Pos {
-	return W.WEnd()
-}
-func (W _go_ast_Stmt) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_ast_Stmt) End() token.Pos { return W.WEnd() }
+func (W _go_ast_Stmt) Pos() token.Pos { return W.WPos() }
 
 // _go_ast_Visitor is an interface wrapper for Visitor type
 type _go_ast_Visitor struct {
@@ -206,6 +186,4 @@ type _go_ast_Visitor struct {
 	WVisit func(node ast.Node) (w ast.Visitor)
 }
 
-func (W _go_ast_Visitor) Visit(node ast.Node) (w ast.Visitor) {
-	return W.WVisit(node)
-}
+func (W _go_ast_Visitor) Visit(node ast.Node) (w ast.Visitor) { return W.WVisit(node) }

--- a/stdlib/go1_22_go_build_constraint.go
+++ b/stdlib/go1_22_go_build_constraint.go
@@ -39,9 +39,7 @@ type _go_build_constraint_Expr struct {
 	WString func() string
 }
 
-func (W _go_build_constraint_Expr) Eval(ok func(tag string) bool) bool {
-	return W.WEval(ok)
-}
+func (W _go_build_constraint_Expr) Eval(ok func(tag string) bool) bool { return W.WEval(ok) }
 func (W _go_build_constraint_Expr) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_22_go_constant.go
+++ b/stdlib/go1_22_go_constant.go
@@ -68,12 +68,8 @@ type _go_constant_Value struct {
 	WString      func() string
 }
 
-func (W _go_constant_Value) ExactString() string {
-	return W.WExactString()
-}
-func (W _go_constant_Value) Kind() constant.Kind {
-	return W.WKind()
-}
+func (W _go_constant_Value) ExactString() string { return W.WExactString() }
+func (W _go_constant_Value) Kind() constant.Kind { return W.WKind() }
 func (W _go_constant_Value) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_22_go_types.go
+++ b/stdlib/go1_22_go_types.go
@@ -185,9 +185,7 @@ type _go_types_Importer struct {
 	WImport func(path string) (*types.Package, error)
 }
 
-func (W _go_types_Importer) Import(path string) (*types.Package, error) {
-	return W.WImport(path)
-}
+func (W _go_types_Importer) Import(path string) (*types.Package, error) { return W.WImport(path) }
 
 // _go_types_ImporterFrom is an interface wrapper for ImporterFrom type
 type _go_types_ImporterFrom struct {
@@ -196,9 +194,7 @@ type _go_types_ImporterFrom struct {
 	WImportFrom func(path string, dir string, mode types.ImportMode) (*types.Package, error)
 }
 
-func (W _go_types_ImporterFrom) Import(path string) (*types.Package, error) {
-	return W.WImport(path)
-}
+func (W _go_types_ImporterFrom) Import(path string) (*types.Package, error) { return W.WImport(path) }
 func (W _go_types_ImporterFrom) ImportFrom(path string, dir string, mode types.ImportMode) (*types.Package, error) {
 	return W.WImportFrom(path, dir, mode)
 }
@@ -216,33 +212,19 @@ type _go_types_Object struct {
 	WType     func() types.Type
 }
 
-func (W _go_types_Object) Exported() bool {
-	return W.WExported()
-}
-func (W _go_types_Object) Id() string {
-	return W.WId()
-}
-func (W _go_types_Object) Name() string {
-	return W.WName()
-}
-func (W _go_types_Object) Parent() *types.Scope {
-	return W.WParent()
-}
-func (W _go_types_Object) Pkg() *types.Package {
-	return W.WPkg()
-}
-func (W _go_types_Object) Pos() token.Pos {
-	return W.WPos()
-}
+func (W _go_types_Object) Exported() bool       { return W.WExported() }
+func (W _go_types_Object) Id() string           { return W.WId() }
+func (W _go_types_Object) Name() string         { return W.WName() }
+func (W _go_types_Object) Parent() *types.Scope { return W.WParent() }
+func (W _go_types_Object) Pkg() *types.Package  { return W.WPkg() }
+func (W _go_types_Object) Pos() token.Pos       { return W.WPos() }
 func (W _go_types_Object) String() string {
 	if W.WString == nil {
 		return ""
 	}
 	return W.WString()
 }
-func (W _go_types_Object) Type() types.Type {
-	return W.WType()
-}
+func (W _go_types_Object) Type() types.Type { return W.WType() }
 
 // _go_types_Sizes is an interface wrapper for Sizes type
 type _go_types_Sizes struct {
@@ -252,15 +234,9 @@ type _go_types_Sizes struct {
 	WSizeof    func(T types.Type) int64
 }
 
-func (W _go_types_Sizes) Alignof(T types.Type) int64 {
-	return W.WAlignof(T)
-}
-func (W _go_types_Sizes) Offsetsof(fields []*types.Var) []int64 {
-	return W.WOffsetsof(fields)
-}
-func (W _go_types_Sizes) Sizeof(T types.Type) int64 {
-	return W.WSizeof(T)
-}
+func (W _go_types_Sizes) Alignof(T types.Type) int64            { return W.WAlignof(T) }
+func (W _go_types_Sizes) Offsetsof(fields []*types.Var) []int64 { return W.WOffsetsof(fields) }
+func (W _go_types_Sizes) Sizeof(T types.Type) int64             { return W.WSizeof(T) }
 
 // _go_types_Type is an interface wrapper for Type type
 type _go_types_Type struct {
@@ -275,6 +251,4 @@ func (W _go_types_Type) String() string {
 	}
 	return W.WString()
 }
-func (W _go_types_Type) Underlying() types.Type {
-	return W.WUnderlying()
-}
+func (W _go_types_Type) Underlying() types.Type { return W.WUnderlying() }

--- a/stdlib/go1_22_hash.go
+++ b/stdlib/go1_22_hash.go
@@ -34,21 +34,11 @@ type _hash_Hash struct {
 	WWrite     func(p []byte) (n int, err error)
 }
 
-func (W _hash_Hash) BlockSize() int {
-	return W.WBlockSize()
-}
-func (W _hash_Hash) Reset() {
-	W.WReset()
-}
-func (W _hash_Hash) Size() int {
-	return W.WSize()
-}
-func (W _hash_Hash) Sum(b []byte) []byte {
-	return W.WSum(b)
-}
-func (W _hash_Hash) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _hash_Hash) BlockSize() int                    { return W.WBlockSize() }
+func (W _hash_Hash) Reset()                            { W.WReset() }
+func (W _hash_Hash) Size() int                         { return W.WSize() }
+func (W _hash_Hash) Sum(b []byte) []byte               { return W.WSum(b) }
+func (W _hash_Hash) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _hash_Hash32 is an interface wrapper for Hash32 type
 type _hash_Hash32 struct {
@@ -61,24 +51,12 @@ type _hash_Hash32 struct {
 	WWrite     func(p []byte) (n int, err error)
 }
 
-func (W _hash_Hash32) BlockSize() int {
-	return W.WBlockSize()
-}
-func (W _hash_Hash32) Reset() {
-	W.WReset()
-}
-func (W _hash_Hash32) Size() int {
-	return W.WSize()
-}
-func (W _hash_Hash32) Sum(b []byte) []byte {
-	return W.WSum(b)
-}
-func (W _hash_Hash32) Sum32() uint32 {
-	return W.WSum32()
-}
-func (W _hash_Hash32) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _hash_Hash32) BlockSize() int                    { return W.WBlockSize() }
+func (W _hash_Hash32) Reset()                            { W.WReset() }
+func (W _hash_Hash32) Size() int                         { return W.WSize() }
+func (W _hash_Hash32) Sum(b []byte) []byte               { return W.WSum(b) }
+func (W _hash_Hash32) Sum32() uint32                     { return W.WSum32() }
+func (W _hash_Hash32) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _hash_Hash64 is an interface wrapper for Hash64 type
 type _hash_Hash64 struct {
@@ -91,21 +69,9 @@ type _hash_Hash64 struct {
 	WWrite     func(p []byte) (n int, err error)
 }
 
-func (W _hash_Hash64) BlockSize() int {
-	return W.WBlockSize()
-}
-func (W _hash_Hash64) Reset() {
-	W.WReset()
-}
-func (W _hash_Hash64) Size() int {
-	return W.WSize()
-}
-func (W _hash_Hash64) Sum(b []byte) []byte {
-	return W.WSum(b)
-}
-func (W _hash_Hash64) Sum64() uint64 {
-	return W.WSum64()
-}
-func (W _hash_Hash64) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _hash_Hash64) BlockSize() int                    { return W.WBlockSize() }
+func (W _hash_Hash64) Reset()                            { W.WReset() }
+func (W _hash_Hash64) Size() int                         { return W.WSize() }
+func (W _hash_Hash64) Sum(b []byte) []byte               { return W.WSum(b) }
+func (W _hash_Hash64) Sum64() uint64                     { return W.WSum64() }
+func (W _hash_Hash64) Write(p []byte) (n int, err error) { return W.WWrite(p) }

--- a/stdlib/go1_22_image.go
+++ b/stdlib/go1_22_image.go
@@ -83,15 +83,9 @@ type _image_Image struct {
 	WColorModel func() color.Model
 }
 
-func (W _image_Image) At(x int, y int) color.Color {
-	return W.WAt(x, y)
-}
-func (W _image_Image) Bounds() image.Rectangle {
-	return W.WBounds()
-}
-func (W _image_Image) ColorModel() color.Model {
-	return W.WColorModel()
-}
+func (W _image_Image) At(x int, y int) color.Color { return W.WAt(x, y) }
+func (W _image_Image) Bounds() image.Rectangle     { return W.WBounds() }
+func (W _image_Image) ColorModel() color.Model     { return W.WColorModel() }
 
 // _image_PalettedImage is an interface wrapper for PalettedImage type
 type _image_PalettedImage struct {
@@ -102,18 +96,10 @@ type _image_PalettedImage struct {
 	WColorModel   func() color.Model
 }
 
-func (W _image_PalettedImage) At(x int, y int) color.Color {
-	return W.WAt(x, y)
-}
-func (W _image_PalettedImage) Bounds() image.Rectangle {
-	return W.WBounds()
-}
-func (W _image_PalettedImage) ColorIndexAt(x int, y int) uint8 {
-	return W.WColorIndexAt(x, y)
-}
-func (W _image_PalettedImage) ColorModel() color.Model {
-	return W.WColorModel()
-}
+func (W _image_PalettedImage) At(x int, y int) color.Color     { return W.WAt(x, y) }
+func (W _image_PalettedImage) Bounds() image.Rectangle         { return W.WBounds() }
+func (W _image_PalettedImage) ColorIndexAt(x int, y int) uint8 { return W.WColorIndexAt(x, y) }
+func (W _image_PalettedImage) ColorModel() color.Model         { return W.WColorModel() }
 
 // _image_RGBA64Image is an interface wrapper for RGBA64Image type
 type _image_RGBA64Image struct {
@@ -124,15 +110,7 @@ type _image_RGBA64Image struct {
 	WRGBA64At   func(x int, y int) color.RGBA64
 }
 
-func (W _image_RGBA64Image) At(x int, y int) color.Color {
-	return W.WAt(x, y)
-}
-func (W _image_RGBA64Image) Bounds() image.Rectangle {
-	return W.WBounds()
-}
-func (W _image_RGBA64Image) ColorModel() color.Model {
-	return W.WColorModel()
-}
-func (W _image_RGBA64Image) RGBA64At(x int, y int) color.RGBA64 {
-	return W.WRGBA64At(x, y)
-}
+func (W _image_RGBA64Image) At(x int, y int) color.Color        { return W.WAt(x, y) }
+func (W _image_RGBA64Image) Bounds() image.Rectangle            { return W.WBounds() }
+func (W _image_RGBA64Image) ColorModel() color.Model            { return W.WColorModel() }
+func (W _image_RGBA64Image) RGBA64At(x int, y int) color.RGBA64 { return W.WRGBA64At(x, y) }

--- a/stdlib/go1_22_image_color.go
+++ b/stdlib/go1_22_image_color.go
@@ -62,9 +62,7 @@ type _image_color_Color struct {
 	WRGBA  func() (r uint32, g uint32, b uint32, a uint32)
 }
 
-func (W _image_color_Color) RGBA() (r uint32, g uint32, b uint32, a uint32) {
-	return W.WRGBA()
-}
+func (W _image_color_Color) RGBA() (r uint32, g uint32, b uint32, a uint32) { return W.WRGBA() }
 
 // _image_color_Model is an interface wrapper for Model type
 type _image_color_Model struct {
@@ -72,6 +70,4 @@ type _image_color_Model struct {
 	WConvert func(c color.Color) color.Color
 }
 
-func (W _image_color_Model) Convert(c color.Color) color.Color {
-	return W.WConvert(c)
-}
+func (W _image_color_Model) Convert(c color.Color) color.Color { return W.WConvert(c) }

--- a/stdlib/go1_22_image_draw.go
+++ b/stdlib/go1_22_image_draw.go
@@ -55,18 +55,10 @@ type _image_draw_Image struct {
 	WSet        func(x int, y int, c color.Color)
 }
 
-func (W _image_draw_Image) At(x int, y int) color.Color {
-	return W.WAt(x, y)
-}
-func (W _image_draw_Image) Bounds() image.Rectangle {
-	return W.WBounds()
-}
-func (W _image_draw_Image) ColorModel() color.Model {
-	return W.WColorModel()
-}
-func (W _image_draw_Image) Set(x int, y int, c color.Color) {
-	W.WSet(x, y, c)
-}
+func (W _image_draw_Image) At(x int, y int) color.Color     { return W.WAt(x, y) }
+func (W _image_draw_Image) Bounds() image.Rectangle         { return W.WBounds() }
+func (W _image_draw_Image) ColorModel() color.Model         { return W.WColorModel() }
+func (W _image_draw_Image) Set(x int, y int, c color.Color) { W.WSet(x, y, c) }
 
 // _image_draw_Quantizer is an interface wrapper for Quantizer type
 type _image_draw_Quantizer struct {
@@ -89,21 +81,9 @@ type _image_draw_RGBA64Image struct {
 	WSetRGBA64  func(x int, y int, c color.RGBA64)
 }
 
-func (W _image_draw_RGBA64Image) At(x int, y int) color.Color {
-	return W.WAt(x, y)
-}
-func (W _image_draw_RGBA64Image) Bounds() image.Rectangle {
-	return W.WBounds()
-}
-func (W _image_draw_RGBA64Image) ColorModel() color.Model {
-	return W.WColorModel()
-}
-func (W _image_draw_RGBA64Image) RGBA64At(x int, y int) color.RGBA64 {
-	return W.WRGBA64At(x, y)
-}
-func (W _image_draw_RGBA64Image) Set(x int, y int, c color.Color) {
-	W.WSet(x, y, c)
-}
-func (W _image_draw_RGBA64Image) SetRGBA64(x int, y int, c color.RGBA64) {
-	W.WSetRGBA64(x, y, c)
-}
+func (W _image_draw_RGBA64Image) At(x int, y int) color.Color            { return W.WAt(x, y) }
+func (W _image_draw_RGBA64Image) Bounds() image.Rectangle                { return W.WBounds() }
+func (W _image_draw_RGBA64Image) ColorModel() color.Model                { return W.WColorModel() }
+func (W _image_draw_RGBA64Image) RGBA64At(x int, y int) color.RGBA64     { return W.WRGBA64At(x, y) }
+func (W _image_draw_RGBA64Image) Set(x int, y int, c color.Color)        { W.WSet(x, y, c) }
+func (W _image_draw_RGBA64Image) SetRGBA64(x int, y int, c color.RGBA64) { W.WSetRGBA64(x, y, c) }

--- a/stdlib/go1_22_image_jpeg.go
+++ b/stdlib/go1_22_image_jpeg.go
@@ -38,9 +38,5 @@ type _image_jpeg_Reader struct {
 	WReadByte func() (byte, error)
 }
 
-func (W _image_jpeg_Reader) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _image_jpeg_Reader) ReadByte() (byte, error) {
-	return W.WReadByte()
-}
+func (W _image_jpeg_Reader) Read(p []byte) (n int, err error) { return W.WRead(p) }
+func (W _image_jpeg_Reader) ReadByte() (byte, error)          { return W.WReadByte() }

--- a/stdlib/go1_22_image_png.go
+++ b/stdlib/go1_22_image_png.go
@@ -41,9 +41,5 @@ type _image_png_EncoderBufferPool struct {
 	WPut   func(a0 *png.EncoderBuffer)
 }
 
-func (W _image_png_EncoderBufferPool) Get() *png.EncoderBuffer {
-	return W.WGet()
-}
-func (W _image_png_EncoderBufferPool) Put(a0 *png.EncoderBuffer) {
-	W.WPut(a0)
-}
+func (W _image_png_EncoderBufferPool) Get() *png.EncoderBuffer   { return W.WGet() }
+func (W _image_png_EncoderBufferPool) Put(a0 *png.EncoderBuffer) { W.WPut(a0) }

--- a/stdlib/go1_22_io.go
+++ b/stdlib/go1_22_io.go
@@ -102,9 +102,7 @@ type _io_ByteReader struct {
 	WReadByte func() (byte, error)
 }
 
-func (W _io_ByteReader) ReadByte() (byte, error) {
-	return W.WReadByte()
-}
+func (W _io_ByteReader) ReadByte() (byte, error) { return W.WReadByte() }
 
 // _io_ByteScanner is an interface wrapper for ByteScanner type
 type _io_ByteScanner struct {
@@ -113,12 +111,8 @@ type _io_ByteScanner struct {
 	WUnreadByte func() error
 }
 
-func (W _io_ByteScanner) ReadByte() (byte, error) {
-	return W.WReadByte()
-}
-func (W _io_ByteScanner) UnreadByte() error {
-	return W.WUnreadByte()
-}
+func (W _io_ByteScanner) ReadByte() (byte, error) { return W.WReadByte() }
+func (W _io_ByteScanner) UnreadByte() error       { return W.WUnreadByte() }
 
 // _io_ByteWriter is an interface wrapper for ByteWriter type
 type _io_ByteWriter struct {
@@ -126,9 +120,7 @@ type _io_ByteWriter struct {
 	WWriteByte func(c byte) error
 }
 
-func (W _io_ByteWriter) WriteByte(c byte) error {
-	return W.WWriteByte(c)
-}
+func (W _io_ByteWriter) WriteByte(c byte) error { return W.WWriteByte(c) }
 
 // _io_Closer is an interface wrapper for Closer type
 type _io_Closer struct {
@@ -136,9 +128,7 @@ type _io_Closer struct {
 	WClose func() error
 }
 
-func (W _io_Closer) Close() error {
-	return W.WClose()
-}
+func (W _io_Closer) Close() error { return W.WClose() }
 
 // _io_ReadCloser is an interface wrapper for ReadCloser type
 type _io_ReadCloser struct {
@@ -147,12 +137,8 @@ type _io_ReadCloser struct {
 	WRead  func(p []byte) (n int, err error)
 }
 
-func (W _io_ReadCloser) Close() error {
-	return W.WClose()
-}
-func (W _io_ReadCloser) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
+func (W _io_ReadCloser) Close() error                     { return W.WClose() }
+func (W _io_ReadCloser) Read(p []byte) (n int, err error) { return W.WRead(p) }
 
 // _io_ReadSeekCloser is an interface wrapper for ReadSeekCloser type
 type _io_ReadSeekCloser struct {
@@ -162,12 +148,8 @@ type _io_ReadSeekCloser struct {
 	WSeek  func(offset int64, whence int) (int64, error)
 }
 
-func (W _io_ReadSeekCloser) Close() error {
-	return W.WClose()
-}
-func (W _io_ReadSeekCloser) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
+func (W _io_ReadSeekCloser) Close() error                     { return W.WClose() }
+func (W _io_ReadSeekCloser) Read(p []byte) (n int, err error) { return W.WRead(p) }
 func (W _io_ReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
 	return W.WSeek(offset, whence)
 }
@@ -179,12 +161,8 @@ type _io_ReadSeeker struct {
 	WSeek  func(offset int64, whence int) (int64, error)
 }
 
-func (W _io_ReadSeeker) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _io_ReadSeeker) Seek(offset int64, whence int) (int64, error) {
-	return W.WSeek(offset, whence)
-}
+func (W _io_ReadSeeker) Read(p []byte) (n int, err error)             { return W.WRead(p) }
+func (W _io_ReadSeeker) Seek(offset int64, whence int) (int64, error) { return W.WSeek(offset, whence) }
 
 // _io_ReadWriteCloser is an interface wrapper for ReadWriteCloser type
 type _io_ReadWriteCloser struct {
@@ -194,15 +172,9 @@ type _io_ReadWriteCloser struct {
 	WWrite func(p []byte) (n int, err error)
 }
 
-func (W _io_ReadWriteCloser) Close() error {
-	return W.WClose()
-}
-func (W _io_ReadWriteCloser) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _io_ReadWriteCloser) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_ReadWriteCloser) Close() error                      { return W.WClose() }
+func (W _io_ReadWriteCloser) Read(p []byte) (n int, err error)  { return W.WRead(p) }
+func (W _io_ReadWriteCloser) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_ReadWriteSeeker is an interface wrapper for ReadWriteSeeker type
 type _io_ReadWriteSeeker struct {
@@ -212,15 +184,11 @@ type _io_ReadWriteSeeker struct {
 	WWrite func(p []byte) (n int, err error)
 }
 
-func (W _io_ReadWriteSeeker) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
+func (W _io_ReadWriteSeeker) Read(p []byte) (n int, err error) { return W.WRead(p) }
 func (W _io_ReadWriteSeeker) Seek(offset int64, whence int) (int64, error) {
 	return W.WSeek(offset, whence)
 }
-func (W _io_ReadWriteSeeker) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_ReadWriteSeeker) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_ReadWriter is an interface wrapper for ReadWriter type
 type _io_ReadWriter struct {
@@ -229,12 +197,8 @@ type _io_ReadWriter struct {
 	WWrite func(p []byte) (n int, err error)
 }
 
-func (W _io_ReadWriter) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _io_ReadWriter) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_ReadWriter) Read(p []byte) (n int, err error)  { return W.WRead(p) }
+func (W _io_ReadWriter) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_Reader is an interface wrapper for Reader type
 type _io_Reader struct {
@@ -242,9 +206,7 @@ type _io_Reader struct {
 	WRead  func(p []byte) (n int, err error)
 }
 
-func (W _io_Reader) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
+func (W _io_Reader) Read(p []byte) (n int, err error) { return W.WRead(p) }
 
 // _io_ReaderAt is an interface wrapper for ReaderAt type
 type _io_ReaderAt struct {
@@ -252,9 +214,7 @@ type _io_ReaderAt struct {
 	WReadAt func(p []byte, off int64) (n int, err error)
 }
 
-func (W _io_ReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
-	return W.WReadAt(p, off)
-}
+func (W _io_ReaderAt) ReadAt(p []byte, off int64) (n int, err error) { return W.WReadAt(p, off) }
 
 // _io_ReaderFrom is an interface wrapper for ReaderFrom type
 type _io_ReaderFrom struct {
@@ -262,9 +222,7 @@ type _io_ReaderFrom struct {
 	WReadFrom func(r io.Reader) (n int64, err error)
 }
 
-func (W _io_ReaderFrom) ReadFrom(r io.Reader) (n int64, err error) {
-	return W.WReadFrom(r)
-}
+func (W _io_ReaderFrom) ReadFrom(r io.Reader) (n int64, err error) { return W.WReadFrom(r) }
 
 // _io_RuneReader is an interface wrapper for RuneReader type
 type _io_RuneReader struct {
@@ -272,9 +230,7 @@ type _io_RuneReader struct {
 	WReadRune func() (r rune, size int, err error)
 }
 
-func (W _io_RuneReader) ReadRune() (r rune, size int, err error) {
-	return W.WReadRune()
-}
+func (W _io_RuneReader) ReadRune() (r rune, size int, err error) { return W.WReadRune() }
 
 // _io_RuneScanner is an interface wrapper for RuneScanner type
 type _io_RuneScanner struct {
@@ -283,12 +239,8 @@ type _io_RuneScanner struct {
 	WUnreadRune func() error
 }
 
-func (W _io_RuneScanner) ReadRune() (r rune, size int, err error) {
-	return W.WReadRune()
-}
-func (W _io_RuneScanner) UnreadRune() error {
-	return W.WUnreadRune()
-}
+func (W _io_RuneScanner) ReadRune() (r rune, size int, err error) { return W.WReadRune() }
+func (W _io_RuneScanner) UnreadRune() error                       { return W.WUnreadRune() }
 
 // _io_Seeker is an interface wrapper for Seeker type
 type _io_Seeker struct {
@@ -296,9 +248,7 @@ type _io_Seeker struct {
 	WSeek  func(offset int64, whence int) (int64, error)
 }
 
-func (W _io_Seeker) Seek(offset int64, whence int) (int64, error) {
-	return W.WSeek(offset, whence)
-}
+func (W _io_Seeker) Seek(offset int64, whence int) (int64, error) { return W.WSeek(offset, whence) }
 
 // _io_StringWriter is an interface wrapper for StringWriter type
 type _io_StringWriter struct {
@@ -306,9 +256,7 @@ type _io_StringWriter struct {
 	WWriteString func(s string) (n int, err error)
 }
 
-func (W _io_StringWriter) WriteString(s string) (n int, err error) {
-	return W.WWriteString(s)
-}
+func (W _io_StringWriter) WriteString(s string) (n int, err error) { return W.WWriteString(s) }
 
 // _io_WriteCloser is an interface wrapper for WriteCloser type
 type _io_WriteCloser struct {
@@ -317,12 +265,8 @@ type _io_WriteCloser struct {
 	WWrite func(p []byte) (n int, err error)
 }
 
-func (W _io_WriteCloser) Close() error {
-	return W.WClose()
-}
-func (W _io_WriteCloser) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_WriteCloser) Close() error                      { return W.WClose() }
+func (W _io_WriteCloser) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_WriteSeeker is an interface wrapper for WriteSeeker type
 type _io_WriteSeeker struct {
@@ -334,9 +278,7 @@ type _io_WriteSeeker struct {
 func (W _io_WriteSeeker) Seek(offset int64, whence int) (int64, error) {
 	return W.WSeek(offset, whence)
 }
-func (W _io_WriteSeeker) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_WriteSeeker) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_Writer is an interface wrapper for Writer type
 type _io_Writer struct {
@@ -344,9 +286,7 @@ type _io_Writer struct {
 	WWrite func(p []byte) (n int, err error)
 }
 
-func (W _io_Writer) Write(p []byte) (n int, err error) {
-	return W.WWrite(p)
-}
+func (W _io_Writer) Write(p []byte) (n int, err error) { return W.WWrite(p) }
 
 // _io_WriterAt is an interface wrapper for WriterAt type
 type _io_WriterAt struct {
@@ -354,9 +294,7 @@ type _io_WriterAt struct {
 	WWriteAt func(p []byte, off int64) (n int, err error)
 }
 
-func (W _io_WriterAt) WriteAt(p []byte, off int64) (n int, err error) {
-	return W.WWriteAt(p, off)
-}
+func (W _io_WriterAt) WriteAt(p []byte, off int64) (n int, err error) { return W.WWriteAt(p, off) }
 
 // _io_WriterTo is an interface wrapper for WriterTo type
 type _io_WriterTo struct {
@@ -364,6 +302,4 @@ type _io_WriterTo struct {
 	WWriteTo func(w io.Writer) (n int64, err error)
 }
 
-func (W _io_WriterTo) WriteTo(w io.Writer) (n int64, err error) {
-	return W.WWriteTo(w)
-}
+func (W _io_WriterTo) WriteTo(w io.Writer) (n int64, err error) { return W.WWriteTo(w) }

--- a/stdlib/go1_22_io_fs.go
+++ b/stdlib/go1_22_io_fs.go
@@ -85,18 +85,10 @@ type _io_fs_DirEntry struct {
 	WType  func() fs.FileMode
 }
 
-func (W _io_fs_DirEntry) Info() (fs.FileInfo, error) {
-	return W.WInfo()
-}
-func (W _io_fs_DirEntry) IsDir() bool {
-	return W.WIsDir()
-}
-func (W _io_fs_DirEntry) Name() string {
-	return W.WName()
-}
-func (W _io_fs_DirEntry) Type() fs.FileMode {
-	return W.WType()
-}
+func (W _io_fs_DirEntry) Info() (fs.FileInfo, error) { return W.WInfo() }
+func (W _io_fs_DirEntry) IsDir() bool                { return W.WIsDir() }
+func (W _io_fs_DirEntry) Name() string               { return W.WName() }
+func (W _io_fs_DirEntry) Type() fs.FileMode          { return W.WType() }
 
 // _io_fs_FS is an interface wrapper for FS type
 type _io_fs_FS struct {
@@ -104,9 +96,7 @@ type _io_fs_FS struct {
 	WOpen  func(name string) (fs.File, error)
 }
 
-func (W _io_fs_FS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
+func (W _io_fs_FS) Open(name string) (fs.File, error) { return W.WOpen(name) }
 
 // _io_fs_File is an interface wrapper for File type
 type _io_fs_File struct {
@@ -116,15 +106,9 @@ type _io_fs_File struct {
 	WStat  func() (fs.FileInfo, error)
 }
 
-func (W _io_fs_File) Close() error {
-	return W.WClose()
-}
-func (W _io_fs_File) Read(a0 []byte) (int, error) {
-	return W.WRead(a0)
-}
-func (W _io_fs_File) Stat() (fs.FileInfo, error) {
-	return W.WStat()
-}
+func (W _io_fs_File) Close() error                { return W.WClose() }
+func (W _io_fs_File) Read(a0 []byte) (int, error) { return W.WRead(a0) }
+func (W _io_fs_File) Stat() (fs.FileInfo, error)  { return W.WStat() }
 
 // _io_fs_FileInfo is an interface wrapper for FileInfo type
 type _io_fs_FileInfo struct {
@@ -137,24 +121,12 @@ type _io_fs_FileInfo struct {
 	WSys     func() any
 }
 
-func (W _io_fs_FileInfo) IsDir() bool {
-	return W.WIsDir()
-}
-func (W _io_fs_FileInfo) ModTime() time.Time {
-	return W.WModTime()
-}
-func (W _io_fs_FileInfo) Mode() fs.FileMode {
-	return W.WMode()
-}
-func (W _io_fs_FileInfo) Name() string {
-	return W.WName()
-}
-func (W _io_fs_FileInfo) Size() int64 {
-	return W.WSize()
-}
-func (W _io_fs_FileInfo) Sys() any {
-	return W.WSys()
-}
+func (W _io_fs_FileInfo) IsDir() bool        { return W.WIsDir() }
+func (W _io_fs_FileInfo) ModTime() time.Time { return W.WModTime() }
+func (W _io_fs_FileInfo) Mode() fs.FileMode  { return W.WMode() }
+func (W _io_fs_FileInfo) Name() string       { return W.WName() }
+func (W _io_fs_FileInfo) Size() int64        { return W.WSize() }
+func (W _io_fs_FileInfo) Sys() any           { return W.WSys() }
 
 // _io_fs_GlobFS is an interface wrapper for GlobFS type
 type _io_fs_GlobFS struct {
@@ -163,12 +135,8 @@ type _io_fs_GlobFS struct {
 	WOpen  func(name string) (fs.File, error)
 }
 
-func (W _io_fs_GlobFS) Glob(pattern string) ([]string, error) {
-	return W.WGlob(pattern)
-}
-func (W _io_fs_GlobFS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
+func (W _io_fs_GlobFS) Glob(pattern string) ([]string, error) { return W.WGlob(pattern) }
+func (W _io_fs_GlobFS) Open(name string) (fs.File, error)     { return W.WOpen(name) }
 
 // _io_fs_ReadDirFS is an interface wrapper for ReadDirFS type
 type _io_fs_ReadDirFS struct {
@@ -177,12 +145,8 @@ type _io_fs_ReadDirFS struct {
 	WReadDir func(name string) ([]fs.DirEntry, error)
 }
 
-func (W _io_fs_ReadDirFS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
-func (W _io_fs_ReadDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	return W.WReadDir(name)
-}
+func (W _io_fs_ReadDirFS) Open(name string) (fs.File, error)          { return W.WOpen(name) }
+func (W _io_fs_ReadDirFS) ReadDir(name string) ([]fs.DirEntry, error) { return W.WReadDir(name) }
 
 // _io_fs_ReadDirFile is an interface wrapper for ReadDirFile type
 type _io_fs_ReadDirFile struct {
@@ -193,18 +157,10 @@ type _io_fs_ReadDirFile struct {
 	WStat    func() (fs.FileInfo, error)
 }
 
-func (W _io_fs_ReadDirFile) Close() error {
-	return W.WClose()
-}
-func (W _io_fs_ReadDirFile) Read(a0 []byte) (int, error) {
-	return W.WRead(a0)
-}
-func (W _io_fs_ReadDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
-	return W.WReadDir(n)
-}
-func (W _io_fs_ReadDirFile) Stat() (fs.FileInfo, error) {
-	return W.WStat()
-}
+func (W _io_fs_ReadDirFile) Close() error                         { return W.WClose() }
+func (W _io_fs_ReadDirFile) Read(a0 []byte) (int, error)          { return W.WRead(a0) }
+func (W _io_fs_ReadDirFile) ReadDir(n int) ([]fs.DirEntry, error) { return W.WReadDir(n) }
+func (W _io_fs_ReadDirFile) Stat() (fs.FileInfo, error)           { return W.WStat() }
 
 // _io_fs_ReadFileFS is an interface wrapper for ReadFileFS type
 type _io_fs_ReadFileFS struct {
@@ -213,12 +169,8 @@ type _io_fs_ReadFileFS struct {
 	WReadFile func(name string) ([]byte, error)
 }
 
-func (W _io_fs_ReadFileFS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
-func (W _io_fs_ReadFileFS) ReadFile(name string) ([]byte, error) {
-	return W.WReadFile(name)
-}
+func (W _io_fs_ReadFileFS) Open(name string) (fs.File, error)    { return W.WOpen(name) }
+func (W _io_fs_ReadFileFS) ReadFile(name string) ([]byte, error) { return W.WReadFile(name) }
 
 // _io_fs_StatFS is an interface wrapper for StatFS type
 type _io_fs_StatFS struct {
@@ -227,12 +179,8 @@ type _io_fs_StatFS struct {
 	WStat  func(name string) (fs.FileInfo, error)
 }
 
-func (W _io_fs_StatFS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
-func (W _io_fs_StatFS) Stat(name string) (fs.FileInfo, error) {
-	return W.WStat(name)
-}
+func (W _io_fs_StatFS) Open(name string) (fs.File, error)     { return W.WOpen(name) }
+func (W _io_fs_StatFS) Stat(name string) (fs.FileInfo, error) { return W.WStat(name) }
 
 // _io_fs_SubFS is an interface wrapper for SubFS type
 type _io_fs_SubFS struct {
@@ -241,9 +189,5 @@ type _io_fs_SubFS struct {
 	WSub   func(dir string) (fs.FS, error)
 }
 
-func (W _io_fs_SubFS) Open(name string) (fs.File, error) {
-	return W.WOpen(name)
-}
-func (W _io_fs_SubFS) Sub(dir string) (fs.FS, error) {
-	return W.WSub(dir)
-}
+func (W _io_fs_SubFS) Open(name string) (fs.File, error) { return W.WOpen(name) }
+func (W _io_fs_SubFS) Sub(dir string) (fs.FS, error)     { return W.WSub(dir) }

--- a/stdlib/go1_22_log_slog.go
+++ b/stdlib/go1_22_log_slog.go
@@ -106,18 +106,10 @@ type _log_slog_Handler struct {
 	WWithGroup func(name string) slog.Handler
 }
 
-func (W _log_slog_Handler) Enabled(a0 context.Context, a1 slog.Level) bool {
-	return W.WEnabled(a0, a1)
-}
-func (W _log_slog_Handler) Handle(a0 context.Context, a1 slog.Record) error {
-	return W.WHandle(a0, a1)
-}
-func (W _log_slog_Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return W.WWithAttrs(attrs)
-}
-func (W _log_slog_Handler) WithGroup(name string) slog.Handler {
-	return W.WWithGroup(name)
-}
+func (W _log_slog_Handler) Enabled(a0 context.Context, a1 slog.Level) bool  { return W.WEnabled(a0, a1) }
+func (W _log_slog_Handler) Handle(a0 context.Context, a1 slog.Record) error { return W.WHandle(a0, a1) }
+func (W _log_slog_Handler) WithAttrs(attrs []slog.Attr) slog.Handler        { return W.WWithAttrs(attrs) }
+func (W _log_slog_Handler) WithGroup(name string) slog.Handler              { return W.WWithGroup(name) }
 
 // _log_slog_Leveler is an interface wrapper for Leveler type
 type _log_slog_Leveler struct {
@@ -125,9 +117,7 @@ type _log_slog_Leveler struct {
 	WLevel func() slog.Level
 }
 
-func (W _log_slog_Leveler) Level() slog.Level {
-	return W.WLevel()
-}
+func (W _log_slog_Leveler) Level() slog.Level { return W.WLevel() }
 
 // _log_slog_LogValuer is an interface wrapper for LogValuer type
 type _log_slog_LogValuer struct {
@@ -135,6 +125,4 @@ type _log_slog_LogValuer struct {
 	WLogValue func() slog.Value
 }
 
-func (W _log_slog_LogValuer) LogValue() slog.Value {
-	return W.WLogValue()
-}
+func (W _log_slog_LogValuer) LogValue() slog.Value { return W.WLogValue() }

--- a/stdlib/go1_22_math_rand.go
+++ b/stdlib/go1_22_math_rand.go
@@ -52,12 +52,8 @@ type _math_rand_Source struct {
 	WSeed  func(seed int64)
 }
 
-func (W _math_rand_Source) Int63() int64 {
-	return W.WInt63()
-}
-func (W _math_rand_Source) Seed(seed int64) {
-	W.WSeed(seed)
-}
+func (W _math_rand_Source) Int63() int64    { return W.WInt63() }
+func (W _math_rand_Source) Seed(seed int64) { W.WSeed(seed) }
 
 // _math_rand_Source64 is an interface wrapper for Source64 type
 type _math_rand_Source64 struct {
@@ -67,12 +63,6 @@ type _math_rand_Source64 struct {
 	WUint64 func() uint64
 }
 
-func (W _math_rand_Source64) Int63() int64 {
-	return W.WInt63()
-}
-func (W _math_rand_Source64) Seed(seed int64) {
-	W.WSeed(seed)
-}
-func (W _math_rand_Source64) Uint64() uint64 {
-	return W.WUint64()
-}
+func (W _math_rand_Source64) Int63() int64    { return W.WInt63() }
+func (W _math_rand_Source64) Seed(seed int64) { W.WSeed(seed) }
+func (W _math_rand_Source64) Uint64() uint64  { return W.WUint64() }

--- a/stdlib/go1_22_math_rand_v2.go
+++ b/stdlib/go1_22_math_rand_v2.go
@@ -53,6 +53,4 @@ type _math_rand_v2_Source struct {
 	WUint64 func() uint64
 }
 
-func (W _math_rand_v2_Source) Uint64() uint64 {
-	return W.WUint64()
-}
+func (W _math_rand_v2_Source) Uint64() uint64 { return W.WUint64() }

--- a/stdlib/go1_22_mime_multipart.go
+++ b/stdlib/go1_22_mime_multipart.go
@@ -39,12 +39,8 @@ type _mime_multipart_File struct {
 	WSeek   func(offset int64, whence int) (int64, error)
 }
 
-func (W _mime_multipart_File) Close() error {
-	return W.WClose()
-}
-func (W _mime_multipart_File) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
+func (W _mime_multipart_File) Close() error                     { return W.WClose() }
+func (W _mime_multipart_File) Read(p []byte) (n int, err error) { return W.WRead(p) }
 func (W _mime_multipart_File) ReadAt(p []byte, off int64) (n int, err error) {
 	return W.WReadAt(p, off)
 }

--- a/stdlib/go1_22_net.go
+++ b/stdlib/go1_22_net.go
@@ -136,9 +136,7 @@ type _net_Addr struct {
 	WString  func() string
 }
 
-func (W _net_Addr) Network() string {
-	return W.WNetwork()
-}
+func (W _net_Addr) Network() string { return W.WNetwork() }
 func (W _net_Addr) String() string {
 	if W.WString == nil {
 		return ""
@@ -159,30 +157,14 @@ type _net_Conn struct {
 	WWrite            func(b []byte) (n int, err error)
 }
 
-func (W _net_Conn) Close() error {
-	return W.WClose()
-}
-func (W _net_Conn) LocalAddr() net.Addr {
-	return W.WLocalAddr()
-}
-func (W _net_Conn) Read(b []byte) (n int, err error) {
-	return W.WRead(b)
-}
-func (W _net_Conn) RemoteAddr() net.Addr {
-	return W.WRemoteAddr()
-}
-func (W _net_Conn) SetDeadline(t time.Time) error {
-	return W.WSetDeadline(t)
-}
-func (W _net_Conn) SetReadDeadline(t time.Time) error {
-	return W.WSetReadDeadline(t)
-}
-func (W _net_Conn) SetWriteDeadline(t time.Time) error {
-	return W.WSetWriteDeadline(t)
-}
-func (W _net_Conn) Write(b []byte) (n int, err error) {
-	return W.WWrite(b)
-}
+func (W _net_Conn) Close() error                       { return W.WClose() }
+func (W _net_Conn) LocalAddr() net.Addr                { return W.WLocalAddr() }
+func (W _net_Conn) Read(b []byte) (n int, err error)   { return W.WRead(b) }
+func (W _net_Conn) RemoteAddr() net.Addr               { return W.WRemoteAddr() }
+func (W _net_Conn) SetDeadline(t time.Time) error      { return W.WSetDeadline(t) }
+func (W _net_Conn) SetReadDeadline(t time.Time) error  { return W.WSetReadDeadline(t) }
+func (W _net_Conn) SetWriteDeadline(t time.Time) error { return W.WSetWriteDeadline(t) }
+func (W _net_Conn) Write(b []byte) (n int, err error)  { return W.WWrite(b) }
 
 // _net_Error is an interface wrapper for Error type
 type _net_Error struct {
@@ -192,15 +174,9 @@ type _net_Error struct {
 	WTimeout   func() bool
 }
 
-func (W _net_Error) Error() string {
-	return W.WError()
-}
-func (W _net_Error) Temporary() bool {
-	return W.WTemporary()
-}
-func (W _net_Error) Timeout() bool {
-	return W.WTimeout()
-}
+func (W _net_Error) Error() string   { return W.WError() }
+func (W _net_Error) Temporary() bool { return W.WTemporary() }
+func (W _net_Error) Timeout() bool   { return W.WTimeout() }
 
 // _net_Listener is an interface wrapper for Listener type
 type _net_Listener struct {
@@ -210,15 +186,9 @@ type _net_Listener struct {
 	WClose  func() error
 }
 
-func (W _net_Listener) Accept() (net.Conn, error) {
-	return W.WAccept()
-}
-func (W _net_Listener) Addr() net.Addr {
-	return W.WAddr()
-}
-func (W _net_Listener) Close() error {
-	return W.WClose()
-}
+func (W _net_Listener) Accept() (net.Conn, error) { return W.WAccept() }
+func (W _net_Listener) Addr() net.Addr            { return W.WAddr() }
+func (W _net_Listener) Close() error              { return W.WClose() }
 
 // _net_PacketConn is an interface wrapper for PacketConn type
 type _net_PacketConn struct {
@@ -232,24 +202,12 @@ type _net_PacketConn struct {
 	WWriteTo          func(p []byte, addr net.Addr) (n int, err error)
 }
 
-func (W _net_PacketConn) Close() error {
-	return W.WClose()
-}
-func (W _net_PacketConn) LocalAddr() net.Addr {
-	return W.WLocalAddr()
-}
-func (W _net_PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
-	return W.WReadFrom(p)
-}
-func (W _net_PacketConn) SetDeadline(t time.Time) error {
-	return W.WSetDeadline(t)
-}
-func (W _net_PacketConn) SetReadDeadline(t time.Time) error {
-	return W.WSetReadDeadline(t)
-}
-func (W _net_PacketConn) SetWriteDeadline(t time.Time) error {
-	return W.WSetWriteDeadline(t)
-}
+func (W _net_PacketConn) Close() error                                        { return W.WClose() }
+func (W _net_PacketConn) LocalAddr() net.Addr                                 { return W.WLocalAddr() }
+func (W _net_PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) { return W.WReadFrom(p) }
+func (W _net_PacketConn) SetDeadline(t time.Time) error                       { return W.WSetDeadline(t) }
+func (W _net_PacketConn) SetReadDeadline(t time.Time) error                   { return W.WSetReadDeadline(t) }
+func (W _net_PacketConn) SetWriteDeadline(t time.Time) error                  { return W.WSetWriteDeadline(t) }
 func (W _net_PacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 	return W.WWriteTo(p, addr)
 }

--- a/stdlib/go1_22_net_http.go
+++ b/stdlib/go1_22_net_http.go
@@ -222,9 +222,7 @@ type _net_http_CloseNotifier struct {
 	WCloseNotify func() <-chan bool
 }
 
-func (W _net_http_CloseNotifier) CloseNotify() <-chan bool {
-	return W.WCloseNotify()
-}
+func (W _net_http_CloseNotifier) CloseNotify() <-chan bool { return W.WCloseNotify() }
 
 // _net_http_CookieJar is an interface wrapper for CookieJar type
 type _net_http_CookieJar struct {
@@ -233,9 +231,7 @@ type _net_http_CookieJar struct {
 	WSetCookies func(u *url.URL, cookies []*http.Cookie)
 }
 
-func (W _net_http_CookieJar) Cookies(u *url.URL) []*http.Cookie {
-	return W.WCookies(u)
-}
+func (W _net_http_CookieJar) Cookies(u *url.URL) []*http.Cookie { return W.WCookies(u) }
 func (W _net_http_CookieJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
 	W.WSetCookies(u, cookies)
 }
@@ -250,21 +246,11 @@ type _net_http_File struct {
 	WStat    func() (fs.FileInfo, error)
 }
 
-func (W _net_http_File) Close() error {
-	return W.WClose()
-}
-func (W _net_http_File) Read(p []byte) (n int, err error) {
-	return W.WRead(p)
-}
-func (W _net_http_File) Readdir(count int) ([]fs.FileInfo, error) {
-	return W.WReaddir(count)
-}
-func (W _net_http_File) Seek(offset int64, whence int) (int64, error) {
-	return W.WSeek(offset, whence)
-}
-func (W _net_http_File) Stat() (fs.FileInfo, error) {
-	return W.WStat()
-}
+func (W _net_http_File) Close() error                                 { return W.WClose() }
+func (W _net_http_File) Read(p []byte) (n int, err error)             { return W.WRead(p) }
+func (W _net_http_File) Readdir(count int) ([]fs.FileInfo, error)     { return W.WReaddir(count) }
+func (W _net_http_File) Seek(offset int64, whence int) (int64, error) { return W.WSeek(offset, whence) }
+func (W _net_http_File) Stat() (fs.FileInfo, error)                   { return W.WStat() }
 
 // _net_http_FileSystem is an interface wrapper for FileSystem type
 type _net_http_FileSystem struct {
@@ -272,9 +258,7 @@ type _net_http_FileSystem struct {
 	WOpen  func(name string) (http.File, error)
 }
 
-func (W _net_http_FileSystem) Open(name string) (http.File, error) {
-	return W.WOpen(name)
-}
+func (W _net_http_FileSystem) Open(name string) (http.File, error) { return W.WOpen(name) }
 
 // _net_http_Flusher is an interface wrapper for Flusher type
 type _net_http_Flusher struct {
@@ -282,9 +266,7 @@ type _net_http_Flusher struct {
 	WFlush func()
 }
 
-func (W _net_http_Flusher) Flush() {
-	W.WFlush()
-}
+func (W _net_http_Flusher) Flush() { W.WFlush() }
 
 // _net_http_Handler is an interface wrapper for Handler type
 type _net_http_Handler struct {
@@ -292,9 +274,7 @@ type _net_http_Handler struct {
 	WServeHTTP func(a0 http.ResponseWriter, a1 *http.Request)
 }
 
-func (W _net_http_Handler) ServeHTTP(a0 http.ResponseWriter, a1 *http.Request) {
-	W.WServeHTTP(a0, a1)
-}
+func (W _net_http_Handler) ServeHTTP(a0 http.ResponseWriter, a1 *http.Request) { W.WServeHTTP(a0, a1) }
 
 // _net_http_Hijacker is an interface wrapper for Hijacker type
 type _net_http_Hijacker struct {
@@ -302,9 +282,7 @@ type _net_http_Hijacker struct {
 	WHijack func() (net.Conn, *bufio.ReadWriter, error)
 }
 
-func (W _net_http_Hijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	return W.WHijack()
-}
+func (W _net_http_Hijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) { return W.WHijack() }
 
 // _net_http_Pusher is an interface wrapper for Pusher type
 type _net_http_Pusher struct {
@@ -324,15 +302,9 @@ type _net_http_ResponseWriter struct {
 	WWriteHeader func(statusCode int)
 }
 
-func (W _net_http_ResponseWriter) Header() http.Header {
-	return W.WHeader()
-}
-func (W _net_http_ResponseWriter) Write(a0 []byte) (int, error) {
-	return W.WWrite(a0)
-}
-func (W _net_http_ResponseWriter) WriteHeader(statusCode int) {
-	W.WWriteHeader(statusCode)
-}
+func (W _net_http_ResponseWriter) Header() http.Header          { return W.WHeader() }
+func (W _net_http_ResponseWriter) Write(a0 []byte) (int, error) { return W.WWrite(a0) }
+func (W _net_http_ResponseWriter) WriteHeader(statusCode int)   { W.WWriteHeader(statusCode) }
 
 // _net_http_RoundTripper is an interface wrapper for RoundTripper type
 type _net_http_RoundTripper struct {

--- a/stdlib/go1_22_net_http_httputil.go
+++ b/stdlib/go1_22_net_http_httputil.go
@@ -46,9 +46,5 @@ type _net_http_httputil_BufferPool struct {
 	WPut   func(a0 []byte)
 }
 
-func (W _net_http_httputil_BufferPool) Get() []byte {
-	return W.WGet()
-}
-func (W _net_http_httputil_BufferPool) Put(a0 []byte) {
-	W.WPut(a0)
-}
+func (W _net_http_httputil_BufferPool) Get() []byte   { return W.WGet() }
+func (W _net_http_httputil_BufferPool) Put(a0 []byte) { W.WPut(a0) }

--- a/stdlib/go1_22_net_rpc.go
+++ b/stdlib/go1_22_net_rpc.go
@@ -58,12 +58,8 @@ type _net_rpc_ClientCodec struct {
 	WWriteRequest       func(a0 *rpc.Request, a1 any) error
 }
 
-func (W _net_rpc_ClientCodec) Close() error {
-	return W.WClose()
-}
-func (W _net_rpc_ClientCodec) ReadResponseBody(a0 any) error {
-	return W.WReadResponseBody(a0)
-}
+func (W _net_rpc_ClientCodec) Close() error                  { return W.WClose() }
+func (W _net_rpc_ClientCodec) ReadResponseBody(a0 any) error { return W.WReadResponseBody(a0) }
 func (W _net_rpc_ClientCodec) ReadResponseHeader(a0 *rpc.Response) error {
 	return W.WReadResponseHeader(a0)
 }
@@ -80,12 +76,8 @@ type _net_rpc_ServerCodec struct {
 	WWriteResponse     func(a0 *rpc.Response, a1 any) error
 }
 
-func (W _net_rpc_ServerCodec) Close() error {
-	return W.WClose()
-}
-func (W _net_rpc_ServerCodec) ReadRequestBody(a0 any) error {
-	return W.WReadRequestBody(a0)
-}
+func (W _net_rpc_ServerCodec) Close() error                 { return W.WClose() }
+func (W _net_rpc_ServerCodec) ReadRequestBody(a0 any) error { return W.WReadRequestBody(a0) }
 func (W _net_rpc_ServerCodec) ReadRequestHeader(a0 *rpc.Request) error {
 	return W.WReadRequestHeader(a0)
 }

--- a/stdlib/go1_22_os.go
+++ b/stdlib/go1_22_os.go
@@ -150,18 +150,10 @@ type _os_DirEntry struct {
 	WType  func() fs.FileMode
 }
 
-func (W _os_DirEntry) Info() (fs.FileInfo, error) {
-	return W.WInfo()
-}
-func (W _os_DirEntry) IsDir() bool {
-	return W.WIsDir()
-}
-func (W _os_DirEntry) Name() string {
-	return W.WName()
-}
-func (W _os_DirEntry) Type() fs.FileMode {
-	return W.WType()
-}
+func (W _os_DirEntry) Info() (fs.FileInfo, error) { return W.WInfo() }
+func (W _os_DirEntry) IsDir() bool                { return W.WIsDir() }
+func (W _os_DirEntry) Name() string               { return W.WName() }
+func (W _os_DirEntry) Type() fs.FileMode          { return W.WType() }
 
 // _os_FileInfo is an interface wrapper for FileInfo type
 type _os_FileInfo struct {
@@ -174,24 +166,12 @@ type _os_FileInfo struct {
 	WSys     func() any
 }
 
-func (W _os_FileInfo) IsDir() bool {
-	return W.WIsDir()
-}
-func (W _os_FileInfo) ModTime() time.Time {
-	return W.WModTime()
-}
-func (W _os_FileInfo) Mode() fs.FileMode {
-	return W.WMode()
-}
-func (W _os_FileInfo) Name() string {
-	return W.WName()
-}
-func (W _os_FileInfo) Size() int64 {
-	return W.WSize()
-}
-func (W _os_FileInfo) Sys() any {
-	return W.WSys()
-}
+func (W _os_FileInfo) IsDir() bool        { return W.WIsDir() }
+func (W _os_FileInfo) ModTime() time.Time { return W.WModTime() }
+func (W _os_FileInfo) Mode() fs.FileMode  { return W.WMode() }
+func (W _os_FileInfo) Name() string       { return W.WName() }
+func (W _os_FileInfo) Size() int64        { return W.WSize() }
+func (W _os_FileInfo) Sys() any           { return W.WSys() }
 
 // _os_Signal is an interface wrapper for Signal type
 type _os_Signal struct {
@@ -200,9 +180,7 @@ type _os_Signal struct {
 	WString func() string
 }
 
-func (W _os_Signal) Signal() {
-	W.WSignal()
-}
+func (W _os_Signal) Signal() { W.WSignal() }
 func (W _os_Signal) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_22_reflect.go
+++ b/stdlib/go1_22_reflect.go
@@ -127,90 +127,38 @@ type _reflect_Type struct {
 	WString          func() string
 }
 
-func (W _reflect_Type) Align() int {
-	return W.WAlign()
-}
-func (W _reflect_Type) AssignableTo(u reflect.Type) bool {
-	return W.WAssignableTo(u)
-}
-func (W _reflect_Type) Bits() int {
-	return W.WBits()
-}
-func (W _reflect_Type) ChanDir() reflect.ChanDir {
-	return W.WChanDir()
-}
-func (W _reflect_Type) Comparable() bool {
-	return W.WComparable()
-}
-func (W _reflect_Type) ConvertibleTo(u reflect.Type) bool {
-	return W.WConvertibleTo(u)
-}
-func (W _reflect_Type) Elem() reflect.Type {
-	return W.WElem()
-}
-func (W _reflect_Type) Field(i int) reflect.StructField {
-	return W.WField(i)
-}
-func (W _reflect_Type) FieldAlign() int {
-	return W.WFieldAlign()
-}
-func (W _reflect_Type) FieldByIndex(index []int) reflect.StructField {
-	return W.WFieldByIndex(index)
-}
+func (W _reflect_Type) Align() int                                   { return W.WAlign() }
+func (W _reflect_Type) AssignableTo(u reflect.Type) bool             { return W.WAssignableTo(u) }
+func (W _reflect_Type) Bits() int                                    { return W.WBits() }
+func (W _reflect_Type) ChanDir() reflect.ChanDir                     { return W.WChanDir() }
+func (W _reflect_Type) Comparable() bool                             { return W.WComparable() }
+func (W _reflect_Type) ConvertibleTo(u reflect.Type) bool            { return W.WConvertibleTo(u) }
+func (W _reflect_Type) Elem() reflect.Type                           { return W.WElem() }
+func (W _reflect_Type) Field(i int) reflect.StructField              { return W.WField(i) }
+func (W _reflect_Type) FieldAlign() int                              { return W.WFieldAlign() }
+func (W _reflect_Type) FieldByIndex(index []int) reflect.StructField { return W.WFieldByIndex(index) }
 func (W _reflect_Type) FieldByName(name string) (reflect.StructField, bool) {
 	return W.WFieldByName(name)
 }
 func (W _reflect_Type) FieldByNameFunc(match func(string) bool) (reflect.StructField, bool) {
 	return W.WFieldByNameFunc(match)
 }
-func (W _reflect_Type) Implements(u reflect.Type) bool {
-	return W.WImplements(u)
-}
-func (W _reflect_Type) In(i int) reflect.Type {
-	return W.WIn(i)
-}
-func (W _reflect_Type) IsVariadic() bool {
-	return W.WIsVariadic()
-}
-func (W _reflect_Type) Key() reflect.Type {
-	return W.WKey()
-}
-func (W _reflect_Type) Kind() reflect.Kind {
-	return W.WKind()
-}
-func (W _reflect_Type) Len() int {
-	return W.WLen()
-}
-func (W _reflect_Type) Method(a0 int) reflect.Method {
-	return W.WMethod(a0)
-}
-func (W _reflect_Type) MethodByName(a0 string) (reflect.Method, bool) {
-	return W.WMethodByName(a0)
-}
-func (W _reflect_Type) Name() string {
-	return W.WName()
-}
-func (W _reflect_Type) NumField() int {
-	return W.WNumField()
-}
-func (W _reflect_Type) NumIn() int {
-	return W.WNumIn()
-}
-func (W _reflect_Type) NumMethod() int {
-	return W.WNumMethod()
-}
-func (W _reflect_Type) NumOut() int {
-	return W.WNumOut()
-}
-func (W _reflect_Type) Out(i int) reflect.Type {
-	return W.WOut(i)
-}
-func (W _reflect_Type) PkgPath() string {
-	return W.WPkgPath()
-}
-func (W _reflect_Type) Size() uintptr {
-	return W.WSize()
-}
+func (W _reflect_Type) Implements(u reflect.Type) bool                { return W.WImplements(u) }
+func (W _reflect_Type) In(i int) reflect.Type                         { return W.WIn(i) }
+func (W _reflect_Type) IsVariadic() bool                              { return W.WIsVariadic() }
+func (W _reflect_Type) Key() reflect.Type                             { return W.WKey() }
+func (W _reflect_Type) Kind() reflect.Kind                            { return W.WKind() }
+func (W _reflect_Type) Len() int                                      { return W.WLen() }
+func (W _reflect_Type) Method(a0 int) reflect.Method                  { return W.WMethod(a0) }
+func (W _reflect_Type) MethodByName(a0 string) (reflect.Method, bool) { return W.WMethodByName(a0) }
+func (W _reflect_Type) Name() string                                  { return W.WName() }
+func (W _reflect_Type) NumField() int                                 { return W.WNumField() }
+func (W _reflect_Type) NumIn() int                                    { return W.WNumIn() }
+func (W _reflect_Type) NumMethod() int                                { return W.WNumMethod() }
+func (W _reflect_Type) NumOut() int                                   { return W.WNumOut() }
+func (W _reflect_Type) Out(i int) reflect.Type                        { return W.WOut(i) }
+func (W _reflect_Type) PkgPath() string                               { return W.WPkgPath() }
+func (W _reflect_Type) Size() uintptr                                 { return W.WSize() }
 func (W _reflect_Type) String() string {
 	if W.WString == nil {
 		return ""

--- a/stdlib/go1_22_runtime.go
+++ b/stdlib/go1_22_runtime.go
@@ -78,9 +78,5 @@ type _runtime_Error struct {
 	WRuntimeError func()
 }
 
-func (W _runtime_Error) Error() string {
-	return W.WError()
-}
-func (W _runtime_Error) RuntimeError() {
-	W.WRuntimeError()
-}
+func (W _runtime_Error) Error() string { return W.WError() }
+func (W _runtime_Error) RuntimeError() { W.WRuntimeError() }

--- a/stdlib/go1_22_sort.go
+++ b/stdlib/go1_22_sort.go
@@ -51,12 +51,6 @@ type _sort_Interface struct {
 	WSwap  func(i int, j int)
 }
 
-func (W _sort_Interface) Len() int {
-	return W.WLen()
-}
-func (W _sort_Interface) Less(i int, j int) bool {
-	return W.WLess(i, j)
-}
-func (W _sort_Interface) Swap(i int, j int) {
-	W.WSwap(i, j)
-}
+func (W _sort_Interface) Len() int               { return W.WLen() }
+func (W _sort_Interface) Less(i int, j int) bool { return W.WLess(i, j) }
+func (W _sort_Interface) Swap(i int, j int)      { W.WSwap(i, j) }

--- a/stdlib/go1_22_sync.go
+++ b/stdlib/go1_22_sync.go
@@ -38,9 +38,5 @@ type _sync_Locker struct {
 	WUnlock func()
 }
 
-func (W _sync_Locker) Lock() {
-	W.WLock()
-}
-func (W _sync_Locker) Unlock() {
-	W.WUnlock()
-}
+func (W _sync_Locker) Lock()   { W.WLock() }
+func (W _sync_Locker) Unlock() { W.WUnlock() }

--- a/stdlib/go1_22_testing.go
+++ b/stdlib/go1_22_testing.go
@@ -71,57 +71,21 @@ type _testing_TB struct {
 	WTempDir func() string
 }
 
-func (W _testing_TB) Cleanup(a0 func()) {
-	W.WCleanup(a0)
-}
-func (W _testing_TB) Error(args ...any) {
-	W.WError(args...)
-}
-func (W _testing_TB) Errorf(format string, args ...any) {
-	W.WErrorf(format, args...)
-}
-func (W _testing_TB) Fail() {
-	W.WFail()
-}
-func (W _testing_TB) FailNow() {
-	W.WFailNow()
-}
-func (W _testing_TB) Failed() bool {
-	return W.WFailed()
-}
-func (W _testing_TB) Fatal(args ...any) {
-	W.WFatal(args...)
-}
-func (W _testing_TB) Fatalf(format string, args ...any) {
-	W.WFatalf(format, args...)
-}
-func (W _testing_TB) Helper() {
-	W.WHelper()
-}
-func (W _testing_TB) Log(args ...any) {
-	W.WLog(args...)
-}
-func (W _testing_TB) Logf(format string, args ...any) {
-	W.WLogf(format, args...)
-}
-func (W _testing_TB) Name() string {
-	return W.WName()
-}
-func (W _testing_TB) Setenv(key string, value string) {
-	W.WSetenv(key, value)
-}
-func (W _testing_TB) Skip(args ...any) {
-	W.WSkip(args...)
-}
-func (W _testing_TB) SkipNow() {
-	W.WSkipNow()
-}
-func (W _testing_TB) Skipf(format string, args ...any) {
-	W.WSkipf(format, args...)
-}
-func (W _testing_TB) Skipped() bool {
-	return W.WSkipped()
-}
-func (W _testing_TB) TempDir() string {
-	return W.WTempDir()
-}
+func (W _testing_TB) Cleanup(a0 func())                 { W.WCleanup(a0) }
+func (W _testing_TB) Error(args ...any)                 { W.WError(args...) }
+func (W _testing_TB) Errorf(format string, args ...any) { W.WErrorf(format, args...) }
+func (W _testing_TB) Fail()                             { W.WFail() }
+func (W _testing_TB) FailNow()                          { W.WFailNow() }
+func (W _testing_TB) Failed() bool                      { return W.WFailed() }
+func (W _testing_TB) Fatal(args ...any)                 { W.WFatal(args...) }
+func (W _testing_TB) Fatalf(format string, args ...any) { W.WFatalf(format, args...) }
+func (W _testing_TB) Helper()                           { W.WHelper() }
+func (W _testing_TB) Log(args ...any)                   { W.WLog(args...) }
+func (W _testing_TB) Logf(format string, args ...any)   { W.WLogf(format, args...) }
+func (W _testing_TB) Name() string                      { return W.WName() }
+func (W _testing_TB) Setenv(key string, value string)   { W.WSetenv(key, value) }
+func (W _testing_TB) Skip(args ...any)                  { W.WSkip(args...) }
+func (W _testing_TB) SkipNow()                          { W.WSkipNow() }
+func (W _testing_TB) Skipf(format string, args ...any)  { W.WSkipf(format, args...) }
+func (W _testing_TB) Skipped() bool                     { return W.WSkipped() }
+func (W _testing_TB) TempDir() string                   { return W.WTempDir() }

--- a/stdlib/go1_22_text_template_parse.go
+++ b/stdlib/go1_22_text_template_parse.go
@@ -84,18 +84,12 @@ type _text_template_parse_Node struct {
 	WType     func() parse.NodeType
 }
 
-func (W _text_template_parse_Node) Copy() parse.Node {
-	return W.WCopy()
-}
-func (W _text_template_parse_Node) Position() parse.Pos {
-	return W.WPosition()
-}
+func (W _text_template_parse_Node) Copy() parse.Node    { return W.WCopy() }
+func (W _text_template_parse_Node) Position() parse.Pos { return W.WPosition() }
 func (W _text_template_parse_Node) String() string {
 	if W.WString == nil {
 		return ""
 	}
 	return W.WString()
 }
-func (W _text_template_parse_Node) Type() parse.NodeType {
-	return W.WType()
-}
+func (W _text_template_parse_Node) Type() parse.NodeType { return W.WType() }

--- a/stdlib/syscall/go1_21_syscall_aix_ppc64.go
+++ b/stdlib/syscall/go1_21_syscall_aix_ppc64.go
@@ -1358,9 +1358,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1370,15 +1368,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_android_386.go
+++ b/stdlib/syscall/go1_21_syscall_android_386.go
@@ -2224,9 +2224,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2236,15 +2234,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_android_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_android_amd64.go
@@ -2190,9 +2190,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2202,15 +2200,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_android_arm.go
+++ b/stdlib/syscall/go1_21_syscall_android_arm.go
@@ -2243,9 +2243,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2255,15 +2253,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_android_arm64.go
+++ b/stdlib/syscall/go1_21_syscall_android_arm64.go
@@ -2334,9 +2334,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2346,15 +2344,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_darwin_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_darwin_amd64.go
@@ -1918,9 +1918,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1930,15 +1928,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_darwin_arm64.go
+++ b/stdlib/syscall/go1_21_syscall_darwin_arm64.go
@@ -1926,9 +1926,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1938,15 +1936,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_dragonfly_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_dragonfly_amd64.go
@@ -1981,9 +1981,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1993,15 +1991,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_freebsd_386.go
+++ b/stdlib/syscall/go1_21_syscall_freebsd_386.go
@@ -2220,9 +2220,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2232,15 +2230,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_freebsd_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_freebsd_amd64.go
@@ -2221,9 +2221,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2233,15 +2231,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_freebsd_arm.go
+++ b/stdlib/syscall/go1_21_syscall_freebsd_arm.go
@@ -2220,9 +2220,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2232,15 +2230,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_freebsd_arm64.go
+++ b/stdlib/syscall/go1_21_syscall_freebsd_arm64.go
@@ -2266,9 +2266,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2278,15 +2276,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_freebsd_riscv64.go
+++ b/stdlib/syscall/go1_21_syscall_freebsd_riscv64.go
@@ -2266,9 +2266,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2278,15 +2276,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_illumos_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_illumos_amd64.go
@@ -829,6 +829,7 @@ func init() {
 		"O_APPEND":                      reflect.ValueOf(constant.MakeFromLiteral("8", token.INT, 0)),
 		"O_CLOEXEC":                     reflect.ValueOf(constant.MakeFromLiteral("8388608", token.INT, 0)),
 		"O_CREAT":                       reflect.ValueOf(constant.MakeFromLiteral("256", token.INT, 0)),
+		"O_DIRECTORY":                   reflect.ValueOf(constant.MakeFromLiteral("16777216", token.INT, 0)),
 		"O_DSYNC":                       reflect.ValueOf(constant.MakeFromLiteral("64", token.INT, 0)),
 		"O_EXCL":                        reflect.ValueOf(constant.MakeFromLiteral("1024", token.INT, 0)),
 		"O_EXEC":                        reflect.ValueOf(constant.MakeFromLiteral("4194304", token.INT, 0)),
@@ -1484,9 +1485,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1496,15 +1495,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_ios_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_ios_amd64.go
@@ -1918,9 +1918,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1930,15 +1928,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_ios_arm64.go
+++ b/stdlib/syscall/go1_21_syscall_ios_arm64.go
@@ -1926,9 +1926,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1938,15 +1936,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_js_wasm.go
+++ b/stdlib/syscall/go1_21_syscall_js_wasm.go
@@ -340,9 +340,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -352,15 +350,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_386.go
+++ b/stdlib/syscall/go1_21_syscall_linux_386.go
@@ -2224,9 +2224,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2236,15 +2234,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_linux_amd64.go
@@ -2190,9 +2190,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2202,15 +2200,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_arm.go
+++ b/stdlib/syscall/go1_21_syscall_linux_arm.go
@@ -2243,9 +2243,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2255,15 +2253,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_arm64.go
+++ b/stdlib/syscall/go1_21_syscall_linux_arm64.go
@@ -2334,9 +2334,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2346,15 +2344,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_loong64.go
+++ b/stdlib/syscall/go1_21_syscall_linux_loong64.go
@@ -2667,9 +2667,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2679,15 +2677,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_mips.go
+++ b/stdlib/syscall/go1_21_syscall_linux_mips.go
@@ -2428,9 +2428,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2440,15 +2438,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_mips64.go
+++ b/stdlib/syscall/go1_21_syscall_linux_mips64.go
@@ -2377,9 +2377,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2389,15 +2387,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_mips64le.go
+++ b/stdlib/syscall/go1_21_syscall_linux_mips64le.go
@@ -2377,9 +2377,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2389,15 +2387,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_mipsle.go
+++ b/stdlib/syscall/go1_21_syscall_linux_mipsle.go
@@ -2428,9 +2428,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2440,15 +2438,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_ppc64.go
+++ b/stdlib/syscall/go1_21_syscall_linux_ppc64.go
@@ -2468,9 +2468,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2480,15 +2478,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_ppc64le.go
+++ b/stdlib/syscall/go1_21_syscall_linux_ppc64le.go
@@ -2492,9 +2492,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2504,15 +2502,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_riscv64.go
+++ b/stdlib/syscall/go1_21_syscall_linux_riscv64.go
@@ -2388,9 +2388,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2400,15 +2398,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_linux_s390x.go
+++ b/stdlib/syscall/go1_21_syscall_linux_s390x.go
@@ -2503,9 +2503,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2515,15 +2513,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_netbsd_386.go
+++ b/stdlib/syscall/go1_21_syscall_netbsd_386.go
@@ -2110,9 +2110,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2122,15 +2120,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_netbsd_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_netbsd_amd64.go
@@ -2100,9 +2100,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2112,15 +2110,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_netbsd_arm.go
+++ b/stdlib/syscall/go1_21_syscall_netbsd_arm.go
@@ -2086,9 +2086,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2098,15 +2096,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_netbsd_arm64.go
+++ b/stdlib/syscall/go1_21_syscall_netbsd_arm64.go
@@ -2100,9 +2100,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2112,15 +2110,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_openbsd_386.go
+++ b/stdlib/syscall/go1_21_syscall_openbsd_386.go
@@ -1943,9 +1943,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1955,15 +1953,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_openbsd_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_openbsd_amd64.go
@@ -1942,9 +1942,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1954,15 +1952,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_openbsd_arm.go
+++ b/stdlib/syscall/go1_21_syscall_openbsd_arm.go
@@ -1946,9 +1946,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1958,15 +1956,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_openbsd_arm64.go
+++ b/stdlib/syscall/go1_21_syscall_openbsd_arm64.go
@@ -2041,9 +2041,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2053,15 +2051,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_21_syscall_plan9_386.go
+++ b/stdlib/syscall/go1_21_syscall_plan9_386.go
@@ -221,9 +221,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -233,12 +231,6 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }

--- a/stdlib/syscall/go1_21_syscall_plan9_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_plan9_amd64.go
@@ -221,9 +221,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -233,12 +231,6 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }

--- a/stdlib/syscall/go1_21_syscall_plan9_arm.go
+++ b/stdlib/syscall/go1_21_syscall_plan9_arm.go
@@ -221,9 +221,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -233,12 +231,6 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }

--- a/stdlib/syscall/go1_21_syscall_solaris_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_solaris_amd64.go
@@ -824,6 +824,7 @@ func init() {
 		"O_APPEND":                      reflect.ValueOf(constant.MakeFromLiteral("8", token.INT, 0)),
 		"O_CLOEXEC":                     reflect.ValueOf(constant.MakeFromLiteral("8388608", token.INT, 0)),
 		"O_CREAT":                       reflect.ValueOf(constant.MakeFromLiteral("256", token.INT, 0)),
+		"O_DIRECTORY":                   reflect.ValueOf(constant.MakeFromLiteral("16777216", token.INT, 0)),
 		"O_DSYNC":                       reflect.ValueOf(constant.MakeFromLiteral("64", token.INT, 0)),
 		"O_EXCL":                        reflect.ValueOf(constant.MakeFromLiteral("1024", token.INT, 0)),
 		"O_EXEC":                        reflect.ValueOf(constant.MakeFromLiteral("4194304", token.INT, 0)),
@@ -1479,9 +1480,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1491,15 +1490,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_wasip1_wasm.go
+++ b/stdlib/syscall/go1_21_syscall_wasip1_wasm.go
@@ -379,9 +379,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -391,15 +389,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_windows_386.go
+++ b/stdlib/syscall/go1_21_syscall_windows_386.go
@@ -1009,9 +1009,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1021,15 +1019,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_windows_amd64.go
+++ b/stdlib/syscall/go1_21_syscall_windows_amd64.go
@@ -1009,9 +1009,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1021,15 +1019,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_windows_arm.go
+++ b/stdlib/syscall/go1_21_syscall_windows_arm.go
@@ -1009,9 +1009,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1021,15 +1019,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_21_syscall_windows_arm64.go
+++ b/stdlib/syscall/go1_21_syscall_windows_arm64.go
@@ -1009,9 +1009,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1021,15 +1019,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_aix_ppc64.go
+++ b/stdlib/syscall/go1_22_syscall_aix_ppc64.go
@@ -1358,9 +1358,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1370,15 +1368,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_android_386.go
+++ b/stdlib/syscall/go1_22_syscall_android_386.go
@@ -2224,9 +2224,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2236,15 +2234,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_android_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_android_amd64.go
@@ -2190,9 +2190,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2202,15 +2200,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_android_arm.go
+++ b/stdlib/syscall/go1_22_syscall_android_arm.go
@@ -2243,9 +2243,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2255,15 +2253,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_android_arm64.go
+++ b/stdlib/syscall/go1_22_syscall_android_arm64.go
@@ -2334,9 +2334,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2346,15 +2344,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_darwin_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_darwin_amd64.go
@@ -1918,9 +1918,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1930,15 +1928,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_darwin_arm64.go
+++ b/stdlib/syscall/go1_22_syscall_darwin_arm64.go
@@ -1926,9 +1926,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1938,15 +1936,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_dragonfly_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_dragonfly_amd64.go
@@ -1981,9 +1981,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1993,15 +1991,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_freebsd_386.go
+++ b/stdlib/syscall/go1_22_syscall_freebsd_386.go
@@ -2220,9 +2220,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2232,15 +2230,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_freebsd_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_freebsd_amd64.go
@@ -2221,9 +2221,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2233,15 +2231,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_freebsd_arm.go
+++ b/stdlib/syscall/go1_22_syscall_freebsd_arm.go
@@ -2220,9 +2220,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2232,15 +2230,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_freebsd_arm64.go
+++ b/stdlib/syscall/go1_22_syscall_freebsd_arm64.go
@@ -2266,9 +2266,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2278,15 +2276,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_freebsd_riscv64.go
+++ b/stdlib/syscall/go1_22_syscall_freebsd_riscv64.go
@@ -2266,9 +2266,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2278,15 +2276,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_illumos_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_illumos_amd64.go
@@ -829,6 +829,7 @@ func init() {
 		"O_APPEND":                      reflect.ValueOf(constant.MakeFromLiteral("8", token.INT, 0)),
 		"O_CLOEXEC":                     reflect.ValueOf(constant.MakeFromLiteral("8388608", token.INT, 0)),
 		"O_CREAT":                       reflect.ValueOf(constant.MakeFromLiteral("256", token.INT, 0)),
+		"O_DIRECTORY":                   reflect.ValueOf(constant.MakeFromLiteral("16777216", token.INT, 0)),
 		"O_DSYNC":                       reflect.ValueOf(constant.MakeFromLiteral("64", token.INT, 0)),
 		"O_EXCL":                        reflect.ValueOf(constant.MakeFromLiteral("1024", token.INT, 0)),
 		"O_EXEC":                        reflect.ValueOf(constant.MakeFromLiteral("4194304", token.INT, 0)),
@@ -1484,9 +1485,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1496,15 +1495,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_ios_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_ios_amd64.go
@@ -1918,9 +1918,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1930,15 +1928,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_ios_arm64.go
+++ b/stdlib/syscall/go1_22_syscall_ios_arm64.go
@@ -1926,9 +1926,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1938,15 +1936,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_js_wasm.go
+++ b/stdlib/syscall/go1_22_syscall_js_wasm.go
@@ -340,9 +340,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -352,15 +350,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_386.go
+++ b/stdlib/syscall/go1_22_syscall_linux_386.go
@@ -2224,9 +2224,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2236,15 +2234,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_linux_amd64.go
@@ -2190,9 +2190,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2202,15 +2200,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_arm.go
+++ b/stdlib/syscall/go1_22_syscall_linux_arm.go
@@ -2243,9 +2243,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2255,15 +2253,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_arm64.go
+++ b/stdlib/syscall/go1_22_syscall_linux_arm64.go
@@ -2334,9 +2334,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2346,15 +2344,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_loong64.go
+++ b/stdlib/syscall/go1_22_syscall_linux_loong64.go
@@ -2667,9 +2667,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2679,15 +2677,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_mips.go
+++ b/stdlib/syscall/go1_22_syscall_linux_mips.go
@@ -2428,9 +2428,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2440,15 +2438,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_mips64.go
+++ b/stdlib/syscall/go1_22_syscall_linux_mips64.go
@@ -2377,9 +2377,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2389,15 +2387,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_mips64le.go
+++ b/stdlib/syscall/go1_22_syscall_linux_mips64le.go
@@ -2377,9 +2377,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2389,15 +2387,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_mipsle.go
+++ b/stdlib/syscall/go1_22_syscall_linux_mipsle.go
@@ -2428,9 +2428,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2440,15 +2438,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_ppc64.go
+++ b/stdlib/syscall/go1_22_syscall_linux_ppc64.go
@@ -2468,9 +2468,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2480,15 +2478,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_ppc64le.go
+++ b/stdlib/syscall/go1_22_syscall_linux_ppc64le.go
@@ -2492,9 +2492,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2504,15 +2502,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_riscv64.go
+++ b/stdlib/syscall/go1_22_syscall_linux_riscv64.go
@@ -2388,9 +2388,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2400,15 +2398,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_linux_s390x.go
+++ b/stdlib/syscall/go1_22_syscall_linux_s390x.go
@@ -2503,9 +2503,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2515,15 +2513,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_netbsd_386.go
+++ b/stdlib/syscall/go1_22_syscall_netbsd_386.go
@@ -2110,9 +2110,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2122,15 +2120,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_netbsd_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_netbsd_amd64.go
@@ -2100,9 +2100,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2112,15 +2110,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_netbsd_arm.go
+++ b/stdlib/syscall/go1_22_syscall_netbsd_arm.go
@@ -2086,9 +2086,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2098,15 +2096,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_netbsd_arm64.go
+++ b/stdlib/syscall/go1_22_syscall_netbsd_arm64.go
@@ -2100,9 +2100,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2112,15 +2110,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_openbsd_386.go
+++ b/stdlib/syscall/go1_22_syscall_openbsd_386.go
@@ -1943,9 +1943,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1955,15 +1953,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_openbsd_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_openbsd_amd64.go
@@ -1942,9 +1942,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1954,15 +1952,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_openbsd_arm.go
+++ b/stdlib/syscall/go1_22_syscall_openbsd_arm.go
@@ -1946,9 +1946,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1958,15 +1956,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_openbsd_arm64.go
+++ b/stdlib/syscall/go1_22_syscall_openbsd_arm64.go
@@ -2041,9 +2041,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2053,15 +2051,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_openbsd_ppc64.go
+++ b/stdlib/syscall/go1_22_syscall_openbsd_ppc64.go
@@ -2075,9 +2075,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -2087,15 +2085,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_RoutingMessage is an interface wrapper for RoutingMessage type
 type _syscall_RoutingMessage struct {

--- a/stdlib/syscall/go1_22_syscall_plan9_386.go
+++ b/stdlib/syscall/go1_22_syscall_plan9_386.go
@@ -221,9 +221,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -233,12 +231,6 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }

--- a/stdlib/syscall/go1_22_syscall_plan9_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_plan9_amd64.go
@@ -221,9 +221,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -233,12 +231,6 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }

--- a/stdlib/syscall/go1_22_syscall_plan9_arm.go
+++ b/stdlib/syscall/go1_22_syscall_plan9_arm.go
@@ -221,9 +221,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -233,12 +231,6 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }

--- a/stdlib/syscall/go1_22_syscall_solaris_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_solaris_amd64.go
@@ -824,6 +824,7 @@ func init() {
 		"O_APPEND":                      reflect.ValueOf(constant.MakeFromLiteral("8", token.INT, 0)),
 		"O_CLOEXEC":                     reflect.ValueOf(constant.MakeFromLiteral("8388608", token.INT, 0)),
 		"O_CREAT":                       reflect.ValueOf(constant.MakeFromLiteral("256", token.INT, 0)),
+		"O_DIRECTORY":                   reflect.ValueOf(constant.MakeFromLiteral("16777216", token.INT, 0)),
 		"O_DSYNC":                       reflect.ValueOf(constant.MakeFromLiteral("64", token.INT, 0)),
 		"O_EXCL":                        reflect.ValueOf(constant.MakeFromLiteral("1024", token.INT, 0)),
 		"O_EXEC":                        reflect.ValueOf(constant.MakeFromLiteral("4194304", token.INT, 0)),
@@ -1479,9 +1480,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1491,15 +1490,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_wasip1_wasm.go
+++ b/stdlib/syscall/go1_22_syscall_wasip1_wasm.go
@@ -379,9 +379,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -391,15 +389,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_windows_386.go
+++ b/stdlib/syscall/go1_22_syscall_windows_386.go
@@ -1009,9 +1009,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1021,15 +1019,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_windows_amd64.go
+++ b/stdlib/syscall/go1_22_syscall_windows_amd64.go
@@ -1009,9 +1009,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1021,15 +1019,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_windows_arm.go
+++ b/stdlib/syscall/go1_22_syscall_windows_arm.go
@@ -1009,9 +1009,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1021,15 +1019,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/syscall/go1_22_syscall_windows_arm64.go
+++ b/stdlib/syscall/go1_22_syscall_windows_arm64.go
@@ -1009,9 +1009,7 @@ type _syscall_Conn struct {
 	WSyscallConn func() (syscall.RawConn, error)
 }
 
-func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) {
-	return W.WSyscallConn()
-}
+func (W _syscall_Conn) SyscallConn() (syscall.RawConn, error) { return W.WSyscallConn() }
 
 // _syscall_RawConn is an interface wrapper for RawConn type
 type _syscall_RawConn struct {
@@ -1021,15 +1019,9 @@ type _syscall_RawConn struct {
 	WWrite   func(f func(fd uintptr) (done bool)) error
 }
 
-func (W _syscall_RawConn) Control(f func(fd uintptr)) error {
-	return W.WControl(f)
-}
-func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error {
-	return W.WRead(f)
-}
-func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error {
-	return W.WWrite(f)
-}
+func (W _syscall_RawConn) Control(f func(fd uintptr)) error           { return W.WControl(f) }
+func (W _syscall_RawConn) Read(f func(fd uintptr) (done bool)) error  { return W.WRead(f) }
+func (W _syscall_RawConn) Write(f func(fd uintptr) (done bool)) error { return W.WWrite(f) }
 
 // _syscall_Sockaddr is an interface wrapper for Sockaddr type
 type _syscall_Sockaddr struct {

--- a/stdlib/wrapper-composed.go
+++ b/stdlib/wrapper-composed.go
@@ -23,17 +23,11 @@ type _netHTTPResponseWriterHijacker struct {
 	WHijack func() (net.Conn, *bufio.ReadWriter, error)
 }
 
-func (w _netHTTPResponseWriterHijacker) Header() http.Header {
-	return w.WHeader()
-}
+func (w _netHTTPResponseWriterHijacker) Header() http.Header { return w.WHeader() }
 
-func (w _netHTTPResponseWriterHijacker) Write(a0 []byte) (int, error) {
-	return w.WWrite(a0)
-}
+func (w _netHTTPResponseWriterHijacker) Write(a0 []byte) (int, error) { return w.WWrite(a0) }
 
-func (w _netHTTPResponseWriterHijacker) WriteHeader(statusCode int) {
-	w.WWriteHeader(statusCode)
-}
+func (w _netHTTPResponseWriterHijacker) WriteHeader(statusCode int) { w.WWriteHeader(statusCode) }
 
 func (w _netHTTPResponseWriterHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return w.WHijack()
@@ -48,13 +42,9 @@ type _ioReaderWriteTo struct {
 	WWriteTo func(w io.Writer) (n int64, err error)
 }
 
-func (w _ioReaderWriteTo) Read(p []byte) (n int, err error) {
-	return w.WRead(p)
-}
+func (w _ioReaderWriteTo) Read(p []byte) (n int, err error) { return w.WRead(p) }
 
-func (w _ioReaderWriteTo) WriteTo(wr io.Writer) (n int64, err error) {
-	return w.WWriteTo(wr)
-}
+func (w _ioReaderWriteTo) WriteTo(wr io.Writer) (n int64, err error) { return w.WWriteTo(wr) }
 
 // In io, a Writer may implement ReadFrom, used by io.Copy().
 
@@ -65,13 +55,9 @@ type _ioWriterReadFrom struct {
 	WReadFrom func(r io.Reader) (n int64, err error)
 }
 
-func (w _ioWriterReadFrom) Write(p []byte) (n int, err error) {
-	return w.WWrite(p)
-}
+func (w _ioWriterReadFrom) Write(p []byte) (n int, err error) { return w.WWrite(p) }
 
-func (w _ioWriterReadFrom) ReadFrom(r io.Reader) (n int64, err error) {
-	return w.WReadFrom(r)
-}
+func (w _ioWriterReadFrom) ReadFrom(r io.Reader) (n int64, err error) { return w.WReadFrom(r) }
 
 // Each MapType value (each slice) must be sorted by complexity, i.e. by number
 // of interface methods.


### PR DESCRIPTION
A side effect of #1281 is that it added unnecessary additional newlines in generated interface wrappers from the `extract` tool. This PR removes those newlines from the extract tool template and updates the generated code with that change. 