### PR TITLE
interp: implement partial type inference

### DIFF
--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -672,8 +672,22 @@ func TestEvalFunctionCallWithFunctionParam(t *testing.T) {
 func TestEvalFunctionPartialInference(t *testing.T) {
 	i := interp.New(interp.Options{})
 	eval(t, i, `
+		func indexExpr[T, U any](v U) U { return v }
+
 		func indexListExpr[T, U, V any](v V) V { return v }
 	`)
+
+	t.Run("one explicit param", func(t *testing.T) {
+		v := eval(t, i, "indexExpr[string](12)")
+		iv, ok := v.Interface().(int)
+		if !ok {
+			t.Fatalf("unexpected return type: got %T, want int", v)
+		}
+		want := 12
+		if iv != want {
+			t.Fatalf("unexpected value: got %v, want %v", i, want)
+		}
+	})
 
 	t.Run("multiple explicit params", func(t *testing.T) {
 		v := eval(t, i, "indexListExpr[string, string](12)")

--- a/interp/interp_eval_test.go
+++ b/interp/interp_eval_test.go
@@ -669,6 +669,25 @@ func TestEvalFunctionCallWithFunctionParam(t *testing.T) {
 	}
 }
 
+func TestEvalFunctionPartialInference(t *testing.T) {
+	i := interp.New(interp.Options{})
+	eval(t, i, `
+		func indexListExpr[T, U, V any](v V) V { return v }
+	`)
+
+	t.Run("multiple explicit params", func(t *testing.T) {
+		v := eval(t, i, "indexListExpr[string, string](12)")
+		iv, ok := v.Interface().(int)
+		if !ok {
+			t.Fatalf("unexpected return type: got %T, want int", v)
+		}
+		want := 12
+		if iv != want {
+			t.Fatalf("unexpected value: got %v, want %v", i, want)
+		}
+	})
+}
+
 func TestEvalCall(t *testing.T) {
 	i := interp.New(interp.Options{})
 	runTests(t, i, []testCase{


### PR DESCRIPTION
Update to #1710. This solves the issue I was running into before - for some reason, it got back `nil` when looking up the `context.Context` type in the scope of a package I was trying to parse. That caused a nil pointer dereference.

I couldn't easily reproduce it in tests. When I tried to interpret similar (but simplified) code, yaegi handled it fine.

In this case, I just added logic to skip type inference for types that come back as `nil` - yaegi should *probably* leave it to some other context to error about that anyway.

---

### Description from #1710:

When a function has multiple type parameters, it is possible to explicitly pass in some types but rely on type inference for others. For example, func Foo[T, U any](v U) T { ... } may be called with Foo[string](12).

This implements support for partial type inference for both indexExpr and indexListExpr ast.
