### PR TITLE
fix: correctly resolve fields of aliased structs

### DIFF
--- a/_test/type34.go
+++ b/_test/type34.go
@@ -1,0 +1,17 @@
+package main
+
+type original struct {
+	Field string
+}
+
+func main() {
+	type alias original
+	type alias2 alias
+	var a = &alias2{
+		Field: "test",
+	}
+	println(a.Field)
+}
+
+// Output:
+// test

--- a/interp/run.go
+++ b/interp/run.go
@@ -2667,10 +2667,7 @@ func compositeBinSlice(n *node) {
 func doCompositeBinStruct(n *node, hasType bool) {
 	next := getExec(n.tnext)
 	value := valueGenerator(n, n.findex)
-	typ := n.typ.rtype
-	if n.typ.cat == ptrT || n.typ.cat == linkedT {
-		typ = n.typ.val.rtype
-	}
+	typ := baseType(n.typ).rtype
 	child := n.child
 	if hasType {
 		child = n.child[1:]
@@ -2734,10 +2731,7 @@ func destType(n *node) *itype {
 func doComposite(n *node, hasType bool, keyed bool) {
 	value := valueGenerator(n, n.findex)
 	next := getExec(n.tnext)
-	typ := n.typ
-	if typ.cat == ptrT || typ.cat == linkedT {
-		typ = typ.val
-	}
+	typ := baseType(n.typ)
 	child := n.child
 	if hasType {
 		child = n.child[1:]

--- a/interp/type.go
+++ b/interp/type.go
@@ -1714,10 +1714,7 @@ func (t *itype) fieldIndex(name string) int {
 func (t *itype) fieldSeq(seq []int) *itype {
 	ft := t
 	for _, i := range seq {
-		if ft.cat == ptrT {
-			ft = ft.val
-		}
-		ft = ft.field[i].typ
+		ft = baseType(ft).field[i].typ
 	}
 	return ft
 }


### PR DESCRIPTION
Fields of types that are aliases are not always resolved correctly, especially if the aliased type is itself an alias.

A minimal example is:
```
package main

type original struct {
	Field string
}

func main() {
	type alias original
	type alias2 alias
	var a = &alias2{
		Field: "test",
	}
	println(a.Field)
}
```

There is already a method (`baseType`) for resolving the underlying struct type; but it isn't always used previous to this change.