### PR TITLE
Range over int

### DIFF
--- a/_test/for17.go
+++ b/_test/for17.go
@@ -1,0 +1,13 @@
+package main
+
+func main() {
+	mx := 3
+	for i := range mx {
+		println(i)
+	}
+}
+
+// Output:
+// 0
+// 1
+// 2

--- a/_test/for18.go
+++ b/_test/for18.go
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	for i := range 3 {
+		println(i)
+	}
+}
+
+// Output:
+// 0
+// 1
+// 2

--- a/_test/for19.go
+++ b/_test/for19.go
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	for range 3 {
+		println("i")
+	}
+}
+
+// Output:
+// i
+// i
+// i

--- a/interp/cfg.go
+++ b/interp/cfg.go
@@ -200,6 +200,10 @@ func (interp *Interpreter) cfg(root *node, sc *scope, importPath, pkgName string
 						sc.add(sc.getType("int")) // Add a dummy type to store array shallow copy for range
 						ktyp = sc.getType("int")
 						vtyp = o.typ.val
+					case intT:
+						n.anc.gen = rangeInt
+						sc.add(sc.getType("int"))
+						ktyp = sc.getType("int")
 					}
 
 					kindex := sc.add(ktyp)

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -11,20 +11,6 @@ import (
 
 func init() { log.SetFlags(log.Lshortfile) }
 
-func TestForRangeInt(t *testing.T) {
-	i := New(Options{})
-	_, err := i.Eval(`
-func main() {
-	for i := range 3 {
-		println(i)
-	}
-}
-`)
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func TestIsNatural(t *testing.T) {
 	tests := []struct {
 		desc     string

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -11,6 +11,20 @@ import (
 
 func init() { log.SetFlags(log.Lshortfile) }
 
+func TestForRangeInt(t *testing.T) {
+	i := New(Options{})
+	_, err := i.Eval(`
+func main() {
+	for i := range 3 {
+		println(i)
+	}
+}
+`)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestIsNatural(t *testing.T) {
 	tests := []struct {
 		desc     string

--- a/interp/run.go
+++ b/interp/run.go
@@ -2873,6 +2873,34 @@ func _range(n *node) {
 	}
 }
 
+func rangeInt(n *node) {
+	index0 := n.child[0].findex // array index location in frame
+	index2 := index0 - 1        // max
+	fnext := getExec(n.fnext)
+	tnext := getExec(n.tnext)
+
+	var value func(*frame) reflect.Value
+	mxn := n.child[1]
+	value = genValue(mxn)
+	n.exec = func(f *frame) bltn {
+		v0 := f.data[index0]
+		v0.SetInt(v0.Int() + 1)
+		if int(v0.Int()) >= int(f.data[index2].Int()) {
+			return fnext
+		}
+		return tnext
+	}
+
+	// Init sequence
+	next := n.exec
+	index := index0
+	n.child[0].exec = func(f *frame) bltn {
+		f.data[index2] = value(f) // set max
+		f.data[index].SetInt(-1)  // assing index value
+		return next
+	}
+}
+
 func rangeChan(n *node) {
 	i := n.child[0].findex        // element index location in frame
 	value := genValue(n.child[1]) // chan


### PR DESCRIPTION
This adds support for the `for i := range n` range-over-int form of the for loop, introduced in go 1.22  https://github.com/golang/go/issues/61405

Includes tests for 3 forms, and everything passes.
