### PR TITLE
interp: fix a missing implicit type conversion for binary expression

### DIFF
--- a/_test/issue-1653.go
+++ b/_test/issue-1653.go
@@ -1,0 +1,12 @@
+package main
+
+func f(b uint) uint {
+	return uint(1) + (0x1 >> b)
+}
+
+func main() {
+	println(f(1))
+}
+
+// Output:
+// 1


### PR DESCRIPTION
When parsing binary operator expressions, make sure that implicit type conversions for untyped expressions are performed. It involves walking the sub-expression subtree at post-processing of binary expressions.

Fixes #1653.