### PR TITLE
fix: ensure that untyped values are converted to the same type

### DIFF
--- a/interp/typecheck.go
+++ b/interp/typecheck.go
@@ -270,6 +270,7 @@ func (check typecheck) binaryExpr(n *node) error {
 		}
 	}
 
+	// Ensure that if values are untyped, both are converted to the same type
 	_ = check.convertUntyped(c0, c1.typ)
 	_ = check.convertUntyped(c1, c0.typ)
 
@@ -1059,7 +1060,7 @@ func (check typecheck) convertUntyped(n *node, typ *itype) error {
 		// Both n and target are untyped.
 		nkind, tkind := ntyp.Kind(), ttyp.Kind()
 		if isNumber(ntyp) && isNumber(ttyp) {
-			if nkind < tkind {
+			if nkind <= tkind {
 				n.typ = typ
 			}
 		} else if nkind != tkind {


### PR DESCRIPTION
This fixes an issue where two untyped values with different `itype` could not be operated on.

Minimal example to reproduce this:

```
package main

import "math"

func main() {
	println(math.MaxFloat64 - 1.0)
}
```

Result: `invalid operation: mismatched types untyped float64 and untyped float`, but should be `1.7976931348623157e+308`